### PR TITLE
feat(OrgCategory): 조직 카테고리 crud 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityUtils.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityUtils.java
@@ -1,0 +1,30 @@
+package com.finalproj.orbitflow.global.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : SecurityUtils
+ * @since : 2025-12-17 수요일
+ */
+public class SecurityUtils {
+
+    public static SecurityUser getCurrentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof SecurityUser user)) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+        return user;
+    }
+
+    public static Long getCompanyId() {
+        return getCurrentUser().getCompanyId();
+    }
+
+    public static Long getEmployeeId() {
+        return getCurrentUser().getEmployeeId();
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
@@ -1,0 +1,77 @@
+package com.finalproj.orbitflow.hr.orgCategory.controller;
+
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryCreateReqDto;
+import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryResDto;
+import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryUpdateReqDto;
+import com.finalproj.orbitflow.hr.orgCategory.service.OrgCategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryController
+ * @since : 2025-12-17 수요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/org-categories")
+public class OrgCategoryController {
+
+    private final OrgCategoryService orgCategoryService;
+
+    @PostMapping
+    public ResponseEntity<Long> create(
+            @RequestBody @Valid OrgCategoryCreateReqDto request
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        Long id = orgCategoryService.create(
+                companyId,
+                request.getName(),
+                request.getOrderIndex()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(id);
+    }
+
+
+    @GetMapping
+    public ResponseEntity<List<OrgCategoryResDto>> list() {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        return ResponseEntity.ok(orgCategoryService.findAll(companyId));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(
+            @PathVariable Long id,
+            @RequestBody @Valid OrgCategoryUpdateReqDto request
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        orgCategoryService.update(
+                companyId,
+                id,
+                request.getName(),
+                request.getOrderIndex()
+        );
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deactivate(
+            @PathVariable Long id
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        orgCategoryService.deactivate(companyId, id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryCreateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryCreateReqDto.java
@@ -1,0 +1,24 @@
+package com.finalproj.orbitflow.hr.orgCategory.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryCreateReqDto
+ * @since : 2025-12-17 수요일
+ */
+@Getter
+public class OrgCategoryCreateReqDto {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    @Min(1)
+    private Integer orderIndex;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryResDto.java
@@ -1,0 +1,31 @@
+package com.finalproj.orbitflow.hr.orgCategory.dto;
+
+import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryResDto
+ * @since : 2025-12-17 수요일
+ */
+
+@Getter
+@AllArgsConstructor
+public class OrgCategoryResDto {
+    private Long id;
+    private String name;
+    private Integer orderIndex;
+    private Boolean isActive;
+
+    public static OrgCategoryResDto from(OrgCategory entity) {
+        return new OrgCategoryResDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getOrderIndex(),
+                entity.getIsActive()
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryUpdateReqDto.java
@@ -1,0 +1,24 @@
+package com.finalproj.orbitflow.hr.orgCategory.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryUpdateReqDto
+ * @since : 2025-12-17 수요일
+ */
+@Getter
+public class OrgCategoryUpdateReqDto {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    @Min(1)
+    private Integer orderIndex;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
@@ -50,4 +50,13 @@ public class OrgCategory extends BaseEntity {
         return category;
     }
 
+    public void update(String name, Integer orderIndex) {
+        this.name = name;
+        this.orderIndex = orderIndex;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
@@ -24,4 +24,10 @@ public interface OrgCategoryRepository extends JpaRepository<OrgCategory, Long> 
      * 회사별 특정 조직 카테고리 조회
      */
     Optional<OrgCategory> findByCompanyIdAndId(Long companyId, Long categoryId);
+
+    /**
+     * 조직 카테고리 중복 체크
+     */
+    boolean existsByCompanyIdAndName(Long companyId, String name);
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
@@ -1,0 +1,89 @@
+package com.finalproj.orbitflow.hr.orgCategory.service;
+
+import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryResDto;
+import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
+import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
+import com.finalproj.orbitflow.hr.organization.repository.OrganizationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryService
+ * @since : 2025-12-17 수요일
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrgCategoryService {
+
+    private final OrgCategoryRepository orgCategoryRepository;
+    private final OrganizationRepository organizationRepository;
+
+    /**
+     * 조직 카테고리 생성
+     */
+    public Long create(Long companyId, String name, Integer orderIndex) {
+
+        if (orgCategoryRepository.existsByCompanyIdAndName(companyId, name)) {
+            throw new IllegalArgumentException("이미 존재하는 조직 카테고리입니다.");
+        }
+
+        OrgCategory category =
+                OrgCategory.create(companyId, name, orderIndex);
+
+        return orgCategoryRepository.save(category).getId();
+    }
+
+    /**
+     * 조직 카테고리 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<OrgCategoryResDto> findAll(Long companyId) {
+
+        return orgCategoryRepository
+                .findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId)
+                .stream()
+                .map(OrgCategoryResDto::from)
+                .toList();
+    }
+
+    /**
+     * 조직 카테고리 수정
+     */
+    public void update(
+            Long companyId,
+            Long categoryId,
+            String name,
+            Integer orderIndex
+    ) {
+        OrgCategory category = orgCategoryRepository
+                .findByCompanyIdAndId(companyId, categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("조직 카테고리를 찾을 수 없습니다."));
+
+        category.update(name, orderIndex);
+    }
+
+    /**
+     * 조직 카테고리 비활성화
+     */
+    public void deactivate(Long companyId, Long categoryId) {
+
+        OrgCategory category = orgCategoryRepository
+                .findByCompanyIdAndId(companyId, categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("조직 카테고리를 찾을 수 없습니다."));
+
+        if (organizationRepository.existsByCompanyIdAndCategoryIdAndIsActiveTrue(companyId, categoryId)) {
+            throw new IllegalArgumentException(
+                    "해당 카테고리를 사용하는 조직이 존재하여 비활성화할 수 없습니다."
+            );
+        }
+
+        category.deactivate();
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrganizationRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrganizationRepository.java
@@ -31,4 +31,10 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
      * 회사별 전체 조직 조회 (트리 구성용)
      */
     List<Organization> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
+
+    /**
+     * 해당 카테고리를 사용하는 활성 조직 존재 여부
+     */
+    boolean existsByCompanyIdAndCategoryIdAndIsActiveTrue(Long companyId, Long categoryId);
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #82

## 📝 작업 내용
- JWT 기반 멀티테넌트 구조로 조직 카테고리(OrgCategory) CRUD 구현
- SecurityUtils를 통해 SecurityContext에서 companyId/employeeId 추출하도록 구현
- 조직 카테고리 비활성화 시, 해당 카테고리를 사용하는 활성 조직 존재 여부 제약 로직 추가
- Request / Response DTO 분리 및 from() 패턴 적용으로 Entity 직접 노출 방지
- Validation 어노테이션(`@NotBlank`, `@Min` 등) 적용 및 Controller에 `@Valid` 연동
- 멀티테넌트 안전성을 위해 Repository 쿼리를 companyId 기준으로 통일

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- 커스텀 예외(BusinessException 등) 적용 여부에 대해 얘기하고 싶습니다.