### PR TITLE
feat(company, employee): 회사 생성 + bsn 검증 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
@@ -1,0 +1,57 @@
+package com.finalproj.orbitflow.hr.company.controller;
+
+import com.finalproj.orbitflow.global.common.ResponseDto;
+import com.finalproj.orbitflow.hr.company.dto.CompanySignupRequest;
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.company.service.CompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : CompanyController
+ * @since : 2025-12-16 화요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+    private final CompanyRepository companyRepository;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto> signup(
+            @RequestBody CompanySignupRequest request
+    ) {
+        Long companyId = companyService.signup(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDto(
+                        HttpStatus.CREATED,
+                        "회사 가입이 완료되었습니다.",
+                        Map.of("companyId", companyId)
+                ));
+    }
+
+    @GetMapping("/check-business-number")
+    public ResponseEntity<ResponseDto> checkBusinessNumber(
+            @RequestParam String businessNumber
+    ) {
+        boolean exists = companyRepository.existsByBusinessNumber(businessNumber);
+
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        exists ? "이미 등록된 사업자번호입니다." : "사용 가능한 사업자번호입니다.",
+                        Map.of("available", !exists)
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/dto/CompanySignupRequest.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/dto/CompanySignupRequest.java
@@ -1,0 +1,23 @@
+package com.finalproj.orbitflow.hr.company.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : CompanySignupRequest
+ * @since : 2025-12-16 화요일
+ */
+@Getter
+@NoArgsConstructor
+public class CompanySignupRequest {
+    private String companyName;
+    private String address;
+    private String representativeName;
+    private String representativeContact;
+    private String adminEmail;
+    private String adminPassword;
+    private String businessNumber;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/entity/Company.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/entity/Company.java
@@ -55,4 +55,24 @@ public class Company extends BaseEntity {
 
     @Column(name = "representative_contact", nullable = false, length = 20)
     private String representativeContact; // 대표자 연락처
+
+    /**
+     * 회사 생성
+     **/
+    public static Company create(
+            String name,
+            String businessNumber,
+            String address,
+            String representativeName,
+            String representativeContact
+    ) {
+        Company company = new Company();
+        company.name = name;
+        company.businessNumber = businessNumber;
+        company.address = address;
+        company.representativeName = representativeName;
+        company.representativeContact = representativeContact;
+        return company;
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -1,0 +1,53 @@
+package com.finalproj.orbitflow.hr.company.service;
+
+import com.finalproj.orbitflow.hr.company.dto.CompanySignupRequest;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : CompanyService
+ * @since : 2025-12-16 화요일
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CompanyService {
+
+    private final CompanyRepository companyRepository;
+    private final EmployeeRepository employeeRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public Long signup(CompanySignupRequest request) {
+
+        if (companyRepository.existsByBusinessNumber(request.getBusinessNumber())) {
+            throw new IllegalArgumentException("이미 등록된 사업자번호입니다.");
+        }
+
+        Company company = Company.create(
+                request.getCompanyName(),
+                request.getBusinessNumber(),
+                request.getAddress(),
+                request.getRepresentativeName(),
+                request.getRepresentativeContact()
+        );
+        companyRepository.save(company);
+
+        Employee admin = Employee.createAdmin(
+                company,
+                request.getAdminEmail(),
+                passwordEncoder.encode(request.getAdminPassword())
+        );
+        employeeRepository.save(admin);
+
+        return company.getId();
+    }
+}
+

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
@@ -111,5 +111,21 @@ public class Employee extends BaseEntity {
     @Column(nullable = false, length = 20)
     private EmployeeStatus status; // 재직 상태 : TEMP(임시 계정), ACTIVE(재직), SUSPENDED(정지), RESIGNED(퇴사)
 
-    // 생성은 정적 팩토리 메서드를 통해서만 수행
+    /**
+     * 대표 관리자 생성
+     **/
+    public static Employee createAdmin(
+            Company company,
+            String email,
+            String encodedPassword
+    ) {
+        Employee employee = new Employee();
+        employee.company = company;
+        employee.email = email;
+        employee.password = encodedPassword;
+        employee.status = EmployeeStatus.ACTIVE;
+        employee.employmentType = EmploymentType.REGULAR;
+        return employee;
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #39

## 📝 작업 내용
- 회사 가입(온보딩)을 위한 Company 생성 및 대표 관리자(Employee) 계정 생성 API 구현
- 사업자번호 중복 확인 API 추가 (회사 가입 화면 사전 검증용)
- 회사 가입 시 Company / Employee를 하나의 트랜잭션으로 생성하도록 서비스 로직 구성
- Company, Employee 엔티티에 정적 팩토리 메서드(create, createAdmin) 추가

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
