### PR TITLE
feat(auth, hr): 컨트롤러 return값 수정 + 프론트 코드 수정

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.finalproj.orbitflow.auth.dto.LoginResDto;
 import com.finalproj.orbitflow.auth.dto.MeResDto;
 import com.finalproj.orbitflow.auth.entity.RefreshToken;
 import com.finalproj.orbitflow.auth.service.AuthService;
+import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.exception.ForbiddenException;
 import com.finalproj.orbitflow.global.exception.UnauthorizedException;
 import com.finalproj.orbitflow.global.security.CustomUserDetailsService;
@@ -12,6 +13,8 @@ import com.finalproj.orbitflow.global.security.SecurityUser;
 import com.finalproj.orbitflow.global.security.jwt.JwtProvider;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -40,7 +43,7 @@ public class AuthController {
      * 로그인
      */
     @PostMapping("/login")
-    public LoginResDto login(@RequestBody LoginReqDto request) {
+    public ResponseEntity<ResponseDto> login(@RequestBody LoginReqDto request) {
 
         SecurityUser user;
         try {
@@ -64,10 +67,18 @@ public class AuthController {
         String accessToken = jwtProvider.createToken(user);
         RefreshToken refreshToken = authService.issueRefreshToken(user);
 
-        return new LoginResDto(
+        LoginResDto res = new LoginResDto(
                 accessToken,
                 refreshToken.getToken(),
                 refreshToken.getExpiresAt()
+        );
+
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        "로그인 성공",
+                        res
+                )
         );
     }
 
@@ -75,8 +86,9 @@ public class AuthController {
      * Access Token 재발급 (Refresh 만료 연장 X)
      */
     @PostMapping("/refresh")
-    public LoginResDto refresh(@RequestHeader("Refresh-Token") String token) {
-
+    public ResponseEntity<ResponseDto> refresh(
+            @RequestHeader("Refresh-Token") String token
+    ) {
         RefreshToken refreshToken = authService.validateRefreshToken(token);
 
         SecurityUser user =
@@ -86,12 +98,14 @@ public class AuthController {
             throw new ForbiddenException("로그인할 수 없는 계정 상태입니다.");
         }
 
-        String newAccessToken = jwtProvider.createToken(user);
-
-        return new LoginResDto(
-                newAccessToken,
+        LoginResDto res = new LoginResDto(
+                jwtProvider.createToken(user),
                 null,
                 refreshToken.getExpiresAt()
+        );
+
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "Access Token 재발급 성공", res)
         );
     }
 
@@ -101,8 +115,9 @@ public class AuthController {
      * - 만료 20시간 재설정
      */
     @PostMapping("/extend-session")
-    public LoginResDto extendSession(@RequestHeader("Refresh-Token") String token) {
-
+    public ResponseEntity<ResponseDto> extendSession(
+            @RequestHeader("Refresh-Token") String token
+    ) {
         RefreshToken oldToken = authService.validateRefreshToken(token);
 
         SecurityUser user =
@@ -118,12 +133,18 @@ public class AuthController {
         // 새 Refresh Token 발급 (20시간)
         RefreshToken newRefreshToken = authService.issueRefreshToken(user);
 
-        String newAccessToken = jwtProvider.createToken(user);
-
-        return new LoginResDto(
-                newAccessToken,
+        LoginResDto res = new LoginResDto(
+                jwtProvider.createToken(user),
                 newRefreshToken.getToken(),
                 newRefreshToken.getExpiresAt()
+        );
+
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        "세션 연장 완료",
+                        res
+                )
         );
     }
 
@@ -131,26 +152,38 @@ public class AuthController {
      * 로그아웃
      */
     @PostMapping("/logout")
-    public void logout(@RequestHeader(value = "Refresh-Token", required = false) String token) {
+    public ResponseEntity<ResponseDto> logout(
+            @RequestHeader(value = "Refresh-Token", required = false) String token
+    ) {
         if (token != null) {
             authService.invalidateRefreshToken(token);
         }
+
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "로그아웃 완료", null)
+        );
     }
 
     /**
      * 내 정보 조회
      */
     @GetMapping("/me")
-    public MeResDto me(@AuthenticationPrincipal SecurityUser user) {
+    public ResponseEntity<ResponseDto> me(
+            @AuthenticationPrincipal SecurityUser user
+    ) {
         if (user == null) {
             throw new UnauthorizedException("인증 정보가 없습니다.");
         }
 
-        return new MeResDto(
+        MeResDto res = new MeResDto(
                 user.getEmployeeId(),
                 user.getName(),
                 user.getEmail(),
                 user.getRole().name()
+        );
+
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "내 정보 조회 성공", res)
         );
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/controller/CompanyController.java
@@ -35,7 +35,7 @@ public class CompanyController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ResponseDto(
                         HttpStatus.CREATED,
-                        "회사 가입이 완료되었습니다.",
+                        "회사 가입 완료",
                         Map.of("companyId", companyId)
                 ));
     }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
@@ -39,7 +39,7 @@ public class OrgCategoryController {
                 .status(HttpStatus.CREATED)
                 .body(new ResponseDto(
                         HttpStatus.CREATED,
-                        "결재 양식 초안이 생성되었습니다.",
+                        "조직 카테고리 생성 완료",
                         id));
 
     }
@@ -52,7 +52,7 @@ public class OrgCategoryController {
         return ResponseEntity.ok(
                 new ResponseDto(
                         HttpStatus.OK,
-                        "조직 카테고리 목록 조회",
+                        "조직 카테고리 목록 조회 완료",
                         orgCategoryService.findAll(companyId)));
     }
 
@@ -67,7 +67,7 @@ public class OrgCategoryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseDto(HttpStatus.OK,
-                        "조직 카테고리가 수정되었습니다.",
+                        "조직 카테고리 수정 완료",
                         null));
     }
 
@@ -81,7 +81,7 @@ public class OrgCategoryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseDto(HttpStatus.OK,
-                        "조직 카테고리의 순서가 일괄 수정되었습니다.",
+                        "조직 카테고리 순서 수정 완료",
                         null));
     }
 
@@ -94,6 +94,6 @@ public class OrgCategoryController {
 
         orgCategoryService.deactivate(companyId, id);
         return ResponseEntity.ok().body(
-                new ResponseDto(HttpStatus.OK, "조직 카테고리를 비활성화 하였습니다.", null)
+                new ResponseDto(HttpStatus.OK, "조직 카테고리 비활성화 완료", null)
         );    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
@@ -1,9 +1,9 @@
 package com.finalproj.orbitflow.hr.organization.controller;
 
+import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.organization.dto.OrgCreateReqDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgResDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgUpdateReqDto;
 import com.finalproj.orbitflow.hr.organization.service.OrgService;
 import jakarta.validation.Valid;
@@ -12,8 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * 조직 관리 컨트롤러 (관리자 전용)
@@ -31,43 +29,61 @@ public class OrgController {
     private final OrgService orgService;
 
     @PostMapping
-    public ResponseEntity<Long> create(
+    public ResponseEntity<ResponseDto> create(
             @RequestBody @Valid OrgCreateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
         Long id = orgService.create(companyId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(id);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseDto(
+                        HttpStatus.CREATED,
+                        "조직 생성 완료.",
+                        id
+                ));
     }
 
     @GetMapping
-    public ResponseEntity<List<OrgResDto>> list() {
+    public ResponseEntity<ResponseDto> list() {
         Long companyId = SecurityUtils.getCompanyId();
-        return ResponseEntity.ok(orgService.findAll(companyId));
+
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.OK,
+                        "조직 목록 조회",
+                        orgService.findAll(companyId)
+                )
+        );
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> update(
+    public ResponseEntity<ResponseDto> update(
             @PathVariable Long id,
             @RequestBody @Valid OrgUpdateReqDto request
     ) {
-        Long companyId = SecurityUtils.getCompanyId();
-        orgService.update(companyId, id, request);
-        return ResponseEntity.ok().build();
+        orgService.update(SecurityUtils.getCompanyId(), id, request);
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "조직 수정 완료", null)
+        );
     }
 
     @PutMapping("/order")
-    public ResponseEntity<Void> updateOrder(
+    public ResponseEntity<ResponseDto> updateOrder(
             @RequestBody @Valid OrgOrderUpdateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
         orgService.updateOrder(companyId, request.getOrders());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "조직 순서 수정 완료", null)
+        );
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deactivate(@PathVariable Long id) {
+    public ResponseEntity<ResponseDto> deactivate(@PathVariable Long id) {
         Long companyId = SecurityUtils.getCompanyId();
         orgService.deactivate(companyId, id);
-        return ResponseEntity.ok().build();
-    }
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "조직 비활성화 완료", null)
+        );    }
 }

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -20,20 +20,18 @@ async function apiFetch(url, options = {}) {
     let res = await fetch(url, options);
 
     if (res.status !== 401) {
-        return res;
+        const result = await res.json();
+        if (!res.ok) throw new Error(result.message);
+        return result.data;
     }
 
-    // 이미 refresh 중이면 대기
+    // refresh 로직
     if (isRefreshing) {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
             refreshSubscribers.push(async () => {
                 options.headers.Authorization =
                     `Bearer ${sessionStorage.getItem('accessToken')}`;
-                try {
-                    resolve(await fetch(url, options));
-                } catch (e) {
-                    reject(e);
-                }
+                resolve(await apiFetch(url, options));
             });
         });
     }
@@ -43,19 +41,14 @@ async function apiFetch(url, options = {}) {
     isRefreshing = false;
 
     if (!refreshed) {
-        refreshSubscribers = []; // 대기 큐 정리
         handleSessionExpired();
         throw new Error('SESSION_EXPIRED');
     }
 
-    // 대기 중이던 요청 재개
     refreshSubscribers.forEach(cb => cb());
     refreshSubscribers = [];
 
-    options.headers.Authorization =
-        `Bearer ${sessionStorage.getItem('accessToken')}`;
-
-    return fetch(url, options);
+    return apiFetch(url, options);
 }
 
 /** Refresh 호출 함수 */
@@ -65,17 +58,15 @@ async function refreshAccessToken() {
 
     const res = await fetch('/api/auth/refresh', {
         method: 'POST',
-        headers: {
-            'Refresh-Token': refreshToken
-        }
+        headers: { 'Refresh-Token': refreshToken }
     });
 
     if (!res.ok) return false;
 
-    const data = await res.json();
-    sessionStorage.setItem('accessToken', data.accessToken);
-    sessionStorage.setItem('refreshToken', data.refreshToken);
+    const result = await res.json();
+    const data = result.data;
 
+    sessionStorage.setItem('accessToken', data.accessToken);
     return true;
 }
 
@@ -109,14 +100,7 @@ async function logout() {
 /** 헤더 사용자 정보 표시 */
 async function loadMe() {
     try {
-        const res = await apiFetch('/api/auth/me');
-
-        if (!res.ok) {
-            location.href = '/login';
-            return;
-        }
-
-        const me = await res.json();
+        const me = await apiFetch('/api/auth/me');
 
         const userNameEl = document.getElementById('userName');
         if (userNameEl) {

--- a/src/main/resources/static/js/company-signup.js
+++ b/src/main/resources/static/js/company-signup.js
@@ -243,10 +243,15 @@ async function submitSignup() {
         body: JSON.stringify(body)
     });
 
-    if (res.ok) {
-        alert('회사 가입이 완료되었습니다.');
-        location.href = '/login';
+    const result = await res.json();
+
+    if (!res.ok) {
+        alert(result.message);
+        return;
     }
+
+    alert(result.message);
+    location.href = '/login';
 }
 
 /* ======================

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -2,22 +2,137 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <title>로그인 | Orbit Flow</title>
+  <title>로그인 | OrbitFlow</title>
+
+  <!-- Font -->
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap">
+
+  <style>
+    * {
+      box-sizing: border-box;
+      font-family: 'Noto Sans KR', sans-serif;
+    }
+
+    body {
+      margin: 0;
+      background: #f6f8fb;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .login-card {
+      width: 420px;
+      background: #fff;
+      border-radius: 16px;
+      padding: 48px 40px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+    }
+
+    .login-title {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    .login-title h1 {
+      margin: 0;
+      font-size: 26px;
+      font-weight: 700;
+      color: #111;
+    }
+
+    .login-title p {
+      margin-top: 8px;
+      font-size: 14px;
+      color: #666;
+    }
+
+    .form-group {
+      margin-bottom: 20px;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #333;
+    }
+
+    input {
+      width: 100%;
+      height: 44px;
+      padding: 0 14px;
+      border-radius: 8px;
+      border: 1px solid #d1d5db;
+      font-size: 14px;
+      outline: none;
+    }
+
+    input:focus {
+      border-color: #4f7cff;
+      box-shadow: 0 0 0 3px rgba(79,124,255,0.15);
+    }
+
+    .error-msg {
+      margin-top: 6px;
+      font-size: 13px;
+      color: #ef4444;
+      display: none;
+    }
+
+    .login-btn {
+      width: 100%;
+      height: 48px;
+      border-radius: 10px;
+      border: none;
+      background: #4f7cff;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 12px;
+    }
+
+    .login-btn:hover {
+      background: #3f6bf2;
+    }
+  </style>
 </head>
 <body>
 
-<h2>로그인</h2>
+<div class="login-card">
+  <div class="login-title">
+    <h1>OrbitFlow</h1>
+    <p>로그인 정보를 입력하세요.</p>
+  </div>
 
-<input id="email" placeholder="이메일">
-<input id="password" type="password" placeholder="비밀번호">
+  <div class="form-group">
+    <label for="email">이메일</label>
+    <input id="email" type="email" placeholder="example@company.com">
+  </div>
 
-<button onclick="login()">로그인</button>
+  <div class="form-group">
+    <label for="password">비밀번호</label>
+    <input id="password" type="password" placeholder="비밀번호를 입력하세요">
+    <div id="loginError" class="error-msg">
+      아이디 또는 비밀번호가 올바르지 않습니다.
+    </div>
+  </div>
+
+  <button class="login-btn" onclick="login()">로그인</button>
+</div>
 
 <script>
   async function login() {
+    const errorEl = document.getElementById('loginError');
+    errorEl.style.display = 'none';
+
     const res = await fetch('/api/auth/login', {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         email: email.value,
         password: password.value
@@ -26,30 +141,35 @@
 
     const result = await res.json();
 
-    if (res.ok) {
-      sessionStorage.setItem('accessToken', result.accessToken);
-      sessionStorage.setItem('refreshToken', result.refreshToken);
-      
-      // 사용자 역할 확인하여 리다이렉트
-      const meRes = await fetch('/api/auth/me', {
-        headers: {
-          'Authorization': `Bearer ${result.accessToken}`
-        }
-      });
-      
-      if (meRes.ok) {
-        const me = await meRes.json();
-        // 관리자(ADMIN, COMPANY_ADMIN)는 관리자 메인으로, 일반 사용자는 메인으로
-        if (me.role === 'ADMIN' || me.role === 'COMPANY_ADMIN') {
-          location.href = '/view/admin';
-        } else {
-          location.href = '/';
-        }
-      } else {
-        location.href = '/';
+    if (!res.ok) {
+      errorEl.textContent = result.message;
+      errorEl.style.display = 'block';
+      return;
+    }
+
+    const data = result.data;
+
+    sessionStorage.setItem('accessToken', data.accessToken);
+    sessionStorage.setItem('refreshToken', data.refreshToken);
+
+    const meRes = await fetch('/api/auth/me', {
+      headers: {
+        'Authorization': `Bearer ${data.accessToken}`
       }
+    });
+
+    if (!meRes.ok) {
+      location.href = '/';
+      return;
+    }
+
+    const meResult = await meRes.json();
+    const me = meResult.data;
+
+    if (me.role === 'ADMIN' || me.role === 'COMPANY_ADMIN') {
+      location.href = '/view/admin';
     } else {
-      alert(result.message);
+      location.href = '/';
     }
   }
 </script>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #145

## 📝 작업 내용
- Auth / HR / Admin API 응답 컨벤션 통일
  - 모든 인증·관리자 API 응답을 ResponseEntity<ResponseDto> 구조로 통합
  - 프론트엔드에서 status / message / data 기반으로 일관된 파싱 가능하도록 정리
- 프론트 인증 로직 ResponseDto 대응
  - 로그인, 내 정보 조회, 토큰 재발급 로직에서 result.data 기준으로 파싱하도록 수정
  - 공통 apiFetch 유틸 개선으로 인증 실패/세션 만료 처리 일원화
- 로그인 화면 UX 개선
  - alert 기반 에러 처리 제거 → 입력 필드 하단 에러 메시지 방식으로 개선
  - 관리자/일반 사용자 역할에 따른 로그인 후 분기 처리 유지
  - 디자인을 SaaS 스타일 카드형 로그인 화면으로 개선

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
