### PR TITLE
feat(company): 회사 가입 페이지 수정

### DIFF
--- a/src/main/resources/static/js/company-signup.js
+++ b/src/main/resources/static/js/company-signup.js
@@ -1,45 +1,202 @@
 let businessChecked = false;
 
-async function checkBusinessNumber() {
-    const bn = document.getElementById('businessNumber').value;
-    const msg = document.getElementById('businessMsg');
+/* ======================
+   공통 메시지
+====================== */
+function showMsg(el, message, type) {
+    el.textContent = message;
+    el.className = 'hint ' + type;
+}
 
-    const res = await fetch(`/api/companies/check-business-number?businessNumber=${bn}`);
+/* ======================
+   버튼 상태
+====================== */
+function updateSignupButtonState() {
+    signupBtn.disabled = !(
+        validateCompanyName() &&
+        validateAddress() &&
+        validateRepresentativeName() &&
+        validateEmail() &&
+        validateContact() &&
+        businessChecked &&
+        validatePasswordLength() &&
+        validatePasswordMatch()
+    );
+}
+
+/* ======================
+   회사명 / 주소
+====================== */
+function validateCompanyName() {
+    const v = companyName.value.trim();
+    if (!v) return companyNameMsg.textContent = '', false;
+    showMsg(companyNameMsg, `${v.length}/100`, 'success');
+    return true;
+}
+
+function validateAddress() {
+    const v = address.value.trim();
+    if (!v) return addressMsg.textContent = '', false;
+    showMsg(addressMsg, `${v.length}/255`, 'success');
+    return true;
+}
+
+/* ======================
+   대표자명
+====================== */
+function validateRepresentativeName() {
+    const v = representativeName.value.trim();
+    if (!v) return representativeNameMsg.textContent = '', false;
+    showMsg(representativeNameMsg, `${v.length}/50`, 'success');
+    return true;
+}
+
+/* ======================
+   대표자 연락처 (숫자만 + 글자수)
+====================== */
+representativeContact.addEventListener('input', () => {
+    // 숫자 외 제거
+    representativeContact.value =
+        representativeContact.value.replace(/[^0-9]/g, '');
+
+    validateContact();
+    updateSignupButtonState();
+});
+
+function validateContact() {
+    const v = representativeContact.value;
+    if (!v) {
+        showMsg(contactMsg, `숫자만 입력 가능합니다. (0/20)`, 'error');
+        return false;
+    }
+    showMsg(contactMsg, `입력됨 (${v.length}/20)`, 'success');
+    return true;
+}
+
+/* ======================
+   이메일
+====================== */
+function validateEmail() {
+    const v = adminEmail.value.trim();
+    if (!v) return emailMsg.textContent = '', false;
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) {
+        showMsg(emailMsg, '이메일 형식이 올바르지 않습니다.', 'error');
+        return false;
+    }
+
+    showMsg(emailMsg, '사용 가능한 이메일 형식입니다.', 'success');
+    return true;
+}
+
+/* ======================
+   비밀번호 길이
+====================== */
+function validatePasswordLength() {
+    const v = adminPassword.value;
+
+    if (!v) {
+        showMsg(passwordLengthMsg, '비밀번호는 8~15자입니다. (0/15)', 'error');
+        return false;
+    }
+
+    if (v.length < 8 || v.length > 15) {
+        showMsg(passwordLengthMsg, `비밀번호는 8~15자입니다. (${v.length}/15)`, 'error');
+        return false;
+    }
+
+    showMsg(passwordLengthMsg, `사용 가능한 길이 (${v.length}/15)`, 'success');
+    return true;
+}
+
+/* ======================
+   비밀번호 일치 여부
+====================== */
+function validatePasswordMatch() {
+    const v1 = adminPassword.value;
+    const v2 = adminPasswordConfirm.value;
+
+    if (!v1 || !v2) {
+        showMsg(passwordMatchMsg, '비밀번호를 입력하면 일치 여부를 확인합니다.', 'error');
+        return false;
+    }
+
+    if (v1 !== v2) {
+        showMsg(passwordMatchMsg, '비밀번호가 일치하지 않습니다.', 'error');
+        return false;
+    }
+
+    showMsg(passwordMatchMsg, '비밀번호가 일치합니다.', 'success');
+    return true;
+}
+
+/* ======================
+   비밀번호 이벤트
+====================== */
+adminPassword.addEventListener('input', () => {
+    validatePasswordLength();
+    validatePasswordMatch();
+    updateSignupButtonState();
+});
+
+adminPasswordConfirm.addEventListener('input', () => {
+    validatePasswordMatch();
+    updateSignupButtonState();
+});
+
+/* ======================
+   사업자번호 (숫자만)
+====================== */
+businessNumber.addEventListener('input', () => {
+    businessNumber.value =
+        businessNumber.value.replace(/[^0-9]/g, '');
+
+    businessChecked = false;
+    businessMsg.textContent = '';
+    updateSignupButtonState();
+});
+
+async function checkBusinessNumber() {
+    const v = businessNumber.value.trim();
+    if (!v) return showMsg(businessMsg, '사업자번호를 입력해주세요.', 'error');
+
+    const res = await fetch(
+        `/api/companies/check-business-number?businessNumber=${encodeURIComponent(v)}`
+    );
     const json = await res.json();
 
     if (json.data.available) {
-        msg.textContent = '사용 가능한 사업자번호입니다.';
-        msg.className = 'hint success';
+        showMsg(businessMsg, '사용 가능한 사업자번호입니다.', 'success');
         businessChecked = true;
     } else {
-        msg.textContent = '이미 등록된 사업자번호입니다.';
-        msg.className = 'hint error';
+        showMsg(businessMsg, '이미 등록된 사업자번호입니다.', 'error');
         businessChecked = false;
     }
+    updateSignupButtonState();
 }
 
+/* ======================
+   공통 입력 이벤트
+====================== */
+[
+    companyName, address, representativeName,
+    adminEmail
+].forEach(el => el.addEventListener('input', updateSignupButtonState));
+
+/* ======================
+   제출
+====================== */
 async function submitSignup() {
-    if (!businessChecked) {
-        alert('사업자번호 중복 확인이 필요합니다.');
-        return;
-    }
-
-    const pwd = adminPassword.value;
-    const pwd2 = adminPasswordConfirm.value;
-
-    if (pwd !== pwd2) {
-        alert('비밀번호가 일치하지 않습니다.');
-        return;
-    }
+    if (signupBtn.disabled) return;
 
     const body = {
-        companyName: companyName.value,
-        address: address.value,
-        representativeName: representativeName.value,
-        representativeContact: representativeContact.value,
-        adminEmail: adminEmail.value,
-        adminPassword: pwd,
-        businessNumber: businessNumber.value
+        companyName: companyName.value.trim(),
+        address: address.value.trim(),
+        representativeName: representativeName.value.trim(),
+        representativeContact: representativeContact.value.trim(),
+        adminEmail: adminEmail.value.trim(),
+        adminPassword: adminPassword.value,
+        businessNumber: businessNumber.value.trim()
     };
 
     const res = await fetch('/api/companies', {
@@ -51,7 +208,5 @@ async function submitSignup() {
     if (res.ok) {
         alert('회사 가입이 완료되었습니다.');
         location.href = '/login';
-    } else {
-        alert('가입 실패');
     }
 }

--- a/src/main/resources/templates/company/signup.html
+++ b/src/main/resources/templates/company/signup.html
@@ -1,151 +1,198 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <meta charset="UTF-8">
-  <title>회사 가입 | Orbit Flow</title>
-  <style>
-    body {
-      font-family: 'Segoe UI', 'Malgun Gothic', sans-serif;
-      background: #f7f9fb;
-    }
+    <meta charset="UTF-8">
+    <title>회사 가입 | Orbit Flow</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', 'Malgun Gothic', sans-serif;
+            background: #f7f9fb;
+        }
 
-    .signup-container {
-      width: 860px;
-      margin: 80px auto;
-      background: #fff;
-      border-radius: 12px;
-      padding: 48px;
-      box-shadow: 0 6px 20px rgba(0,0,0,.08);
-    }
+        .signup-container {
+            width: 860px;
+            margin: 80px auto;
+            background: #fff;
+            border-radius: 12px;
+            padding: 48px;
+            box-shadow: 0 6px 20px rgba(0, 0, 0, .08);
+        }
 
-    h1 {
-      margin-bottom: 8px;
-      color: #253464;
-    }
+        h1 {
+            margin-bottom: 8px;
+            color: #253464;
+        }
 
-    .desc {
-      color: #6b7280;
-      margin-bottom: 36px;
-    }
+        .desc {
+            color: #6b7280;
+            margin-bottom: 36px;
+        }
 
-    .row {
-      display: flex;
-      gap: 24px;
-      margin-bottom: 24px;
-    }
+        .row {
+            display: flex;
+            gap: 24px;
+            margin-bottom: 24px;
+        }
 
-    .field {
-      flex: 1;
-    }
+        .field {
+            flex: 1;
+        }
 
-    label {
-      display: block;
-      margin-bottom: 6px;
-      font-weight: 600;
-      color: #374151;
-    }
+        label {
+            display: block;
+            margin-bottom: 6px;
+            font-weight: 600;
+            color: #374151;
+        }
 
-    input {
-      width: 100%;
-      padding: 12px;
-      border-radius: 6px;
-      border: 1px solid #d1d5db;
-      font-size: 15px;
-    }
+        input {
+            width: 100%;
+            padding: 12px;
+            border-radius: 6px;
+            border: 1px solid #d1d5db;
+            font-size: 15px;
+        }
 
-    .hint {
-      font-size: 12px;
-      margin-top: 6px;
-    }
+        .hint {
+            font-size: 12px;
+            margin-top: 6px;
+        }
 
-    .error { color: #ef4444; }
-    .success { color: #10b981; }
+        .error {
+            color: #ef4444;
+        }
 
-    .business-row {
-      display: flex;
-      gap: 8px;
-    }
+        .success {
+            color: #10b981;
+        }
 
-    .btn {
-      background: #5687ef;
-      color: #fff;
-      border: none;
-      border-radius: 8px;
-      padding: 14px;
-      width: 100%;
-      font-size: 16px;
-      font-weight: 600;
-      cursor: pointer;
-      margin-top: 32px;
-    }
+        .business-row {
+            display: flex;
+            gap: 8px;
+        }
 
-    .btn-check {
-      width: 120px;
-      background: #e5e7eb;
-      border: none;
-      border-radius: 6px;
-      cursor: pointer;
-    }
-  </style>
+        .btn {
+            background: #5687ef;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            padding: 14px;
+            width: 100%;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            margin-top: 32px;
+        }
+
+        .btn-check {
+            width: 120px;
+            background: #e5e7eb;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+
+        button:disabled {
+            background: #d1d5db;
+            cursor: not-allowed;
+        }
+    </style>
 </head>
 <body>
 
 <div class="signup-container">
-  <h1>회사 가입</h1>
-  <p class="desc">서비스 이용을 위한 회사 정보와 대표 관리자 계정을 등록해주세요.</p>
+    <h1>회사 가입</h1>
+    <p class="desc">서비스 이용을 위한 회사 정보와 대표 관리자 계정을 등록해주세요.</p>
 
-  <div class="row">
-    <div class="field">
-      <label>회사명</label>
-      <input id="companyName">
+    <!-- 회사 정보 -->
+    <div class="row">
+        <div class="field">
+            <label>회사명</label>
+            <input id="companyName" maxlength="100">
+            <div id="companyNameMsg" class="hint"></div>
+        </div>
+        <div class="field">
+            <label>주소</label>
+            <input id="address" maxlength="255">
+            <div id="addressMsg" class="hint"></div>
+        </div>
     </div>
-    <div class="field">
-      <label>주소</label>
-      <input id="address">
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="field">
-      <label>대표자명</label>
-      <input id="representativeName">
+    <!-- 대표자 -->
+    <div class="row">
+        <div class="field">
+            <label>대표자명</label>
+            <input id="representativeName" maxlength="50">
+            <div id="representativeNameMsg" class="hint"></div>
+        </div>
+        <div class="field">
+            <label>대표자 연락처</label>
+            <input
+                    id="representativeContact"
+                    maxlength="20"
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="숫자만 입력"
+            />
+            <div id="contactMsg" class="hint"></div>
+        </div>
     </div>
-    <div class="field">
-      <label>대표자 연락처</label>
-      <input id="representativeContact">
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="field">
-      <label>대표 관리자 이메일</label>
-      <input id="adminEmail">
+    <!-- 이메일 / 비밀번호 -->
+    <div class="row">
+        <div class="field">
+            <label>대표 관리자 이메일</label>
+            <input id="adminEmail" maxlength="100">
+            <div id="emailMsg" class="hint"></div>
+        </div>
+        <div class="field">
+            <label>비밀번호</label>
+            <input
+                    id="adminPassword"
+                    type="password"
+                    maxlength="15"
+                    placeholder="8~15자"
+            />
+            <div id="passwordLengthMsg" class="hint"></div>
+        </div>
     </div>
-    <div class="field">
-      <label>비밀번호</label>
-      <input id="adminPassword" type="password">
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="field">
-      <label>비밀번호 확인</label>
-      <input id="adminPasswordConfirm" type="password">
-    </div>
-  </div>
+    <div class="row">
+        <div class="field">
+            <label>비밀번호 확인</label>
+            <input
+                    id="adminPasswordConfirm"
+                    type="password"
+                    maxlength="15"
+                    placeholder="비밀번호 재입력"
+            />
+            <div id="passwordMatchMsg" class="hint"></div>
+        </div>
 
-  <div class="row">
-    <div class="field">
-      <label>사업자번호</label>
-      <div class="business-row">
-        <input id="businessNumber">
-        <button class="btn-check" onclick="checkBusinessNumber()">확인</button>
-      </div>
-      <div id="businessMsg" class="hint"></div>
+        <div class="field">
+            <label>사업자번호</label>
+            <div class="business-row">
+                <input
+                id="businessNumber"
+                maxlength="20"
+                inputmode="numeric"
+                pattern="[0-9]*"
+                        placeholder="숫자만 입력"
+                />
+                <button type="button" class="btn-check" onclick="checkBusinessNumber()">확인</button>
+            </div>
+            <div id="businessMsg" class="hint"></div>
+        </div>
     </div>
-  </div>
 
-  <button class="btn" onclick="submitSignup()">가입하기</button>
+    <button
+            id="signupBtn"
+            class="btn"
+            onclick="submitSignup()"
+            disabled
+    >
+        가입하기
+    </button>
 </div>
 
 <script src="/js/company-signup.js"></script>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #79

## 📝 작업 내용
- 회사 가입 화면 전반에 입력값 Validation 로직 구현
  - 회사명/주소/대표자명: 입력 길이 제한 및 실시간 글자 수 안내
  - 대표자 연락처: 숫자만 입력 가능하도록 처리(입력 단계 필터링) 및 실시간 글자 수 안내
  - 관리자 이메일: 이메일 형식 검증 및 즉시 피드백
  - 비밀번호: 8~15자 길이 제한 검증 및 실시간 길이 안내
  - 비밀번호 확인: 비밀번호 일치 여부 실시간 안내
- 사업자번호 입력 UX 개선
  - 숫자만 입력 가능하도록 처리
  - 사업자번호 중복 확인 API 연동 및 결과 메시지 표시
  - 사업자번호 변경 시 재확인 필요 상태로 초기화
- 모든 필수 Validation 조건 충족 시에만 가입 버튼 활성화
  - 조건 미충족 시 버튼 disabled 처리
  - disabled 상태 시 스타일 분리 적용
- alert 기반 오류 안내 제거 및 입력 필드 하단 메시지 기반 UX로 통일
- HTML input 속성 보강
  - maxlength, inputmode, pattern, placeholder 적용으로 입력 의도 명확화

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="1919" height="989" alt="image" src="https://github.com/user-attachments/assets/d2f0b84f-b9c8-425c-a834-860579b80c36" />
<img width="1919" height="985" alt="image" src="https://github.com/user-attachments/assets/50513705-db4e-4594-9965-ccd06524537b" />
<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/b4259943-c656-4d34-bf77-81ca55d555a0" />

## 💬 리뷰 요구사항(선택)
