### PR TITLE
fix(employee, organization): Position 흔적 제거

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/attendance/attendanceDefaultRule/dto/EmployeeSearchDto.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/attendanceDefaultRule/dto/EmployeeSearchDto.java
@@ -24,7 +24,7 @@ public record EmployeeSearchDto(
                 emp.getName(),
                 emp.getEmployeeNo(),
                 emp.getOrganization() != null ? emp.getOrganization().getName() : "",
-                emp.getPosition() != null ? emp.getPosition().getName() : ""
+                emp.getPositionCategory() != null ? emp.getPositionCategory().getName() : ""
         );
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -67,7 +67,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     List<Employee> findAllByStatus(String active);
 
-    boolean existsByCompanyIdAndPositionId(Long companyId, Long positionId);
     List<Employee> findAllByStatus(EmployeeStatus status);
 
     int countByCompanyIdAndStatus(Long companyId, EmployeeStatus status);

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -86,9 +86,9 @@ public class OrgService {
 
     /* ================= 수정 ================= */
     public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
-        String oldName = org.getName();
 
         Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
+        String oldName = org.getName();
 
         Long newParentId = request.getParentOrgId();
         String newName = normalizeNameOrThrow(request.getName());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #197

## 📝 작업 내용
- OrgService.update() 수정
- EmployeeRepository에 남아있던 Position 흔적 제거
- EmployeeSearchDto에 있던 `getPosition() -> `getPositionCategory` 변경

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
