### PR TITLE
feat(auth): 로그인 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
@@ -7,9 +7,8 @@ import com.finalproj.orbitflow.global.security.SecurityUser;
 import com.finalproj.orbitflow.global.security.jwt.JwtProvider;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,25 +26,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-
+    // Spring Security AuthenticationManager를 사용하지 않고
+    // 회사 ID + 이메일 기반의 커스텀 로그인 정책을 적용한다.
     private final CustomUserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
+
     private final JwtProvider jwtProvider;
 
     @PostMapping("/login")
     public LoginResponse login(@RequestBody LoginRequest request) {
 
-        SecurityUser user = userDetailsService.loadByCompanyIdAndEmail(
-                request.getCompanyId(),
-                request.getEmail()
-        );
+        SecurityUser user = userDetailsService.loadByEmail(request.getEmail());
+
 
         if (user.getStatus() != EmployeeStatus.ACTIVE) {
-            throw new IllegalStateException("로그인할 수 없는 계정 상태입니다.");
+            throw new AccessDeniedException("로그인할 수 없는 계정 상태입니다.");
         }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
+            throw new BadCredentialsException("비밀번호가 올바르지 않습니다.");
         }
 
         String token = jwtProvider.createToken(user);

--- a/src/main/java/com/finalproj/orbitflow/auth/dto/LoginRequest.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/dto/LoginRequest.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginRequest {
 
-    private Long companyId;
     private String email;
     private String password;
 }

--- a/src/main/java/com/finalproj/orbitflow/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/CustomUserDetailsService.java
@@ -25,8 +25,8 @@ public class CustomUserDetailsService  {
     /**
      * 로그인 시 사용 (email 기준)
      */
-    public SecurityUser loadByCompanyIdAndEmail(Long companyId, String email) {
-        Employee employee = employeeRepository.findByCompanyIdAndEmail(companyId, email)
+    public SecurityUser loadByEmail(String email) {
+        Employee employee = employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사원 정보 없음"));
         return new SecurityUser(employee);
     }

--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityUser.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityUser.java
@@ -30,7 +30,7 @@ public class SecurityUser implements UserDetails {
 
     public SecurityUser(Employee employee) {
         this.employeeId = employee.getId();
-        this.companyId = employee.getCompanyId();
+        this.companyId = employee.getCompany().getId();
         this.email = employee.getEmail();
         this.password = employee.getPassword();
         this.status = employee.getStatus();

--- a/src/main/java/com/finalproj/orbitflow/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.finalproj.orbitflow.global.security.jwt;
 
 import com.finalproj.orbitflow.global.security.CustomUserDetailsService;
 import com.finalproj.orbitflow.global.security.SecurityUser;
+import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -56,6 +57,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
 
+                // 계정 상태 체크 (JWT 단계)
+                if (user.getStatus() != EmployeeStatus.ACTIVE) {
+                    SecurityContextHolder.clearContext();
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    return;
+                }
+
+                // 인증 객체 생성
                 var auth = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #37

## 📝 작업 내용
- 이메일 전역 유니크 정책에 맞춰 로그인 요청에서 companyId 제거 및 이메일 기반 단건 인증 로직 확정
- 사원 상태(EmployeeStatus)에 따른 로그인/인증 차단 로직 정리 (ACTIVE 계정만 인증 허용)
- JWT 발급 및 인증 필터에서 테넌트(company) 및 계정 상태 이중 검증 구조 확정
- JWT 기반 인증 구조이므로 로그아웃은 클라이언트에서 토큰을 제거하는 방식으로 처리하도록 정책 확정

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
