### PR TITLE
feat(auth, hr): 사업자번호 검증 및 화면 고도화 + 조직 카테고리 return값 수정

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/AuthViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/AuthViewController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @since : 2025-12-17 수요일
  */
 @Controller
-@RequestMapping("/view/login")
+@RequestMapping("/login")
 public class AuthViewController {
 
     @GetMapping

--- a/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
@@ -44,13 +44,28 @@ public class CompanyController {
     public ResponseEntity<ResponseDto> checkBusinessNumber(
             @RequestParam String businessNumber
     ) {
-        boolean exists = companyRepository.existsByBusinessNumber(businessNumber);
+        companyService.validateBusinessNumber(businessNumber);
 
         return ResponseEntity.ok(
                 new ResponseDto(
                         HttpStatus.OK,
-                        exists ? "이미 등록된 사업자번호입니다." : "사용 가능한 사업자번호입니다.",
-                        Map.of("available", !exists)
+                        "사용 가능한 사업자번호입니다.",
+                        Map.of("available", true)
+                )
+        );
+    }
+
+    @GetMapping("/check-email")
+    public ResponseEntity<ResponseDto> checkEmail(
+            @RequestParam String email
+    ) {
+        boolean available = companyService.isEmailAvailable(email);
+
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        "이메일 중복 확인 완료",
+                        Map.of("available", available)
                 )
         );
     }

--- a/src/main/java/com/finalproj/orbitflow/hr/company/dto/BsnCheckReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/dto/BsnCheckReqDto.java
@@ -1,0 +1,21 @@
+package com.finalproj.orbitflow.hr.company.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : BSNCheckReqDto
+ * @since : 2025-12-20 토요일
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BsnCheckReqDto {
+    private List<String> b_no;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/dto/BsnCheckResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/dto/BsnCheckResDto.java
@@ -1,0 +1,24 @@
+package com.finalproj.orbitflow.hr.company.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : BsnCheckResDto
+ * @since : 2025-12-20 토요일
+ */
+@Getter
+public class BsnCheckResDto {
+    private List<Data> data;
+
+    @Getter
+    public static class Data {
+        private String b_no;
+        private String b_stt;    // 사업자 상태
+        private String tax_type; // 과세 유형
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/external/BsnClient.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/external/BsnClient.java
@@ -1,0 +1,58 @@
+package com.finalproj.orbitflow.hr.company.external;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : BsnClient
+ * @since : 2025-12-20 토요일
+ */
+@Component
+@RequiredArgsConstructor
+public class BsnClient {
+
+    @Value("${external.business.api-key}")
+    private String apiKey;
+
+    @Value("${external.business.url}")
+    private String url;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String getBusinessStatus(String businessNumber) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of(
+                "b_no", List.of(businessNumber)
+        );
+
+        HttpEntity<Map<String, Object>> request =
+                new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response =
+                restTemplate.postForEntity(
+                        url + "?serviceKey=" + apiKey,
+                        request,
+                        Map.class
+                );
+
+        List<Map<String, Object>> data =
+                (List<Map<String, Object>>) response.getBody().get("data");
+
+        return (String) data.get(0).get("b_stt"); // 계속사업자 / 휴업자 / 폐업자
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -1,7 +1,9 @@
 package com.finalproj.orbitflow.hr.company.service;
 
+import com.finalproj.orbitflow.global.exception.BusinessException;
 import com.finalproj.orbitflow.hr.company.dto.CompanySignupReqDto;
 import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.company.external.BsnClient;
 import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
@@ -10,6 +12,7 @@ import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.organization.entity.Organization;
 import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,12 +34,15 @@ public class CompanyService {
     private final PasswordEncoder passwordEncoder;
     private final OrgRepository orgRepository;
     private final OrgCategoryRepository orgCategoryRepository;
+    private final BsnClient bsnClient;
+
+    @Value("${business.validation.strict}")
+    private boolean strictValidation;
+
 
     public Long signup(CompanySignupReqDto request) {
 
-        if (companyRepository.existsByBusinessNumber(request.getBusinessNumber())) {
-            throw new IllegalArgumentException("이미 등록된 사업자번호입니다.");
-        }
+        validateBusinessNumber(request.getBusinessNumber());
 
         // 회사 생성
         Company company = Company.create(
@@ -101,6 +107,11 @@ public class CompanyService {
                 )
         );
 
+        // 대표 관리자 이메일 중복 체크
+        if (employeeRepository.existsByEmail(request.getAdminEmail())) {
+            throw new BusinessException("이미 사용 중인 이메일입니다.");
+        }
+
         // 대표 관리자 생성
         Employee admin = Employee.createAdmin(
                 company,
@@ -112,5 +123,29 @@ public class CompanyService {
 
         return company.getId();
     }
+
+    public boolean isEmailAvailable(String email) {
+        return !employeeRepository.existsByEmail(email);
+    }
+
+    public void validateBusinessNumber(String businessNumber) {
+
+        // DB 중복 체크 (무조건)
+        if (companyRepository.existsByBusinessNumber(businessNumber)) {
+            throw new BusinessException("이미 등록된 사업자번호입니다.");
+        }
+
+        // 외부 API 상태 조회
+        String status = bsnClient.getBusinessStatus(businessNumber);
+
+        // 운영 모드 → 계속사업자만 허용
+        if (strictValidation && !"계속사업자".equals(status)) {
+            throw new BusinessException("계속사업자만 가입할 수 있습니다.");
+        }
+
+        // 시연 모드(strict=false)는 통과
+    }
+
+
 }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -57,4 +57,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
             @Param("keyword") String keyword
 
     );
+
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
@@ -1,9 +1,9 @@
 package com.finalproj.orbitflow.hr.orgCategory.controller;
 
+import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryCreateReqDto;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryResDto;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryUpdateReqDto;
 import com.finalproj.orbitflow.hr.orgCategory.service.OrgCategoryService;
 import jakarta.validation.Valid;
@@ -12,8 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * Please explain the class!!!
@@ -31,52 +29,71 @@ public class OrgCategoryController {
     private final OrgCategoryService orgCategoryService;
 
     @PostMapping
-    public ResponseEntity<Long> create(
+    public ResponseEntity<ResponseDto> create(
             @RequestBody @Valid OrgCategoryCreateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
 
         Long id = orgCategoryService.create(companyId, request.getName());
-        return ResponseEntity.status(HttpStatus.CREATED).body(id);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseDto(
+                        HttpStatus.CREATED,
+                        "결재 양식 초안이 생성되었습니다.",
+                        id));
+
     }
 
 
     @GetMapping
-    public ResponseEntity<List<OrgCategoryResDto>> list() {
+    public ResponseEntity<ResponseDto> list() {
         Long companyId = SecurityUtils.getCompanyId();
 
-        return ResponseEntity.ok(orgCategoryService.findAll(companyId));
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        "조직 카테고리 목록 조회",
+                        orgCategoryService.findAll(companyId)));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> update(
+    public ResponseEntity<ResponseDto> update(
             @PathVariable Long id,
             @RequestBody @Valid OrgCategoryUpdateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
 
         orgCategoryService.update(companyId, id, request.getName());
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseDto(HttpStatus.OK,
+                        "조직 카테고리가 수정되었습니다.",
+                        null));
     }
 
 
     @PutMapping("/order")
-    public ResponseEntity<Void> updateOrder(
+    public ResponseEntity<ResponseDto> updateOrder(
             @RequestBody @Valid OrgCategoryOrderUpdateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
         orgCategoryService.updateOrder(companyId, request.getOrders());
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseDto(HttpStatus.OK,
+                        "조직 카테고리의 순서가 일괄 수정되었습니다.",
+                        null));
     }
 
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deactivate(
+    public ResponseEntity<ResponseDto> deactivate(
             @PathVariable Long id
     ) {
         Long companyId = SecurityUtils.getCompanyId();
 
         orgCategoryService.deactivate(companyId, id);
-        return ResponseEntity.ok().build();
-    }
+        return ResponseEntity.ok().body(
+                new ResponseDto(HttpStatus.OK, "조직 카테고리를 비활성화 하였습니다.", null)
+        );    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,3 +27,12 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION:3600000}
+
+external:
+  business:
+    api-key: ${BSN_KEY}
+    url: https://api.odcloud.kr/api/nts-businessman/v1/status
+
+business:
+  validation:
+    strict: false   # 시연용 (true = 운영)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,3 +23,12 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION}
+
+external:
+  business:
+    api-key: ${BSN_KEY}
+    url: https://api.odcloud.kr/api/nts-businessman/v1/status
+
+business:
+  validation:
+    strict: false   # 시연용 (true = 운영)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,12 @@ server:
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION:3600000}
+
+external:
+  business:
+    api-key: ${BSN_KEY}
+    url: https://api.odcloud.kr/api/nts-businessman/v1/status
+
+business:
+  validation:
+    strict: false   # 시연용 (true = 운영)

--- a/src/main/resources/static/js/company-signup.js
+++ b/src/main/resources/static/js/company-signup.js
@@ -17,6 +17,7 @@ function updateSignupButtonState() {
         validateAddress() &&
         validateRepresentativeName() &&
         validateEmail() &&
+        emailChecked &&
         validateContact() &&
         businessChecked &&
         validatePasswordLength() &&
@@ -76,9 +77,31 @@ function validateContact() {
 /* ======================
    이메일
 ====================== */
+adminEmail.addEventListener('input', () => {
+    // 한글 제거 (입력/붙여넣기 모두 차단)
+    adminEmail.value = adminEmail.value.replace(/[ㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
+
+    validateEmail();
+    updateSignupButtonState();
+
+    adminEmail.addEventListener('blur', checkEmailDuplicate);
+
+});
+
+
 function validateEmail() {
     const v = adminEmail.value.trim();
-    if (!v) return emailMsg.textContent = '', false;
+
+    if (!v) {
+        emailMsg.textContent = '';
+        return false;
+    }
+
+    // 한글 포함 차단 (최종 방어)
+    if (/[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(v)) {
+        showMsg(emailMsg, '이메일에는 한글을 사용할 수 없습니다.', 'error');
+        return false;
+    }
 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) {
         showMsg(emailMsg, '이메일 형식이 올바르지 않습니다.', 'error');
@@ -158,18 +181,33 @@ businessNumber.addEventListener('input', () => {
 
 async function checkBusinessNumber() {
     const v = businessNumber.value.trim();
-    if (!v) return showMsg(businessMsg, '사업자번호를 입력해주세요.', 'error');
 
-    const res = await fetch(
-        `/api/companies/check-business-number?businessNumber=${encodeURIComponent(v)}`
-    );
-    const json = await res.json();
+    if (!v) {
+        showMsg(businessMsg, '사업자번호를 입력해주세요.', 'error');
+        businessChecked = false;
+        updateSignupButtonState();
+        return;
+    }
 
-    if (json.data.available) {
-        showMsg(businessMsg, '사용 가능한 사업자번호입니다.', 'success');
+    try {
+        const res = await fetch(
+            `/api/companies/check-business-number?businessNumber=${encodeURIComponent(v)}`
+        );
+
+        const json = await res.json();
+
+        if (!res.ok) {
+            showMsg(businessMsg, json.message, 'error');
+            businessChecked = false;
+            return;
+        }
+
+        // 성공 (시연 모드 포함)
+        showMsg(businessMsg, json.message, 'success');
         businessChecked = true;
-    } else {
-        showMsg(businessMsg, '이미 등록된 사업자번호입니다.', 'error');
+
+    } catch (e) {
+        showMsg(businessMsg, '사업자번호 검증 중 오류가 발생했습니다.', 'error');
         businessChecked = false;
     }
     updateSignupButtonState();
@@ -209,4 +247,33 @@ async function submitSignup() {
         alert('회사 가입이 완료되었습니다.');
         location.href = '/login';
     }
+}
+
+/* ======================
+   이메일 중복 체크 (자동)
+====================== */
+
+let emailChecked = false;
+
+async function checkEmailDuplicate() {
+    const v = adminEmail.value.trim();
+    if (!validateEmail()) {
+        emailChecked = false;
+        return;
+    }
+
+    const res = await fetch(
+        `/api/companies/check-email?email=${encodeURIComponent(v)}`
+    );
+    const json = await res.json();
+
+    if (json.data.available) {
+        showMsg(emailMsg, '사용 가능한 이메일입니다.', 'success');
+        emailChecked = true;
+    } else {
+        showMsg(emailMsg, '이미 사용 중인 이메일입니다.', 'error');
+        emailChecked = false;
+    }
+
+    updateSignupButtonState();
 }

--- a/src/main/resources/templates/company/signup.html
+++ b/src/main/resources/templates/company/signup.html
@@ -31,16 +31,18 @@
         .row {
             display: flex;
             gap: 24px;
-            margin-bottom: 24px;
+            margin-bottom: 28px;
         }
 
         .field {
             flex: 1;
+            padding-right: 8px;
+            padding-left: 8px;
         }
 
         label {
             display: block;
-            margin-bottom: 6px;
+            margin-bottom: 8px;
             font-weight: 600;
             color: #374151;
         }
@@ -86,6 +88,7 @@
 
         .btn-check {
             width: 120px;
+            height: 43.2px;
             background: #e5e7eb;
             border: none;
             border-radius: 6px;
@@ -142,7 +145,7 @@
     <div class="row">
         <div class="field">
             <label>대표 관리자 이메일</label>
-            <input id="adminEmail" maxlength="100">
+            <input id="adminEmail" maxlength="100" inputmode="email" autocomplete="email" placeholder="example@company.com">
             <div id="emailMsg" class="hint"></div>
         </div>
         <div class="field">
@@ -173,10 +176,10 @@
             <label>사업자번호</label>
             <div class="business-row">
                 <input
-                id="businessNumber"
-                maxlength="20"
-                inputmode="numeric"
-                pattern="[0-9]*"
+                        id="businessNumber"
+                        maxlength="20"
+                        inputmode="numeric"
+                        pattern="[0-9]*"
                         placeholder="숫자만 입력"
                 />
                 <button type="button" class="btn-check" onclick="checkBusinessNumber()">확인</button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #142

## 📝 작업 내용
- 사업자번호 검증 로직 통합
  - 기존 DB 중복 체크와 외부 API 검증 로직을 CompanyService로 통합
  - Controller에서 Repository 직접 접근하던 구조 제거
- 외부 사업자번호 검증 API 연동
  - 국세청 공공데이터 API를 사용해 사업자번호 실존 여부 및 상태 조회
  - 외부 API 연동 책임을 BusinessNumberClient로 분리
- 시연 환경 / 운영 환경 분기 처리
  - business.validation.strict 설정값을 통해 검증 정책 분기
    - true: 계속사업자만 가입 가능 (운영 환경)
    - false: 폐업/휴업 사업자도 검증 결과 표시 후 가입 허용 (시연 환경)
- 프론트 검증 방식 개선
  - 사업자번호 검증 API를 예외 기반 응답 구조에 맞게 수정
  - 검증 실패 시 서버 메시지를 그대로 사용자에게 노출하도록 UX 개선
- OrgCategoryController의 return값들을 일괄 수정

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
