### PR TITLE
feat(hr, notification): hr 및 알림 entity & repository 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/attendance/commute/service/AttendanceRuleService.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/commute/service/AttendanceRuleService.java
@@ -105,8 +105,8 @@ public class AttendanceRuleService {
                 .collect(Collectors.toList());
 
         // 3. 한 번의 쿼리로 해당 ID의 모든 사원 정보를 가져와 Map<ID, Name>으로 변환합니다.
-        Map<Long, String> employeeMap = employeeRepository.findAllByEmployeeIdIn(employeeIds).stream()
-                .collect(Collectors.toMap(Employee::getEmployeeId, Employee::getName));
+        Map<Long, String> employeeMap = employeeRepository.findAllByIdIn(employeeIds).stream()
+                .collect(Collectors.toMap(Employee::getId, Employee::getName));
 
         // 4. 규칙 목록을 순회하며 DTO를 생성하고 이름을 매핑합니다.
         return rules.stream()

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
@@ -1,9 +1,13 @@
 package com.finalproj.orbitflow.hr.employee.entity;
 
 import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.enums.EmploymentType;
 import com.finalproj.orbitflow.hr.employee.enums.Gender;
+import com.finalproj.orbitflow.hr.organization.entity.Organization;
+import com.finalproj.orbitflow.hr.position.entity.Position;
+import com.finalproj.orbitflow.hr.rank.entity.Rank;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -42,20 +46,25 @@ public class Employee extends BaseEntity {
     private Long id;   // 사원 ID (PK)
 
     /* ==============================
-       소속 정보 // TODO: FK -> 추후 관계 매핑 설정 필요
+       소속 정보
        ============================== */
 
-    @Column(nullable = false)
-    private Long companyId;    // 회사 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
 
-    @Column(nullable = false)
-    private Long orgId;        // 조직 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "org_id", nullable = false)
+    private Organization organization;
 
-    @Column
-    private Long rankId;       // 직급 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rank_id")
+    private Rank rank;
 
-    @Column
-    private Long positionId;   // 직책 ID (FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "position_id")
+    private Position position;
+
 
     /* ==============================
        사원 기본 정보

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -35,6 +35,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     Optional<Employee> findByCompanyIdAndEmail(Long companyId, String email);
 
 
-    List<Employee> findAllByEmployeeIdIn(List<Long> employeeIds);
+    List<Employee> findAllByIdIn(List<Long> ids);
 
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/entity/AuditLog.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/entity/AuditLog.java
@@ -1,0 +1,56 @@
+package com.finalproj.orbitflow.hr.logAudit.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @filename    : AuditLog
+ * @author : seunga03
+ * @since       : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "log_audit")
+public class AuditLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_employee_id", nullable = false)
+    private Employee actor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entity_type", nullable = false, length = 30)
+    private AuditEntityType entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private Long entityId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    private AuditEventType eventType;
+
+    @Lob
+    @Column(name = "before_data")
+    private String beforeData; // JSON
+
+    @Lob
+    @Column(name = "after_data")
+    private String afterData; // JSON
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
@@ -1,0 +1,17 @@
+package com.finalproj.orbitflow.hr.logAudit.enums;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditEntityType
+ * @since : 2025-12-16 화요일
+ */
+public enum AuditEntityType {
+    COMPANY,            // 회사
+    ORGANIZATION,       // 조직
+    EMPLOYEE,           // 사원
+    RANK,               // 직급
+    POSITION,           // 직책
+    ORG_POSITION_USAGE  // 조직-직책 정책
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEventType.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEventType.java
@@ -1,0 +1,22 @@
+package com.finalproj.orbitflow.hr.logAudit.enums;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditEventType
+ * @since : 2025-12-16 화요일
+ */
+public enum AuditEventType {
+    CREATE,             // 신규 생성
+    UPDATE,             // 일반 정보 수정
+
+    STATUS_CHANGE,      // 사용자 상태 변경 (임시/재직/휴직/퇴사)
+
+    ACTIVATE,           // 엔티티 활성화
+    DEACTIVATE,         // 엔티티 비활성화
+
+    MOVE,               // 조직 이동
+    ASSIGN,             // 직급/직책 부여
+    UNASSIGN            // 직급/직책 해제
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
@@ -1,0 +1,15 @@
+package com.finalproj.orbitflow.hr.logAudit.repository;
+
+import com.finalproj.orbitflow.hr.logAudit.entity.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditLogRepository
+ * @since : 2025-12-16 화요일
+ */
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
@@ -1,4 +1,4 @@
-package com.finalproj.orbitflow.hr.organization.entity;
+package com.finalproj.orbitflow.hr.orgCategory.entity;
 
 import com.finalproj.orbitflow.global.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
@@ -1,6 +1,6 @@
-package com.finalproj.orbitflow.hr.organization.repository;
+package com.finalproj.orbitflow.hr.orgCategory.repository;
 
-import com.finalproj.orbitflow.hr.organization.entity.OrgCategory;
+import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/entity/OrgPositionUsage.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/entity/OrgPositionUsage.java
@@ -1,0 +1,48 @@
+package com.finalproj.orbitflow.hr.orgPositionUsage.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.organization.entity.Organization;
+import com.finalproj.orbitflow.hr.position.entity.Position;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgPositionUsage
+ * @since : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "org_position_usage",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"company_id", "org_id", "position_id"})
+        }
+)
+public class OrgPositionUsage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 정책 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "org_id", nullable = false)
+    private Organization organization;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "position_id", nullable = false)
+    private Position position;
+
+    @Column(name = "is_enabled", nullable = false)
+    private Boolean isEnabled;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.orgPositionUsage.repository;
+
+import com.finalproj.orbitflow.hr.orgPositionUsage.entity.OrgPositionUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgPositionUsageRepository
+ * @since : 2025-12-16 화요일
+ */
+public interface OrgPositionUsageRepository extends JpaRepository<OrgPositionUsage, Long> {
+
+    List<OrgPositionUsage> findByOrganization_IdAndIsEnabledTrue(Long orgId);
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/position/entity/Position.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/position/entity/Position.java
@@ -1,0 +1,53 @@
+package com.finalproj.orbitflow.hr.position.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : Position
+ * @since : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "position",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"company_id", "name"})
+        }
+)
+public class Position extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 직책 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private PositionCategory category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_position_id")
+    private Position parentPosition;
+
+    @Column(nullable = false, length = 50)
+    private String name; // 개발팀장 등
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/position/repository/PositionRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/position/repository/PositionRepository.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.position.repository;
+
+import com.finalproj.orbitflow.hr.position.entity.Position;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionRepository
+ * @since : 2025-12-16 화요일
+ */
+public interface PositionRepository extends JpaRepository<Position, Long> {
+
+    List<Position> findByCompanyIdAndIsActiveTrue(Long companyId);
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
@@ -1,0 +1,44 @@
+package com.finalproj.orbitflow.hr.positionCategory.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategory
+ * @since : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "position_category",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"company_id", "name"})
+        }
+)
+public class PositionCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 카테고리 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(nullable = false, length = 50)
+    private String name; // 본부장 / 팀장 등
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.positionCategory.repository;
+
+import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryRepository
+ * @since : 2025-12-16 화요일
+ */
+public interface PositionCategoryRepository extends JpaRepository<PositionCategory, Long> {
+
+    List<PositionCategory> findByCompanyIdAndIsActiveTrue(Long companyId);
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/entity/Rank.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/entity/Rank.java
@@ -1,0 +1,48 @@
+package com.finalproj.orbitflow.hr.rank.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : Rank
+ * @since : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "rank",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"company_id", "name"})
+        }
+)
+public class Rank extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 직급 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_rank_id")
+    private Rank parentRank;
+
+    @Column(nullable = false, length = 50)
+    private String name; // 대리 / 과장 등
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/repository/RankRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/repository/RankRepository.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.rank.repository;
+
+import com.finalproj.orbitflow.hr.rank.entity.Rank;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : RankRepository
+ * @since : 2025-12-16 화요일
+ */
+public interface RankRepository extends JpaRepository<Rank, Long> {
+
+    List<Rank> findByCompanyIdAndIsActiveTrue(Long companyId);
+}

--- a/src/main/java/com/finalproj/orbitflow/notification/entity/Notification.java
+++ b/src/main/java/com/finalproj/orbitflow/notification/entity/Notification.java
@@ -1,0 +1,44 @@
+package com.finalproj.orbitflow.notification.entity;
+
+import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : Notification
+ * @since : 2025-12-16 화요일
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee receiver;
+
+    @Column(nullable = false, length = 30)
+    private String type;
+
+    @Column(nullable = false, length = 255)
+    private String content;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead;
+}

--- a/src/main/java/com/finalproj/orbitflow/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/notification/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.notification.repository;
+
+import com.finalproj.orbitflow.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : NotificationRepository
+ * @since : 2025-12-16 화요일
+ */
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByReceiverIdAndIsReadFalse(Long employeeId);
+}

--- a/src/main/java/com/finalproj/orbitflow/schedule/entity/Schedule.java
+++ b/src/main/java/com/finalproj/orbitflow/schedule/entity/Schedule.java
@@ -3,7 +3,7 @@ package com.finalproj.orbitflow.schedule.entity;
 import com.finalproj.orbitflow.global.common.BaseEntity;
 import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
-import com.finalproj.orbitflow.hr.organization.entity.OrgCategory;
+import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import com.finalproj.orbitflow.hr.organization.entity.Organization;
 import com.finalproj.orbitflow.schedule.enums.ScheduleStatus;
 import com.finalproj.orbitflow.schedule.enums.ScheduleType;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #35

## 📝 작업 내용
- HR 도메인 전반의 엔티티 및 레포지토리 구조 정비 (Company, Organization, Employee, Rank, Position 등)
- 모든 엔티티의 PK를 id 기준으로 통일하고, 멀티테넌트 구조 유지를 위해 company_id 기준 관계 확정
- 조직·직급·직책·사원 간 연관관계를 `@ManyToOne(fetch = LAZY)` 단방향으로 통일
- 조직별 직책 사용 정책을 위한 ORG_POSITION_USAGE 엔티티 구조 확정 및 UNIQUE 제약 적용
- 사원 상태(EmployeeStatus)와 감사 이벤트(AuditEventType)를 분리하여 감사 로그 구조 명확화
- 감사 대상 엔티티 범위에 ORG_POSITION_USAGE 추가 (AuditEntityType)
- 엔티티 필드명과 불일치하던 Repository 메서드 네이밍 오류 수정

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
