### PR TITLE
feat(common, employee): BaseEntity 수정 + Employee createAdmin 수정

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/global/common/BaseEntity.java
+++ b/src/main/java/com/finalproj/orbitflow/global/common/BaseEntity.java
@@ -29,11 +29,10 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(nullable = false, updatable = false)
+    @Column(updatable = false)
     private Instant createdAt;
 
     @LastModifiedDate
-    @Column(nullable = false)
     private Instant updatedAt;
 
     @CreatedBy

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
@@ -131,6 +131,7 @@ public class Employee extends BaseEntity {
         employee.password = encodedPassword;
         employee.status = EmployeeStatus.ACTIVE;
         employee.employmentType = EmploymentType.REGULAR;
+        employee.workStatus = WorkStatus.OFF_WORK;
         return employee;
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #52

## 📝 작업 내용
- BaseEntity 수정
  - Instant로 타입 유지하기로 결정
  - `createdAt`/`updatedAt`에서 null 허용
- Employee createAdmin 수정
  - `employee.workStatus = WorkStatus.OFF_WORK;` 추가

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
