### PR TITLE
feat(company, org): 회사 가입 + 조직 CRUD 검증 로직 고도화

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -54,7 +54,12 @@ CREATE TABLE organization
     CONSTRAINT fk_org_category
         FOREIGN KEY (category_id) REFERENCES org_category (id),
     CONSTRAINT fk_org_parent
-        FOREIGN KEY (parent_org_id) REFERENCES organization (id)
+        FOREIGN KEY (parent_org_id) REFERENCES organization (id),
+
+    CONSTRAINT uk_org_sibling_order -- 형제 단위 정렬 충돌 방지
+        UNIQUE (company_id, parent_org_id, order_index),
+    CONSTRAINT uk_org_sibling_name -- 형제 단위 이름 중복 방지
+        UNIQUE (company_id, parent_org_id, name)
 ) ENGINE = InnoDB;
 
 CREATE TABLE hr_rank

--- a/src/main/java/com/finalproj/orbitflow/hr/company/external/BsnClient.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/external/BsnClient.java
@@ -50,9 +50,26 @@ public class BsnClient {
                         Map.class
                 );
 
-        List<Map<String, Object>> data =
-                (List<Map<String, Object>>) response.getBody().get("data");
+        // HTTP 상태 체크
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new RuntimeException("사업자 API 호출 실패");
+        }
 
-        return (String) data.get(0).get("b_stt"); // 계속사업자 / 휴업자 / 폐업자
+        // body / data 체크
+        if (response.getBody() == null || response.getBody().get("data") == null) {
+            throw new RuntimeException("사업자 API 응답 오류");
+        }
+
+        Object rawData = response.getBody().get("data");
+        if (!(rawData instanceof List<?> data) || data.isEmpty()) {
+            throw new RuntimeException("사업자 API data 형식 오류");
+        }
+
+        Object first = data.get(0);
+        if (!(first instanceof Map<?, ?> item) || item.get("b_stt") == null) {
+            throw new RuntimeException("사업자 상태 조회 실패");
+        }
+
+        return item.get("b_stt").toString(); // 계속사업자 / 휴업자 / 폐업자
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -43,6 +43,10 @@ public class CompanyService {
     public Long signup(CompanySignupReqDto request) {
 
         validateBusinessNumber(request.getBusinessNumber());
+        // 대표 관리자 이메일 중복 체크
+        if (employeeRepository.existsByEmail(request.getAdminEmail())) {
+            throw new BusinessException("이미 사용 중인 이메일입니다.");
+        }
 
         // 회사 생성
         Company company = Company.create(
@@ -107,11 +111,6 @@ public class CompanyService {
                 )
         );
 
-        // 대표 관리자 이메일 중복 체크
-        if (employeeRepository.existsByEmail(request.getAdminEmail())) {
-            throw new BusinessException("이미 사용 중인 이메일입니다.");
-        }
-
         // 대표 관리자 생성
         Employee admin = Employee.createAdmin(
                 company,
@@ -136,14 +135,26 @@ public class CompanyService {
         }
 
         // 외부 API 상태 조회
-        String status = bsnClient.getBusinessStatus(businessNumber);
-
-        // 운영 모드 → 계속사업자만 허용
-        if (strictValidation && !"계속사업자".equals(status)) {
-            throw new BusinessException("계속사업자만 가입할 수 있습니다.");
+        String status;
+        try {
+            status = bsnClient.getBusinessStatus(businessNumber);
+        } catch (Exception e) {
+            throw new BusinessException("사업자번호 외부 검증에 실패했습니다.");
         }
 
-        // 시연 모드(strict=false)는 통과
+        // strict 정책 분기
+        if (strictValidation) { // 운영
+            if (!"계속사업자".equals(status)) {
+                throw new BusinessException("계속사업자만 가입할 수 있습니다.");
+            }
+        } else { // 개발/시연
+            if (!"계속사업자".equals(status)
+                    && !"휴업자".equals(status)
+                    && !"폐업자".equals(status)
+            ) {
+                throw new BusinessException("유효하지 않은 사업자번호입니다.");
+            }
+        }
     }
 
 

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
@@ -4,6 +4,7 @@ import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.organization.dto.OrgCreateReqDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgOrderUpdateReqDto;
+import com.finalproj.orbitflow.hr.organization.dto.OrgResDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgUpdateReqDto;
 import com.finalproj.orbitflow.hr.organization.service.OrgService;
 import jakarta.validation.Valid;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 조직 관리 컨트롤러 (관리자 전용)
@@ -37,15 +40,15 @@ public class OrgController {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(new ResponseDto(
+                .body(new ResponseDto<>(
                         HttpStatus.CREATED,
-                        "조직 생성 완료.",
+                        "조직 생성 완료",
                         id
                 ));
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDto> list() {
+    public ResponseEntity<ResponseDto<List<OrgResDto>>> list() {
         Long companyId = SecurityUtils.getCompanyId();
 
         return ResponseEntity.ok(
@@ -58,7 +61,7 @@ public class OrgController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ResponseDto> update(
+    public ResponseEntity<ResponseDto<Void>> update(
             @PathVariable Long id,
             @RequestBody @Valid OrgUpdateReqDto request
     ) {
@@ -69,7 +72,7 @@ public class OrgController {
     }
 
     @PutMapping("/order")
-    public ResponseEntity<ResponseDto> updateOrder(
+    public ResponseEntity<ResponseDto<Void>> updateOrder(
             @RequestBody @Valid OrgOrderUpdateReqDto request
     ) {
         Long companyId = SecurityUtils.getCompanyId();
@@ -80,10 +83,10 @@ public class OrgController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ResponseDto> deactivate(@PathVariable Long id) {
+    public ResponseEntity<ResponseDto<Void>> deactivate(@PathVariable Long id) {
         Long companyId = SecurityUtils.getCompanyId();
         orgService.deactivate(companyId, id);
         return ResponseEntity.ok(
-                new ResponseDto(HttpStatus.OK, "조직 비활성화 완료", null)
-        );    }
+        new ResponseDto<>(HttpStatus.OK, "조직 비활성화 완료", null));
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgCreateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgCreateReqDto.java
@@ -2,6 +2,7 @@ package com.finalproj.orbitflow.hr.organization.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 /**
@@ -20,6 +21,7 @@ public class OrgCreateReqDto {
     private Long parentOrgId;
 
     @NotBlank
+    @Size(max = 100)
     private String name;
 
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgUpdateReqDto.java
@@ -2,6 +2,7 @@ package com.finalproj.orbitflow.hr.organization.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 /**
@@ -20,6 +21,7 @@ public class OrgUpdateReqDto {
     private Long parentOrgId;
 
     @NotBlank
+    @Size(max = 100)
     private String name;
 
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrgRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrgRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface OrgRepository extends JpaRepository<Organization, Long> {
 
     /**
-     * 회사별 전체 조직 조회 (트리 구성용)
+     * 회사별 전체 조직 조회 (트리 구성용) - 활성만
      */
     List<Organization> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
 
@@ -28,8 +28,27 @@ public interface OrgRepository extends JpaRepository<Organization, Long> {
     );
 
     /**
-     * 해당 카테고리를 사용하는 활성 조직 존재 여부
+     * 해당 카테고리를 사용하는 활성 조직 존재 여부 (OrgCategory 비활성 정책용)
      */
     boolean existsByCompanyIdAndCategoryIdAndIsActiveTrue(Long companyId, Long categoryId);
 
+    /**
+     * 하위 조직 존재 여부(활성)
+     */
+    boolean existsByCompanyIdAndParentOrgIdAndIsActiveTrue(Long companyId, Long parentOrgId);
+
+    /**
+     * 형제 단위 이름 중복(생성)
+     */
+    boolean existsByCompanyIdAndParentOrgIdAndNameAndIsActiveTrue(Long companyId, Long parentOrgId, String name);
+
+    /**
+     *  형제 단위 이름 중복(수정 - 자기 자신 제외)
+    */
+    boolean existsByCompanyIdAndParentOrgIdAndNameAndIsActiveTrueAndIdNot(
+            Long companyId,
+            Long parentOrgId,
+            String name,
+            Long id
+    );
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -6,6 +6,7 @@ import com.finalproj.orbitflow.global.exception.InvalidStateException;
 import com.finalproj.orbitflow.global.exception.NotFoundException;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.organization.dto.OrgCreateReqDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgOrderUpdateReqDto;
 import com.finalproj.orbitflow.hr.organization.dto.OrgResDto;
@@ -33,27 +34,33 @@ public class OrgService {
 
     private final OrgRepository orgRepository;
     private final EmployeeRepository employeeRepository;
+    private final OrgCategoryRepository orgCategoryRepository;
 
     /* ================= 생성 ================= */
     public Long create(Long companyId, OrgCreateReqDto request) {
 
-        long count =
-                orgRepository
-                        .countByCompanyIdAndParentOrgIdAndIsActiveTrue(
-                                companyId,
-                                request.getParentOrgId()
-                        );
+        Long parentOrgId = request.getParentOrgId();
+        Long categoryId = request.getCategoryId();
+        String name = normalizeNameOrThrow(request.getName());
 
-        int nextOrderIndex = (int) count + 1;
+        // 카테고리 검증(존재 + 같은 회사 + 활성)
+        validateCategoryActiveInCompany(companyId, categoryId);
 
-        Organization org = Organization.create(
-                companyId,
-                request.getCategoryId(),
-                request.getParentOrgId(),
-                request.getName(),
-                nextOrderIndex
-        );
+        // 상위 조직 검증(있다면 존재 + 같은 회사 + 활성)
+        if (parentOrgId != null) {
+            Organization parent = getActiveOrgInCompanyOrThrow(companyId, parentOrgId);
+            // parent 변수는 검증용 (미사용이어도 OK)
+        }
 
+        // 형제 단위 이름 중복(활성 기준)
+        if (orgRepository.existsByCompanyIdAndParentOrgIdAndNameAndIsActiveTrue(companyId, parentOrgId, name)) {
+            throw new InvalidStateException("이미 존재하는 조직명입니다.");
+        }
+
+        // 다음 orderIndex (형제 단위)
+        int nextOrderIndex = (int) orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, parentOrgId) + 1;
+
+        Organization org = Organization.create(companyId, categoryId, parentOrgId, name, nextOrderIndex);
         return orgRepository.save(org).getId();
     }
 
@@ -69,43 +76,65 @@ public class OrgService {
     }
 
     /* ================= 수정 ================= */
-    public void update(
-            Long companyId,
-            Long organizationId,
-            OrgUpdateReqDto request
-    ) {
+    public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
 
-        Organization org = orgRepository
-                .findByCompanyIdAndId(companyId, organizationId)
-                .orElseThrow(() ->
-                        new NotFoundException("조직을 찾을 수 없습니다.")
-                );
+        Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
 
-        org.update(
-                request.getCategoryId(),
-                request.getParentOrgId(),
-                request.getName()
-        );
+        Long newParentId = request.getParentOrgId();
+        Long newCategoryId = request.getCategoryId();
+        String newName = normalizeNameOrThrow(request.getName());
+
+        // 카테고리 검증
+        validateCategoryActiveInCompany(companyId, newCategoryId);
+
+        // 자기 자신을 상위로 금지
+        if (newParentId != null && Objects.equals(newParentId, organizationId)) {
+            throw new InvalidRequestException("자기 자신을 상위 조직으로 지정할 수 없습니다.");
+        }
+
+        // 상위 조직 검증(존재/회사/활성)
+        if (newParentId != null) {
+            getActiveOrgInCompanyOrThrow(companyId, newParentId);
+        }
+
+        // 순환 참조 방지: newParent의 조상 중에 organizationId가 있으면 금지
+        if (newParentId != null && isCycle(companyId, organizationId, newParentId)) {
+            throw new InvalidStateException("조직 트리에 순환 구조가 발생할 수 있어 상위 조직을 변경할 수 없습니다.");
+        }
+
+        // 형제 단위 이름 중복 (수정: 자기 자신 제외)
+        if (orgRepository.existsByCompanyIdAndParentOrgIdAndNameAndIsActiveTrueAndIdNot(
+                companyId, newParentId, newName, organizationId)) {
+            throw new InvalidStateException("이미 존재하는 조직명입니다.");
+        }
+
+        // 부모가 바뀌면: 새 부모의 마지막 순번으로 이동
+        boolean parentChanged = !Objects.equals(org.getParentOrgId(), newParentId);
+        if (parentChanged) {
+            int nextOrderIndex = (int) orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, newParentId) + 1;
+            org.updateOrderIndex(nextOrderIndex);
+        }
+
+        org.update(newCategoryId, newParentId, newName);
     }
 
     /* ================= 비활성화 ================= */
     public void deactivate(Long companyId, Long organizationId) {
 
-        Organization org = orgRepository
-                .findByCompanyIdAndId(companyId, organizationId)
-                .orElseThrow(() ->
-                        new NotFoundException("조직을 찾을 수 없습니다.")
-                );
+        Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
 
-        // 조직에 재직/정지/임시 계정이 남아 있으면 비활성화 불가
+        // 하위 조직 존재하면 비활성화 불가(트리 무결성)
+        if (orgRepository.existsByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, organizationId)) {
+            throw new InvalidStateException("하위 조직이 존재하여 비활성화할 수 없습니다.");
+        }
+
+        // 기존 정책: 조직에 재직/정지/임시 계정이 남아 있으면 비활성화 불가
         if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
                 companyId,
                 organizationId,
                 EmployeeStatus.RESIGNED
         )) {
-            throw new InvalidStateException(
-                    "해당 조직에 소속된 재직 중인 사원이 존재하여 비활성화할 수 없습니다."
-            );
+            throw new InvalidStateException("해당 조직에 소속된 재직 중인 사원이 존재하여 비활성화할 수 없습니다.");
         }
 
         org.deactivate();
@@ -114,52 +143,49 @@ public class OrgService {
 
 
     /* ================= 정렬 ================= */
-    public void updateOrder(
-            Long companyId,
-            List<OrgOrderUpdateReqDto.OrderItem> orders
-    ) {
-        // 기본 검증
+    public void updateOrder(Long companyId, List<OrgOrderUpdateReqDto.OrderItem> orders) {
+
         if (orders == null || orders.isEmpty()) {
             throw new InvalidRequestException("순서 정보가 비어 있습니다.");
         }
 
-        // 같은 parentOrgId인지 검증
+        // 중복 ID 방지
+        long distinctCount = orders.stream()
+                .map(OrgOrderUpdateReqDto.OrderItem::getId)
+                .distinct()
+                .count();
+
+        if (distinctCount != orders.size()) {
+            throw new InvalidRequestException("중복된 조직 ID가 존재합니다.");
+        }
+
+        // 같은 parentOrgId인지 검증 + 활성 검증
         Long parentOrgId = null;
 
         for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = orgRepository
-                    .findByCompanyIdAndId(companyId, item.getId())
-                    .orElseThrow(() ->
-                            new ForbiddenException("해당 회사의 조직이 아닙니다.")
-                    );
+            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
+
+            if (!Boolean.TRUE.equals(org.getIsActive())) {
+                throw new InvalidStateException("비활성 조직은 정렬 대상이 될 수 없습니다.");
+            }
 
             if (parentOrgId == null) {
                 parentOrgId = org.getParentOrgId();
             } else if (!Objects.equals(parentOrgId, org.getParentOrgId())) {
-                throw new InvalidStateException(
-                        "서로 다른 상위 조직의 조직은 함께 정렬할 수 없습니다."
-                );
+                throw new InvalidStateException("서로 다른 상위 조직의 조직은 함께 정렬할 수 없습니다.");
             }
         }
 
-        // 정렬 대상 개수 검증
-        long activeCount =
-                orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(
-                        companyId, parentOrgId
-                );
-
+        // 정렬 대상 개수 검증(형제 단위)
+        long activeCount = orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, parentOrgId);
         if (activeCount != orders.size()) {
             throw new InvalidStateException("정렬 대상 개수가 일치하지 않습니다.");
         }
 
-        // 임시 orderIndex 할당
+        // 임시 orderIndex 할당 (충돌 방지)
         int tempIndex = -1;
         for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = orgRepository
-                    .findByCompanyIdAndId(companyId, item.getId())
-                    .orElseThrow(() ->
-                            new ForbiddenException("해당 회사의 조직이 아닙니다.")
-                    );
+            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
             org.updateOrderIndex(tempIndex--);
         }
 
@@ -168,13 +194,55 @@ public class OrgService {
         // 최종 orderIndex 재할당
         int orderIndex = 1;
         for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = orgRepository
-                    .findByCompanyIdAndId(companyId, item.getId())
-                    .orElseThrow(() ->
-                            new ForbiddenException("해당 회사의 조직이 아닙니다.")
-                    );
+            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
             org.updateOrderIndex(orderIndex++);
         }
     }
 
+    private Organization getOrgInCompanyOrThrow(Long companyId, Long orgId) {
+        return orgRepository.findByCompanyIdAndId(companyId, orgId)
+                .orElseThrow(() -> new NotFoundException("조직을 찾을 수 없습니다."));
+    }
+
+    private Organization getActiveOrgInCompanyOrThrow(Long companyId, Long orgId) {
+        Organization org = getOrgInCompanyOrThrow(companyId, orgId);
+        if (!Boolean.TRUE.equals(org.getIsActive())) {
+            throw new InvalidStateException("비활성 조직은 상위 조직으로 지정할 수 없습니다.");
+        }
+        return org;
+    }
+
+    private boolean isCycle(Long companyId, Long targetOrgId, Long newParentId) {
+        Long cursor = newParentId;
+        while (cursor != null) {
+            if (Objects.equals(cursor, targetOrgId)) {
+                return true;
+            }
+            Organization parent = getOrgInCompanyOrThrow(companyId, cursor);
+            cursor = parent.getParentOrgId();
+        }
+        return false;
+    }
+
+    private void validateCategoryActiveInCompany(Long companyId, Long categoryId) {
+        // OrgCategory 엔티티 구조가 companyId를 갖고 있으니 이 방식으로 검증 가능
+        com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory category =
+                orgCategoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new NotFoundException("조직 카테고리를 찾을 수 없습니다."));
+
+        if (!Objects.equals(category.getCompanyId(), companyId)) {
+            throw new ForbiddenException("해당 회사의 조직 카테고리가 아닙니다.");
+        }
+        if (!Boolean.TRUE.equals(category.getIsActive())) {
+            throw new InvalidStateException("비활성 조직 카테고리는 사용할 수 없습니다.");
+        }
+    }
+
+    private String normalizeNameOrThrow(String raw) {
+        if (raw == null) throw new InvalidRequestException("조직명은 필수입니다.");
+        String name = raw.trim();
+        if (name.isBlank()) throw new InvalidRequestException("조직명은 필수입니다.");
+        if (name.length() > 100) throw new InvalidRequestException("조직명은 100자 이하여야 합니다.");
+        return name;
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #161

## 📝 작업 내용
### 회사 가입 (Company)
- 회사 가입 API 구현 및 Postman 테스트 완료
- 대표 관리자 계정 생성 로직 구현
- 회사 가입 시 기본 데이터 자동 생성
  - 조직 카테고리(회사/본부/부서/팀)
  - 기본 조직 트리(회사 → 본부 → 부서 → 팀)

### 사업자번호 검증
- 사업자번호 검증 로직 개선
  - DB 중복 여부 우선 검증
  - 외부 사업자 API 연동
- 환경별 검증 정책 분리
  - 개발/시연 모드(`strict=false`)
    - 계속사업자 / 휴업자 / 폐업자 허용
  - 운영 모드(`strict=true`)
    - 계속사업자만 허용
- 외부 API 응답 이상/실패 시 예외 처리 강화

### 이메일 중복 검증
- 대표 관리자 이메일 중복 검증 API 구현
- 이메일 `available` 값의 의미를 “사용 가능 여부”로 명확화
- 회사 가입 시 이메일 중복 검증을 선행 처리하도록 개선


## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb1c207f-acea-4a5e-b185-c4a2fd49e128" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1582ae2f-468b-454c-8306-c6ef76d6477b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0f42455f-801b-4442-8a1b-8d7b77dcecf6" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ee14f11-1c0d-46c5-acf5-293e2e21b6e4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6cf3c10a-8960-456b-a492-93c1141b8fb2" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0978feb6-f43a-46e5-b7c4-4d7aee595395" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/aaad6173-364d-4c81-84c8-698e1f5704b7" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/47e9a930-d05d-41e0-ae08-c09a1771dc0e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b2098fbc-0811-4c15-848d-7a1e555e1c2a" />



## 💬 리뷰 요구사항(선택)
