### PR TITLE
feat(positionCategory): 직책 카테고리 CRUD 구현

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -58,7 +58,7 @@ CREATE TABLE organization
 
     CONSTRAINT uk_org_sibling_order -- 형제 단위 정렬 충돌 방지
         UNIQUE (company_id, parent_org_id, order_index),
-    CONSTRAINT uk_org_sibling_name -- 형제 단위 이름 중복 방지
+    CONSTRAINT uk_org_sibling_name  -- 형제 단위 이름 중복 방지
         UNIQUE (company_id, parent_org_id, name)
 ) ENGINE = InnoDB;
 
@@ -82,14 +82,29 @@ CREATE TABLE hr_rank
 
 CREATE TABLE position_category
 (
-    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    company_id  BIGINT      NOT NULL,
-    name        VARCHAR(50) NOT NULL,
-    order_index INT         NOT NULL,
-    is_active   BOOLEAN     NOT NULL DEFAULT TRUE,
-    created_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    company_id         BIGINT      NOT NULL,
+    name               VARCHAR(50) NOT NULL,
+    order_index        INT, -- 비활성 항목 때문에 NULL 허용
+    is_active          BOOLEAN     NOT NULL DEFAULT TRUE,
+    -- 활성일 때만 정렬 유니크를 적용하기 위한 가상 컬럼
+    active_order_index INT
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN is_active = TRUE THEN order_index
+                               ELSE NULL
+                               END
+                           ) STORED,
+    created_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT uk_pos_cat_company_name
+        UNIQUE (company_id, name),
+
+    -- 활성 상태에서만 orderIndex 유니크 보장
+    CONSTRAINT uk_pos_cat_company_active_order
+        UNIQUE (company_id, active_order_index),
+
     CONSTRAINT fk_pos_cat_company
         FOREIGN KEY (company_id) REFERENCES company (id)
 ) ENGINE = InnoDB;
@@ -210,7 +225,7 @@ CREATE TABLE refresh_token
     id          BIGINT AUTO_INCREMENT PRIMARY KEY,
     company_id  BIGINT       NOT NULL,
     employee_id BIGINT       NOT NULL,
-    token       VARCHAR(500) NOT NULL UNIQUE ,
+    token       VARCHAR(500) NOT NULL UNIQUE,
     expires_at  TIMESTAMP    NOT NULL,
     created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_refresh_employee
@@ -313,12 +328,12 @@ CREATE TABLE form_template
 
     -- ✅ ACTIVE 상태에서만 version을 유니크하게 만들기 위한 컬럼
     active_version       INT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN status = 'ACTIVE' THEN version
-                ELSE NULL
-                END
-            ) STORED,
+                         GENERATED ALWAYS AS (
+                             CASE
+                                 WHEN status = 'ACTIVE' THEN version
+                                 ELSE NULL
+                                 END
+                             ) STORED,
 
     -- ===============================
     -- CONSTRAINTS

--- a/src/main/java/com/finalproj/orbitflow/hr/position/repository/PositionRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/position/repository/PositionRepository.java
@@ -15,4 +15,6 @@ import java.util.List;
 public interface PositionRepository extends JpaRepository<Position, Long> {
 
     List<Position> findByCompanyIdAndIsActiveTrue(Long companyId);
+
+    boolean existsByCompanyIdAndCategoryIdAndIsActiveTrue(Long companyId, Long categoryId);
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
@@ -1,0 +1,83 @@
+package com.finalproj.orbitflow.hr.positionCategory.controller;
+
+import com.finalproj.orbitflow.global.common.ResponseDto;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryOrderUpdateReqDto;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryReqDto;
+import com.finalproj.orbitflow.hr.positionCategory.service.PositionCategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryController
+ * @since : 2025-12-22 월요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/position-categories")
+public class PositionCategoryController {
+
+    private final PositionCategoryService positionCategoryService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto> create(
+            @RequestBody @Valid PositionCategoryReqDto request
+    ) {
+        return ResponseEntity.ok(
+                new ResponseDto(
+                        HttpStatus.CREATED,
+                        "직책 카테고리 생성 완료",
+                        positionCategoryService.create(SecurityUtils.getCompanyId(), request)
+                )
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDto> findAll(
+            @RequestParam(defaultValue = "false") boolean includeInactive
+    ) {
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "직책 카테고리 전체 조회 완료",
+                        positionCategoryService.findAll(SecurityUtils.getCompanyId(), includeInactive)
+                )
+        );
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseDto> update(
+            @PathVariable Long id,
+            @RequestBody @Valid PositionCategoryReqDto request
+    ) {
+        positionCategoryService.update(SecurityUtils.getCompanyId(), id, request);
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "직책 카테고리 수정 완료",
+                        null
+                )
+        );
+    }
+
+    @PostMapping("/order")
+    public ResponseEntity<ResponseDto> updateOrder(
+            @RequestBody @Valid PositionCategoryOrderUpdateReqDto request
+    ) {
+        positionCategoryService.updateOrder(SecurityUtils.getCompanyId(), request.getOrders());
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "직책 카테고리 순서 수정 완료",
+                        null
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryOrderUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryOrderUpdateReqDto.java
@@ -1,0 +1,26 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryOrderUpdateReqDto
+ * @since : 2025-12-22 월요일
+ */
+
+@Getter
+public class PositionCategoryOrderUpdateReqDto {
+
+    private List<OrderItem> orders;
+
+    @Getter
+    @NoArgsConstructor
+    public static class OrderItem {
+        private Long id;
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryReqDto
+ * @since : 2025-12-22 월요일
+ */
+@Getter
+@NoArgsConstructor
+public class PositionCategoryReqDto {
+    private String name;
+    private Boolean isActive;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryResDto.java
@@ -1,0 +1,33 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryResDto
+ * @since : 2025-12-22 월요일
+ */
+
+@Getter
+@Builder
+public class PositionCategoryResDto {
+    private Long id;
+    private String name;
+    private Integer orderIndex;
+    private Boolean isActive;
+
+
+    public static PositionCategoryResDto from(PositionCategory entity) {
+        return PositionCategoryResDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .orderIndex(entity.getOrderIndex())
+                .isActive(entity.getIsActive())
+                .build();
+    }
+
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
@@ -36,9 +36,33 @@ public class PositionCategory extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name; // 본부장 / 팀장 등
 
-    @Column(name = "order_index", nullable = false)
+    @Column(name = "order_index")
     private Integer orderIndex;
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
+
+    /* ========= 생성 ========= */
+    public static PositionCategory create(
+            Company company,
+            String name,
+            int orderIndex
+    ) {
+        PositionCategory category = new PositionCategory();
+        category.company = company;
+        category.name = name;
+        category.orderIndex = orderIndex;
+        category.isActive = true;
+        return category;
+    }
+
+    /* ========= 수정 ========= */
+    public void update(String name, Boolean isActive) {
+        this.name = name;
+        this.isActive = isActive;
+    }
+
+    public void updateOrderIndex(Integer orderIndex) {
+        this.orderIndex = orderIndex;
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
@@ -2,6 +2,8 @@ package com.finalproj.orbitflow.hr.positionCategory.repository;
 
 import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,5 +16,22 @@ import java.util.List;
  */
 public interface PositionCategoryRepository extends JpaRepository<PositionCategory, Long> {
 
+    List<PositionCategory> findByCompanyId(Long companyId);
+
     List<PositionCategory> findByCompanyIdAndIsActiveTrue(Long companyId);
+
+    long countByCompanyIdAndIsActiveTrue(Long companyId);
+
+    boolean existsByCompanyIdAndName(Long companyId, String name);
+
+    @Query("""
+                select max(pc.orderIndex)
+                from PositionCategory pc
+                where pc.company.id = :companyId
+                  and pc.isActive = true
+            """)
+    Integer findMaxActiveOrderIndexByCompanyId(@Param("companyId") Long companyId);
+
+    List<PositionCategory> findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(Long companyId);
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
@@ -1,0 +1,163 @@
+package com.finalproj.orbitflow.hr.positionCategory.service;
+
+import com.finalproj.orbitflow.global.exception.ForbiddenException;
+import com.finalproj.orbitflow.global.exception.InvalidRequestException;
+import com.finalproj.orbitflow.global.exception.InvalidStateException;
+import com.finalproj.orbitflow.global.exception.NotFoundException;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.position.repository.PositionRepository;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryOrderUpdateReqDto;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryReqDto;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryResDto;
+import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
+import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryService
+ * @since : 2025-12-22 월요일
+ */
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PositionCategoryService {
+
+    private final PositionCategoryRepository positionCategoryRepository;
+    private final PositionRepository positionRepository;
+    private final CompanyRepository companyRepository;
+
+    /* ================= 생성 ================= */
+    public Long create(Long companyId, PositionCategoryReqDto request) {
+
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new NotFoundException("회사를 찾을 수 없습니다."));
+
+        if (positionCategoryRepository.existsByCompanyIdAndName(companyId, request.getName())) {
+            throw new InvalidStateException("이미 존재하는 직책 카테고리명입니다.");
+        }
+
+        Integer maxOrder =
+                positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
+
+        int nextOrder = maxOrder == null ? 1 : maxOrder + 1;
+
+
+        PositionCategory category =
+                PositionCategory.create(company, request.getName(), nextOrder);
+
+        return positionCategoryRepository.save(category).getId();
+    }
+
+    /* ================= 조회 ================= */
+    @Transactional(readOnly = true)
+    public List<PositionCategoryResDto> findAll(
+            Long companyId,
+            boolean includeInactive
+    ) {
+        List<PositionCategory> list =
+                includeInactive
+                        ? positionCategoryRepository.findByCompanyId(companyId)
+                        : positionCategoryRepository.findByCompanyIdAndIsActiveTrue(companyId);
+
+        return list.stream()
+                .map(PositionCategoryResDto::from)
+                .toList();
+    }
+
+    /* ================= 수정 ================= */
+    public void update(
+            Long companyId,
+            Long categoryId,
+            PositionCategoryReqDto request
+    ) {
+        PositionCategory category = getCategoryInCompany(companyId, categoryId);
+
+        boolean wasInactive = !category.getIsActive();
+        boolean willActivate = Boolean.TRUE.equals(request.getIsActive());
+
+        if (wasInactive && willActivate) {
+            // 재활성화 -> 맨 뒤로 이동
+            Integer maxOrder =
+                    positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
+            category.updateOrderIndex(maxOrder == null ? 1 : maxOrder + 1);
+        }
+
+        // 비활성화 시 직책 사용 여부 검증
+        if (Boolean.FALSE.equals(request.getIsActive())) {
+            boolean used =
+                    positionRepository.existsByCompanyIdAndCategoryIdAndIsActiveTrue(
+                            companyId,
+                            categoryId
+                    );
+
+            if (used) {
+                throw new InvalidStateException(
+                        "해당 카테고리를 사용하는 직책이 존재하여 비활성화할 수 없습니다."
+                );
+            }
+
+            category.updateOrderIndex(null);
+        }
+
+        category.update(request.getName(), request.getIsActive());
+    }
+
+    /* ================= 정렬 ================= */
+    public void updateOrder(
+            Long companyId,
+            List<PositionCategoryOrderUpdateReqDto.OrderItem> orders
+    ) {
+        if (orders == null || orders.isEmpty()) {
+            throw new InvalidRequestException("순서 정보가 비어 있습니다.");
+        }
+
+        long activeCount =
+                positionCategoryRepository.countByCompanyIdAndIsActiveTrue(companyId);
+
+        if (activeCount != orders.size()) {
+            throw new InvalidStateException("정렬 대상 개수가 일치하지 않습니다.");
+        }
+
+        int temp = -1;
+        for (var item : orders) {
+            PositionCategory category = getCategoryInCompany(companyId, item.getId());
+            if (!category.getIsActive()) {
+                throw new InvalidStateException("비활성 카테고리는 정렬할 수 없습니다.");
+            }
+            category.updateOrderIndex(temp--);
+        }
+
+        positionCategoryRepository.flush();
+
+        int orderIndex = 1;
+        for (var item : orders) {
+            PositionCategory category = getCategoryInCompany(companyId, item.getId());
+            category.updateOrderIndex(orderIndex++);
+        }
+    }
+
+
+
+
+    /* ================= 내부 메서드 ================= */
+    private PositionCategory getCategoryInCompany(Long companyId, Long categoryId) {
+        PositionCategory category =
+                positionCategoryRepository.findById(categoryId)
+                        .orElseThrow(() -> new NotFoundException("직책 카테고리를 찾을 수 없습니다."));
+
+        if (!category.getCompany().getId().equals(companyId)) {
+            throw new ForbiddenException("해당 회사의 직책 카테고리가 아닙니다.");
+        }
+
+        return category;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #169

## 📝 작업 내용
### 직책 카테고리 CRUD 구현
- 직책 카테고리 생성 / 조회 / 수정 / 정렬 API 구현
- 회사 단위(company_id)로 직책 카테고리 관리 가능하도록 설계
###정렬(orderIndex) & 활성/비활성 정책 설계
- 활성 카테고리만 정렬 대상이 되도록 로직 분리
- 비활성화 시 orderIndex = null 처리하여 정렬 대상에서 제외
- 재활성화 시 현재 활성 카테고리 기준 맨 마지막 순서로 자동 배치
### 데이터 무결성 및 예외 처리
- 회사 + 카테고리명 중복 생성 방지
- 사용 중인 직책이 존재하는 카테고리는 비활성화 불가하도록 검증 로직 추가
- 정렬 요청 시 활성 카테고리 개수와 요청 데이터 불일치 시 예외 처리
### DB 설계 개선
- position_category.order_index → NULL 허용
- 활성 상태에서만 정렬 유니크를 보장하기 위해 active_order_index (generated column) + UNIQUE 제약 적용
- 도메인 모델과 DB 제약 역할을 분리하여 엔티티는 도메인 중심으로 유지

## 체크리스트
- [x] 비활성/재활성 시 정렬 정책이 일관되게 동작합니다.
- [x] Postman을 통해 CRUD 및 정렬 API 동작을 검증했습니다.
## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
