### PR TITLE
feat(OrgPositionUsage, PositionCategory): isHead 설계 적용

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -183,19 +183,19 @@ public class CompanyService {
             OrgCategory teamCat
     ) {
         positionCategoryRepository.save(
-                PositionCategory.create(company, companyCat, "사장", 1)
+                PositionCategory.create(company, companyCat, "사장", 1, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, hqCat, "본부장", 2)
+                PositionCategory.create(company, hqCat, "본부장", 2, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, deptCat, "부장", 3)
+                PositionCategory.create(company, deptCat, "부장", 3, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, teamCat, "팀장", 4)
+                PositionCategory.create(company, teamCat, "팀장", 4, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, teamCat, "팀원", 5)
+                PositionCategory.create(company, teamCat, "팀원", 5, true)
         );
     }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/dto/OrgPositionUsageResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/dto/OrgPositionUsageResDto.java
@@ -17,11 +17,13 @@ public class OrgPositionUsageResDto {
 
     private Long positionCategoryId;
     private String positionCategoryName;
+    private boolean isHead;
 
     public static OrgPositionUsageResDto from(OrgPositionUsage entity) {
         return new OrgPositionUsageResDto(
                 entity.getPositionCategory().getId(),
-                entity.getPositionCategory().getName()
+                entity.getPositionCategory().getName(),
+                entity.getPositionCategory().getIsHead()
         );
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
@@ -2,6 +2,7 @@ package com.finalproj.orbitflow.hr.orgPositionUsage.repository;
 
 import com.finalproj.orbitflow.hr.orgPositionUsage.entity.OrgPositionUsage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -25,4 +26,13 @@ public interface OrgPositionUsageRepository extends JpaRepository<OrgPositionUsa
 
     /* 조직 정책 전체 삭제 (덮어쓰기 방식) */
     void deleteByCompany_IdAndOrganization_Id(Long companyId, Long organizationId);
+
+    @Query("""
+    select opp
+    from OrgPositionUsage opp
+    join fetch opp.positionCategory pc
+    where opp.organization.id = :orgId
+""")
+    List<OrgPositionUsage> findAllUsagesByOrgId(Long orgId);
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
@@ -47,7 +47,7 @@ public class OrgPositionUsageService {
 
         Organization org = getActiveOrg(companyId, orgId);
 
-        return repository.findByOrganization_Id(org.getId())
+        return repository.findAllUsagesByOrgId(org.getId())
                 .stream()
                 .map(OrgPositionUsageResDto::from)
                 .toList();

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
@@ -15,5 +15,6 @@ import lombok.NoArgsConstructor;
 public class PositionCategoryReqDto {
     private String name;
     private Long orgCategoryId;
+    private Boolean isHead;
     private Boolean isActive;
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
@@ -44,6 +44,10 @@ public class PositionCategory extends BaseEntity {
     @Column(name = "order_index")
     private Integer orderIndex;
 
+    @Getter
+    @Column(name = "is_head", nullable = false)
+    private Boolean isHead;
+
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
@@ -52,13 +56,15 @@ public class PositionCategory extends BaseEntity {
             Company company,
             OrgCategory orgCategory,
             String name,
-            int orderIndex
+            int orderIndex,
+            boolean isHead
     ) {
         PositionCategory category = new PositionCategory();
         category.company = company;
         category.orgCategory = orgCategory;
         category.name = name;
         category.orderIndex = orderIndex;
+        category.isHead = isHead;
         category.isActive = true;
         return category;
     }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
@@ -34,4 +34,5 @@ public interface PositionCategoryRepository extends JpaRepository<PositionCatego
 
     List<PositionCategory> findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(Long companyId);
 
+    boolean existsByCompanyIdAndOrgCategoryIdAndIsHeadTrue(Long companyId, Long id);
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
@@ -63,8 +63,26 @@ public class PositionCategoryService {
 
         String name = normalizeNameOrThrow(request.getName());
 
+        boolean isHead = request.getIsHead();
+
+        if (isHead) {
+            boolean exists =
+                    positionCategoryRepository
+                            .existsByCompanyIdAndOrgCategoryIdAndIsHeadTrue(
+                                    companyId,
+                                    orgCategory.getId()
+                            );
+
+            if (exists) {
+                throw new InvalidStateException(
+                        "해당 조직 유형에는 이미 HEAD 직책이 존재합니다."
+                );
+            }
+        }
+
+
         PositionCategory category =
-                PositionCategory.create(company, orgCategory, name, nextOrder);
+                PositionCategory.create(company, orgCategory, name, nextOrder, isHead);
 
         return positionCategoryRepository.save(category).getId();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #210

## 📝 작업 내용
### 1. 조직별 직책 사용 정책 (OrgPositionUsage)
- 조직에서 사용 가능한 직책을 **화이트리스트 방식**으로 관리
- 정책은 조직 단위로 저장되며, 저장 시 항상 **덮어쓰기 방식**으로 처리
- HEAD 여부는 정책이 아닌 **직책 카테고리의 의미적 속성**으로 판단

### 2. HEAD 직책 설계 정리
- HEAD는 `PositionCategory.isHead`로 관리
- 관리자가 직책 생성 시 HEAD 여부를 직접 지정
- 조직 카테고리(팀/본부/부서 등) 당 HEAD 직책은 **1개만 허용**
- 생성 이후 HEAD 변경은 불가하도록 설계

### 3. 조회 API 개선
- 조직별 직책 정책 조회 시
  `OrgPositionUsage` + `PositionCategory` JOIN을 통해
  사용 중인 직책과 HEAD 여부를 함께 반환

---

## 설계 의도 요약
- 조직 생성 직후 직책/HEAD가 없어도 정상 상태
- HEAD가 존재하면 → 직책 기준 결재선
- HEAD가 없으면 → 사원 직접 지정 결재선
- 정책 테이블은 "사용 여부"만 담당하고,
  직책의 의미(HEAD)는 직책 카테고리에서 관리


## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
