### PR TITLE
feat(meetingroom): 사용자 화면 디자인 + 개발용으로 전체 permitAll

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
@@ -47,30 +47,32 @@ public class SecurityConfig {
                                 "/favicon.ico",
                                 "/css/**",
                                 "/js/**",
-                                "/images/**"
+                                "/images/**",
+                                "/view/**",
+                                "/api/**"
                         ).permitAll()
 
-                        // ===== 인증 API =====
-                        .requestMatchers(
-                                "/api/auth/login",
-                                "/api/auth/refresh"
-                        ).permitAll()
-
-                        // ===== 관리자 화면 =====
-                        .requestMatchers("/view/admin/**").permitAll()
-
-                        // ===== 일반 화면 =====
-                        .requestMatchers("/view/**")
-                        .authenticated()
-
-                        // ===== API =====
-                        .requestMatchers("/api/company-admin/**")
-                        .hasRole("COMPANY_ADMIN")
-
-                        .requestMatchers("/api/admin/**")
-                        .hasAnyRole("ADMIN", "COMPANY_ADMIN")
-
-                        .anyRequest().authenticated()
+//                        // ===== 인증 API =====
+//                        .requestMatchers(
+//                                "/api/auth/login",
+//                                "/api/auth/refresh"
+//                        ).permitAll()
+//
+//                        // ===== 관리자 화면 =====
+//                        .requestMatchers("/view/admin/**").permitAll()
+//
+//                        // ===== 일반 화면 =====
+//                        .requestMatchers("/view/**")
+//                        .authenticated()
+//
+//                        // ===== API =====
+//                        .requestMatchers("/api/company-admin/**")
+//                        .hasRole("COMPANY_ADMIN")
+//
+//                        .requestMatchers("/api/admin/**")
+//                        .hasAnyRole("ADMIN", "COMPANY_ADMIN")
+//
+//                        .anyRequest().authenticated()
                 )
                 // HttpSession + JSESSIONID 기반이라 주석처리함
 //                .formLogin(login -> login

--- a/src/main/java/com/finalproj/orbitflow/resource/meetingroom/controller/MeetingroomViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/resource/meetingroom/controller/MeetingroomViewController.java
@@ -12,15 +12,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @filename : MeetingroomViewController
  * @since : 2025-12-18 오후 11:03 목요일
  */
-@RequestMapping("/view/admin/resource")
+@RequestMapping("/view/resource")
 @Controller
 public class MeetingroomViewController {
 
-    @GetMapping("/meetingrooms")
+    @GetMapping("/admin/meetingrooms")
     public String getMeetingroomsPage(Model model) {
 
         model.addAttribute("currentGNB", "admin");
 
         return "admin/admin_meetingrooms";
+    }
+
+    // 사용자 회의실 조회 화면
+    @GetMapping("/meetingrooms")
+    public String meetingroomList() {
+        return "meetingroom/meetingroom-list";
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect
 
   thymeleaf:
     cache: false

--- a/src/main/resources/static/css/meetingroom-user.css
+++ b/src/main/resources/static/css/meetingroom-user.css
@@ -1,0 +1,205 @@
+/* =========================
+   Page Header
+========================= */
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.page-title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #222;
+    letter-spacing: -1px;
+}
+
+/* =========================
+   Buttons
+========================= */
+.btn-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+
+    background: #4a69bd;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 6px;
+
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.btn-add:hover {
+    background: #3a5aa0;
+}
+
+/* =========================
+   Table Container
+========================= */
+.table-container {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+/* =========================
+   Resource Table (Base)
+========================= */
+.resource-table {
+    width: 100%;
+    margin-top: 16px;
+    border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.resource-table thead {
+    background: #f8f9fa;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.resource-table th,
+.resource-table td {
+    padding: 14px 16px;
+    font-size: 14px;
+    text-align: left;
+    border-bottom: 1px solid #f0f0f0;
+
+    /* 한 줄 유지 */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    position: relative;
+}
+
+.resource-table th {
+    font-weight: 600;
+    color: #495057;
+}
+
+.resource-table td {
+    color: #555;
+}
+
+.resource-table td:first-child {
+    text-align: center;
+    font-weight: 600;
+    color: #6c757d;
+}
+
+.resource-table tbody tr {
+    transition: background 0.2s;
+}
+
+.resource-table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+.resource-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* =========================
+   Tooltip Base (공통 디자인)
+========================= */
+.tooltip,
+.resource-table td[data-fulltext]:hover::after {
+    max-width: 400px;
+    padding: 6px 10px;
+
+    background: rgba(33, 37, 41, 0.95);
+    color: #fff;
+    font-size: 13px;
+    line-height: 1.4;
+
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+
+    white-space: normal;
+    font-family: 'Noto Sans KR', system-ui, sans-serif;
+}
+
+/* =========================
+   JS Tooltip (position: fixed)
+========================= */
+.tooltip {
+    position: fixed;
+    z-index: 9999;
+    pointer-events: none;
+}
+
+/* =========================
+   CSS Hover Tooltip (Columns 3, 4)
+========================= */
+.resource-table td:nth-child(3),
+.resource-table td:nth-child(4) {
+    cursor: help;
+}
+
+.resource-table td:nth-child(3):hover::after,
+.resource-table td:nth-child(4):hover::after {
+    content: attr(data-fulltext);
+
+    position: absolute;
+    left: 0;
+    top: 100%;
+    z-index: 1000;
+}
+
+/* =========================
+   Action Buttons
+========================= */
+.action-btns {
+    display: flex;
+    gap: 8px;
+}
+
+.btn-edit,
+.btn-delete {
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.btn-edit {
+    background: #e3f2fd;
+    color: #1976d2;
+}
+
+.btn-edit:hover {
+    background: #bbdefb;
+}
+
+.btn-delete {
+    background: #ffebee;
+    color: #c62828;
+}
+
+.btn-delete:hover {
+    background: #ffcdd2;
+}
+
+/* =========================
+   Empty State
+========================= */
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #999;
+}
+
+.empty-state i {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.3;
+}

--- a/src/main/resources/static/js/meetingroom-user.js
+++ b/src/main/resources/static/js/meetingroom-user.js
@@ -1,0 +1,94 @@
+/* ==========================
+   Tooltip (공통 재사용)
+========================== */
+let tooltipEl = null;
+
+function ensureTooltip() {
+    if (!tooltipEl) {
+        tooltipEl = document.createElement('div');
+        tooltipEl.className = 'tooltip';
+        document.body.appendChild(tooltipEl);
+    }
+}
+
+function showTooltip(e) {
+    const text = e.currentTarget.dataset.fulltext;
+    if (!text) return;
+
+    ensureTooltip();
+    tooltipEl.textContent = text;
+    tooltipEl.style.display = 'block';
+    moveTooltip(e);
+}
+
+function moveTooltip(e) {
+    if (!tooltipEl) return;
+    tooltipEl.style.left = e.pageX + 12 + 'px';
+    tooltipEl.style.top = e.pageY + 12 + 'px';
+}
+
+function hideTooltip() {
+    if (tooltipEl) tooltipEl.style.display = 'none';
+}
+
+/* ==========================
+   Cell Helper
+========================== */
+function createCell(value = '', tooltip = false) {
+    const td = document.createElement('td');
+    const text = (value ?? '').toString();
+    td.textContent = text;
+
+    if (tooltip && text) {
+        td.dataset.fulltext = text;
+        td.addEventListener('mouseenter', showTooltip);
+        td.addEventListener('mousemove', moveTooltip);
+        td.addEventListener('mouseleave', hideTooltip);
+    }
+    return td;
+}
+
+/* ==========================
+   Load Data (USER)
+========================== */
+async function loadMeetingRooms() {
+    try {
+        const res = await apiFetch('/api/meetingrooms');
+        if (!res.ok) throw new Error();
+
+        const { data } = await res.json();
+        const tbody = document.querySelector('.resource-table tbody');
+        tbody.innerHTML = '';
+
+        if (!data?.length) {
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="5">
+                        <div class="empty-state">
+                            <i class="fas fa-inbox"></i>
+                            <p>사용 가능한 회의실이 없습니다.</p>
+                        </div>
+                    </td>
+                </tr>`;
+            return;
+        }
+
+        data.forEach((room, i) => {
+            const tr = document.createElement('tr');
+            tr.append(
+                createCell(i + 1),
+                createCell(room.name),
+                createCell(room.position, true),
+                createCell(room.description, true),
+                createCell(room.statusName)
+            );
+            tbody.appendChild(tr);
+        });
+
+    } catch (e) {
+        console.error(e);
+        alert('회의실 목록을 불러오지 못했습니다.');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadMeetingRooms);

--- a/src/main/resources/templates/layout/layout-admin.html
+++ b/src/main/resources/templates/layout/layout-admin.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" th:href="@{/css/layout.css}">
     <link rel="stylesheet" th:href="@{/css/layout-admin.css}">
 
-    <!-- ✅ 페이지별 CSS 삽입 위치 -->
+    <!-- 페이지별 CSS 삽입 위치 -->
     <th:block th:replace="${pageCss}"></th:block>
 </head>
 

--- a/src/main/resources/templates/layout/layout-user.html
+++ b/src/main/resources/templates/layout/layout-user.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:fragment="layout(content, headerFragment, sidebarFragment, pageCss)">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title th:text="${pageTitle} ?: 'OrbitFlow'">OrbitFlow</title>
     
     <!-- Font 및 아이콘 -->
@@ -11,198 +11,14 @@
     
     <!-- 공통 CSS -->
     <link rel="stylesheet" th:href="@{/css/layout.css}">
-    
-    <!-- 헤더 및 사이드바 CSS - 인라인으로 직접 포함 -->
-    <style>
-        /* 공통 헤더 스타일 */
-        .header-bar {
-            background-color: #e1e2ef;
-            height: 55px;
-            padding: 0 24px;
-            display: flex;
-            align-items: center;
-            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-        }
-        .gnb {
-            display: flex;
-            flex: 1;
-            gap: 20px;
-        }
-        .gnb a {
-            text-decoration: none;
-            color: #363637;
-            font-weight: 500;
-            line-height: 55px;
-            font-size: 16px;
-            transition: color 0.2s, border-bottom 0.2s;
-        }
-        .gnb a:hover {
-            color: #4a69bd;
-        }
-        .gnb a.selected {
-            border-bottom: 3px solid #23273c;
-            color: #23273c;
-            font-weight: 700;
-        }
-        .header-bar .profile {
-            margin-left: auto;
-            display: flex;
-            align-items: center;
-            font-size: 16px;
-            color: #23273c;
-        }
-        .header-bar .profile .icon-group {
-            margin-right: 15px;
-            color: #666;
-        }
-        .header-bar .profile .icon-group i {
-            margin: 0 8px;
-            cursor: pointer;
-            font-size: 18px;
-        }
-        .header-bar .profile .icon-group i:hover {
-            color: #333;
-        }
-        .header-bar .profile .user-info {
-            display: flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            background: rgba(255, 255, 255, 0.5);
-        }
-        .header-bar .profile .user-info span {
-            margin-right: 8px;
-            font-size: 14px;
-            color: #666;
-            cursor: pointer;
-        }
-        .header-bar .profile .user-info span:hover {
-            color: #333;
-        }
-        .header-bar .profile .user-info i.fa-user-circle {
-            margin-left: 8px;
-            font-size: 24px;
-            color: #666;
-        }
-        .header-bar .profile .user {
-            margin-left: 8px;
-            font-weight: bold;
-        }
-        .admin-header {
-            background-color: #2c3e50;
-        }
-        .admin-header .gnb a {
-            color: #ecf0f1;
-        }
-        .admin-header .gnb a:hover {
-            color: #3498db;
-        }
-        .admin-header .gnb a.selected {
-            border-bottom: 3px solid #3498db;
-            color: #3498db;
-        }
-        .admin-header .profile {
-            color: #ecf0f1;
-        }
-        
-        /* 공통 사이드바 스타일 */
-        .sidebar {
-            width: 250px;
-            background: #23273c;
-            color: #fff;
-            display: flex;
-            flex-direction: column;
-            box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-            z-index: 10;
-        }
-        .sidebar-inner {
-            display: flex;
-            flex-direction: column;
-            height: 100%;
-            padding-top: 24px;
-        }
-        .sidebar-title {
-            padding: 0 0 16px 36px;
-            letter-spacing: -2px;
-            font-weight: bold;
-            color: #b3b3cd;
-            font-size: 20px;
-        }
-        .sidebar-logo-icon {
-            color: #4a69bd;
-            margin-right: 8px;
-        }
-        .sidebar-menu-wrapper {
-            flex: 1;
-            overflow-y: auto;
-        }
-        .sidebar-menu {
-            list-style: none;
-            margin: 0;
-            padding: 0 0 16px 36px;
-        }
-        .sidebar-section-title {
-            margin-top: 20px;
-            margin-bottom: 8px;
-            font-weight: bold;
-            font-size: 15px;
-            color: #ffffff;
-        }
-        .sidebar-link {
-            text-decoration: none;
-            color: #c9ccdd;
-            font-size: 15px;
-            display: block;
-            padding: 4px 0;
-        }
-        .sidebar-link:hover {
-            color: #ffffff;
-        }
-        .sidebar-menu li {
-            margin: 6px 0;
-            cursor: pointer;
-            transition: color 0.2s, background 0.2s, transform 0.2s;
-        }
-        .sidebar-menu li a {
-            display: block;
-            padding: 8px 0;
-            text-decoration: none;
-            color: #c9ccdd;
-            font-size: 15px;
-            transition: color 0.2s;
-        }
-        .sidebar-menu li:hover a {
-            color: #fff;
-        }
-        .sidebar-menu li.selected {
-            color: #fff;
-            font-weight: bold;
-            background: rgba(255, 255, 255, 0.1);
-            margin-left: -36px;
-            padding: 8px 36px;
-            border-left: 4px solid #4a69bd;
-        }
-        .sidebar-menu li.selected a {
-            color: #fff;
-            font-weight: bold;
-        }
-        .sidebar-footer {
-            margin-top: auto;
-            background: #fff;
-            min-height: 80px;
-            padding: 15px 24px;
-            font-size: 13px;
-            color: #333;
-        }
-    </style>
+    <link rel="stylesheet" th:href="@{/css/layout-user.css}">
 
-    <!-- 페이지별 추가 CSS -->
-    <th:block th:if="${pageStyles != null}">
-        <link th:each="style : ${pageStyles}" rel="stylesheet" th:href="@{${style}}">
-    </th:block>
+    <!-- 페이지별 CSS 삽입 위치 -->
+    <th:block th:replace="${pageCss}"></th:block>
+
 </head>
 <body>
-<div th:fragment="layout(content, headerFragment, sidebarFragment)" class="app-wrapper">
+<div class="app-wrapper">
     <header th:replace="${headerFragment}"></header>
 
     <div class="app-body">
@@ -213,5 +29,9 @@
         </main>
     </div>
 </div>
+
+<script th:src="@{/js/common.js}"></script>
+
+
 </body>
 </html>

--- a/src/main/resources/templates/meetingroom/meetingroom-list.html
+++ b/src/main/resources/templates/meetingroom/meetingroom-list.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-user :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{::user-sidebar-menu},
+        ~{::page-css}
+      )}">
+
+<!-- 페이지 전용 CSS -->
+<th:block th:fragment="page-css">
+  <link rel="stylesheet" th:href="@{/css/meetingroom-user.css}">
+</th:block>
+
+<div th:fragment="content">
+  <div class="page-header">
+    <h1 class="page-title">회의실 조회</h1>
+  </div>
+
+  <div class="table-container">
+    <table class="resource-table">
+      <colgroup>
+        <col style="width:5%">
+        <col style="width:25%">
+        <col style="width:25%">
+        <col style="width:35%">
+        <col style="width:10%">
+      </colgroup>
+      <thead>
+      <tr>
+        <th>번호</th>
+        <th>회의실명</th>
+        <th>위치</th>
+        <th>설명</th>
+        <th>상태</th>
+      </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script th:src="@{/js/meetingroom-user.js}"></script>
+</div>
+
+<ul th:fragment="user-sidebar-menu" class="sidebar-menu">
+  <li class="selected">
+    <a th:href="@{/view/resource/meetingrooms}" class="sidebar-link">
+      회의실 목록
+    </a>
+  </li>
+</ul>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #128

## 📝 작업 내용
- 회의실 사용자 화면 신규 구현
  - 사용자용 회의실 조회 화면 추가 (/view/resource/meetingrooms)
  - 관리자 화면과 분리된 View 구조 적용
  - AVAILABLE 상태의 회의실만 조회하도록 사용자 API 연동
- 관리자 / 사용자 화면 접근 경로 분리
  - 관리자: /view/resource/admin/meetingrooms
  - 사용자: /view/resource/meetingrooms
  - View Controller 역할 분리로 URL 충돌 방지
- Spring Security 접근 정책 조정 (개발 단계)
  - View 페이지(/view/**)는 permitAll로 설정
  - 실제 권한 검증은 API 단에서 처리하도록 구조 정리
  - JWT 기반 API 인증 흐름 유지

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/d542f1b7-e1b3-4397-bd39-4ad7c28d3d66" />

## 💬 리뷰 요구사항(선택)
