### PR TITLE
feat(company, auth, main): 회사가입/로그인/메인 화면 틀 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/AuthViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/AuthViewController.java
@@ -1,0 +1,22 @@
+package com.finalproj.orbitflow.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuthViewController
+ * @since : 2025-12-17 수요일
+ */
+@Controller
+@RequestMapping("/login")
+public class AuthViewController {
+
+    @GetMapping
+    public String loginPage() {
+        return "auth/login";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/global/main/controller/MainViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/global/main/controller/MainViewController.java
@@ -1,0 +1,20 @@
+package com.finalproj.orbitflow.global.main.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : MainViewController
+ * @since : 2025-12-17 수요일
+ */
+@Controller
+public class MainViewController {
+
+    @GetMapping("/")
+    public String main() {
+        return "main/index";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyViewController.java
@@ -1,0 +1,23 @@
+package com.finalproj.orbitflow.hr.company.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : CompanyViewController
+ * @since : 2025-12-17 수요일
+ */
+@Controller
+@RequestMapping("/companies")
+public class CompanyViewController {
+
+    @GetMapping("/signup")
+    public String signupPage() {
+        return "company/signup";
+        // templates/company/signup.html
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -5,6 +5,10 @@ import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
+import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
+import com.finalproj.orbitflow.hr.organization.entity.Organization;
+import com.finalproj.orbitflow.hr.organization.repository.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,6 +29,8 @@ public class CompanyService {
     private final CompanyRepository companyRepository;
     private final EmployeeRepository employeeRepository;
     private final PasswordEncoder passwordEncoder;
+    private final OrganizationRepository organizationRepository;
+    private final OrgCategoryRepository orgCategoryRepository;
 
     public Long signup(CompanySignupRequest request) {
 
@@ -32,6 +38,7 @@ public class CompanyService {
             throw new IllegalArgumentException("이미 등록된 사업자번호입니다.");
         }
 
+        // 회사 생성
         Company company = Company.create(
                 request.getCompanyName(),
                 request.getBusinessNumber(),
@@ -41,8 +48,63 @@ public class CompanyService {
         );
         companyRepository.save(company);
 
+        // 3. 기본 조직 카테고리 생성
+        OrgCategory companyCat =
+                orgCategoryRepository.save(
+                        OrgCategory.create(company.getId(), "회사", 0)
+                );
+        OrgCategory hqCat =
+                orgCategoryRepository.save(
+                        OrgCategory.create(company.getId(), "본부", 1)
+                );
+        OrgCategory deptCat =
+                orgCategoryRepository.save(
+                        OrgCategory.create(company.getId(), "부서", 2)
+                );
+        OrgCategory teamCat =
+                orgCategoryRepository.save(
+                        OrgCategory.create(company.getId(), "팀", 3)
+                );
+
+        // 4. 기본 조직 트리 생성
+        Organization rootOrg = organizationRepository.save(
+                Organization.createRoot(company, companyCat.getId())
+        );
+
+        Organization hqOrg = organizationRepository.save(
+                Organization.create(
+                        company.getId(),
+                        hqCat.getId(),
+                        rootOrg.getId(),
+                        "기본생성본부",
+                        1
+                )
+        );
+
+        Organization deptOrg = organizationRepository.save(
+                Organization.create(
+                        company.getId(),
+                        deptCat.getId(),
+                        hqOrg.getId(),
+                        "기본생성부",
+                        1
+                )
+        );
+
+        Organization teamOrg = organizationRepository.save(
+                Organization.create(
+                        company.getId(),
+                        teamCat.getId(),
+                        deptOrg.getId(),
+                        "기본생성팀",
+                        1
+                )
+        );
+
+        // 대표 관리자 생성
         Employee admin = Employee.createAdmin(
                 company,
+                rootOrg,
                 request.getAdminEmail(),
                 passwordEncoder.encode(request.getAdminPassword())
         );

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/entity/Employee.java
@@ -122,16 +122,24 @@ public class Employee extends BaseEntity {
      **/
     public static Employee createAdmin(
             Company company,
+            Organization organization,
             String email,
             String encodedPassword
     ) {
         Employee employee = new Employee();
         employee.company = company;
+        employee.organization = organization;
         employee.email = email;
         employee.password = encodedPassword;
-        employee.status = EmployeeStatus.ACTIVE;
+
+        employee.employeeNo = "ADMIN-" + company.getId();
+
+        employee.name = "대표 관리자";
+        employee.gender = Gender.MALE;
         employee.employmentType = EmploymentType.REGULAR;
+        employee.status = EmployeeStatus.ACTIVE;
         employee.workStatus = WorkStatus.OFF_WORK;
+
         return employee;
     }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
@@ -32,8 +32,22 @@ public class OrgCategory extends BaseEntity {
     private String name;                                // 조직 유형명 (회사/본부/부서/팀)
 
     @Column(name = "order_index", nullable = false)
-private Integer orderIndex;                             // 정렬 순서
+    private Integer orderIndex;                             // 정렬 순서
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;                           // 사용 여부 (소프트 삭제)
+
+    public static OrgCategory create(
+            Long companyId,
+            String name,
+            Integer orderIndex
+    ) {
+        OrgCategory category = new OrgCategory();
+        category.companyId = companyId;
+        category.name = name;
+        category.orderIndex = orderIndex;
+        category.isActive = true;
+        return category;
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/entity/Organization.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/entity/Organization.java
@@ -1,6 +1,7 @@
 package com.finalproj.orbitflow.hr.organization.entity;
 
 import com.finalproj.orbitflow.global.common.BaseEntity;
+import com.finalproj.orbitflow.hr.company.entity.Company;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -42,4 +43,37 @@ public class Organization extends BaseEntity {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;  // 사용 여부 (소프트 삭제)
+
+    public static Organization createRoot(
+            Company company,
+            Long companyCategoryId   // ← "회사" 카테고리 ID
+    ) {
+        Organization org = new Organization();
+        org.companyId = company.getId();
+        org.categoryId = companyCategoryId;
+        org.parentOrgId = null;     // 루트
+        org.name = company.getName(); // 또는 "회사"
+        org.orderIndex = 0;
+        org.isActive = true;
+        return org;
+    }
+
+    public static Organization create(
+            Long companyId,
+            Long categoryId,
+            Long parentOrgId,
+            String name,
+            Integer orderIndex
+    ) {
+        Organization org = new Organization();
+        org.companyId = companyId;
+        org.categoryId = categoryId;
+        org.parentOrgId = parentOrgId;
+        org.name = name;
+        org.orderIndex = orderIndex;
+        org.isActive = true;
+        return org;
+    }
+
+
 }

--- a/src/main/resources/static/js/company-signup.js
+++ b/src/main/resources/static/js/company-signup.js
@@ -1,0 +1,57 @@
+let businessChecked = false;
+
+async function checkBusinessNumber() {
+    const bn = document.getElementById('businessNumber').value;
+    const msg = document.getElementById('businessMsg');
+
+    const res = await fetch(`/api/companies/check-business-number?businessNumber=${bn}`);
+    const json = await res.json();
+
+    if (json.data.available) {
+        msg.textContent = '사용 가능한 사업자번호입니다.';
+        msg.className = 'hint success';
+        businessChecked = true;
+    } else {
+        msg.textContent = '이미 등록된 사업자번호입니다.';
+        msg.className = 'hint error';
+        businessChecked = false;
+    }
+}
+
+async function submitSignup() {
+    if (!businessChecked) {
+        alert('사업자번호 중복 확인이 필요합니다.');
+        return;
+    }
+
+    const pwd = adminPassword.value;
+    const pwd2 = adminPasswordConfirm.value;
+
+    if (pwd !== pwd2) {
+        alert('비밀번호가 일치하지 않습니다.');
+        return;
+    }
+
+    const body = {
+        companyName: companyName.value,
+        address: address.value,
+        representativeName: representativeName.value,
+        representativeContact: representativeContact.value,
+        adminEmail: adminEmail.value,
+        adminPassword: pwd,
+        businessNumber: businessNumber.value
+    };
+
+    const res = await fetch('/api/companies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+
+    if (res.ok) {
+        alert('회사 가입이 완료되었습니다.');
+        location.href = '/login';
+    } else {
+        alert('가입 실패');
+    }
+}

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>로그인 | Orbit Flow</title>
+</head>
+<body>
+
+<h2>로그인</h2>
+
+<input id="email" placeholder="이메일">
+<input id="password" type="password" placeholder="비밀번호">
+
+<button onclick="login()">로그인</button>
+
+<script>
+  async function login() {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        email: email.value,
+        password: password.value
+      })
+    });
+
+    if (res.ok) {
+      location.href = '/';
+    } else {
+      alert('로그인 실패');
+    }
+  }
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/company/signup.html
+++ b/src/main/resources/templates/company/signup.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>회사 가입 | Orbit Flow</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', 'Malgun Gothic', sans-serif;
+      background: #f7f9fb;
+    }
+
+    .signup-container {
+      width: 860px;
+      margin: 80px auto;
+      background: #fff;
+      border-radius: 12px;
+      padding: 48px;
+      box-shadow: 0 6px 20px rgba(0,0,0,.08);
+    }
+
+    h1 {
+      margin-bottom: 8px;
+      color: #253464;
+    }
+
+    .desc {
+      color: #6b7280;
+      margin-bottom: 36px;
+    }
+
+    .row {
+      display: flex;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+
+    .field {
+      flex: 1;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    input {
+      width: 100%;
+      padding: 12px;
+      border-radius: 6px;
+      border: 1px solid #d1d5db;
+      font-size: 15px;
+    }
+
+    .hint {
+      font-size: 12px;
+      margin-top: 6px;
+    }
+
+    .error { color: #ef4444; }
+    .success { color: #10b981; }
+
+    .business-row {
+      display: flex;
+      gap: 8px;
+    }
+
+    .btn {
+      background: #5687ef;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 14px;
+      width: 100%;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 32px;
+    }
+
+    .btn-check {
+      width: 120px;
+      background: #e5e7eb;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+<div class="signup-container">
+  <h1>회사 가입</h1>
+  <p class="desc">서비스 이용을 위한 회사 정보와 대표 관리자 계정을 등록해주세요.</p>
+
+  <div class="row">
+    <div class="field">
+      <label>회사명</label>
+      <input id="companyName">
+    </div>
+    <div class="field">
+      <label>주소</label>
+      <input id="address">
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="field">
+      <label>대표자명</label>
+      <input id="representativeName">
+    </div>
+    <div class="field">
+      <label>대표자 연락처</label>
+      <input id="representativeContact">
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="field">
+      <label>대표 관리자 이메일</label>
+      <input id="adminEmail">
+    </div>
+    <div class="field">
+      <label>비밀번호</label>
+      <input id="adminPassword" type="password">
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="field">
+      <label>비밀번호 확인</label>
+      <input id="adminPasswordConfirm" type="password">
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="field">
+      <label>사업자번호</label>
+      <div class="business-row">
+        <input id="businessNumber">
+        <button class="btn-check" onclick="checkBusinessNumber()">확인</button>
+      </div>
+      <div id="businessMsg" class="hint"></div>
+    </div>
+  </div>
+
+  <button class="btn" onclick="submitSignup()">가입하기</button>
+</div>
+
+<script src="/js/company-signup.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/main/index.html
+++ b/src/main/resources/templates/main/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+메인 페이지는 다같이 만들어보아용 ><
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #60

## 📝 작업 내용
- 회사 가입 API 구현 및 사업자번호 중복 검증 로직 추가
- 회사 가입 시 조직 카테고리(회사/본부/부서/팀) 자동 생성
- 기본 조직 트리(회사 → 본부 → 부서 → 팀) 자동 생성 로직 구현
- 회사 가입 시 대표 관리자(Employee) 계정 자동 생성
- 소속 조직: 회사 루트 조직
- 임시 사번 자동 부여(ADMIN-{companyId})
- 회사 가입 화면(Thymeleaf) 및 사업자번호 중복 확인 UI 구현
- 메인 페이지(View) 진입을 위한 기본 구조 추가
- 로그인 페이지 틀 구현

## 체크리스트
- [x]  컴파일 및 서버 실행 확인
- [x]  회사 가입 전체 플로우 정상 동작 확인
- [x]  조직 카테고리 및 조직 트리 자동 생성 확인
- [x]  대표 관리자 계정 생성 및 매핑 확인

## 스크린샷 (선택)
<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/3762cc63-9935-44ac-a48a-eb928b201829" />
<img width="1624" height="888" alt="image" src="https://github.com/user-attachments/assets/c22d99c0-f0be-4212-979a-049836cc4efe" />


## 💬 리뷰 요구사항(선택)
