### PR TITLE
feat(OrgCategory): 조직 카테고리 활성/비활성 관리 및 순서 정렬 개선

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -21,8 +21,17 @@ CREATE TABLE org_category
     id          BIGINT AUTO_INCREMENT PRIMARY KEY,
     company_id  BIGINT      NOT NULL,
     name        VARCHAR(50) NOT NULL,
-    order_index INT         NOT NULL,
+    order_index INT,  -- NULL 허용
     is_active   BOOLEAN     NOT NULL DEFAULT TRUE,
+
+    active_order_index INT
+        GENERATED ALWAYS AS (
+                    CASE
+                        WHEN is_active = TRUE THEN order_index
+                        ELSE NULL
+                        END
+                    ) STORED,
+
     created_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
@@ -30,8 +39,8 @@ CREATE TABLE org_category
     CONSTRAINT uk_org_category_company_name
         UNIQUE (company_id, name),
 
-    CONSTRAINT uk_org_category_company_order -- orderIndex 유니크 제약 추가
-        UNIQUE (company_id, order_index),
+    CONSTRAINT uk_org_category_company_active_order
+        UNIQUE (company_id, active_order_index),
 
     CONSTRAINT fk_org_category_company
         FOREIGN KEY (company_id) REFERENCES company (id)

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryController.java
@@ -33,13 +33,14 @@ public class OrgCategoryController {
 
     @GetMapping
     public ResponseEntity<ResponseDto<List<OrgCategoryResDto>>> list(
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean includeInactive
     ) {
         return ResponseEntity.ok(
                 new ResponseDto<>(
                         HttpStatus.OK,
                         "조직 카테고리 목록 조회 성공",
-                        service.findAll(SecurityUtils.getCompanyId(), keyword)
+                        service.findAll(SecurityUtils.getCompanyId(), keyword, includeInactive)
                 )
         );
     }
@@ -58,7 +59,7 @@ public class OrgCategoryController {
             @PathVariable Long id,
             @RequestBody @Valid OrgCategoryUpdateReqDto request
     ) {
-        service.update(SecurityUtils.getCompanyId(), id, request.getName());
+        service.update(SecurityUtils.getCompanyId(), id, request);
         return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "조직 카테고리 수정 성공", null));
     }
 
@@ -70,9 +71,4 @@ public class OrgCategoryController {
         return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "순서 변경 저장 완료", null));
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<ResponseDto<Void>> deactivate(@PathVariable Long id) {
-        service.deactivate(SecurityUtils.getCompanyId(), id);
-        return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "조직 카테고리 비활성화 완료", null));
-    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/controller/OrgCategoryViewController.java
@@ -1,0 +1,38 @@
+package com.finalproj.orbitflow.hr.orgCategory.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ /**
+ * 조직 카테고리 화면(View) 컨트롤러
+ * - 관리자 전용 화면
+ * - Thymeleaf 템플릿 반환 전용
+ *
+ * URL 규칙:
+ * /view/admin/org-categories
+ *
+ *
+ * @author : seunga03
+ * @filename : OrgCategoryViewController
+ * @since : 2025-12-23 화요일
+ */
+@Controller
+@RequestMapping("/view/admin/org-categories")
+public class OrgCategoryViewController {
+
+    /**
+     * 조직 카테고리 관리 목록 화면
+     */
+    @GetMapping
+    public String orgCategoryList(Model model) {
+
+        model.addAttribute("pageTitle", "조직 카테고리 관리");
+        model.addAttribute("currentMenu", "org-category");
+        model.addAttribute("sidebarFragment", "admin-sidebar");
+
+        return "admin/hr/org-category/list";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/dto/OrgCategoryUpdateReqDto.java
@@ -14,8 +14,11 @@ import lombok.Getter;
 @Getter
 public class OrgCategoryUpdateReqDto {
 
+    // 이름 수정, 비활성화, 재활성화 가능
+
     @NotBlank
     @Size(max = 50)
     private String name;
 
+    private Boolean isActive;
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/entity/OrgCategory.java
@@ -20,8 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "org_category",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"company_id", "name"}),
-                @UniqueConstraint(columnNames = {"company_id", "order_index"})
+                @UniqueConstraint(columnNames = {"company_id", "name"})
         }
 )
 public class OrgCategory extends BaseEntity {
@@ -37,8 +36,8 @@ public class OrgCategory extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name;                                // 조직 유형명 (회사/본부/부서/팀)
 
-    @Column(name = "order_index", nullable = false)
-    private Integer orderIndex;                             // 정렬 순서
+    @Column(name = "order_index")
+    private Integer orderIndex;                             // 정렬 순서 (null 허용)
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;                           // 사용 여부 (소프트 삭제)
@@ -56,6 +55,21 @@ public class OrgCategory extends BaseEntity {
         return category;
     }
 
+
+    /* ========= 상태 변경 ========= */
+
+    public void activate(Integer newOrderIndex) {
+        this.isActive = true;
+        this.orderIndex = newOrderIndex;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        this.orderIndex = null;
+    }
+
+    /* ========= 수정 ========= */
+
     public void updateName(String name) {
         this.name = name;
     }
@@ -63,10 +77,4 @@ public class OrgCategory extends BaseEntity {
     public void updateOrderIndex(Integer orderIndex) {
         this.orderIndex = orderIndex;
     }
-
-
-    public void deactivate() {
-        this.isActive = false;
-    }
-
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/repository/OrgCategoryRepository.java
@@ -20,6 +20,7 @@ public interface OrgCategoryRepository extends JpaRepository<OrgCategory, Long> 
      * 회사별 조직 카테고리 전체 조회 (정렬 포함)
      */
     List<OrgCategory> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
+    List<OrgCategory> findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(Long companyId);
 
     /**
      * 회사별 특정 조직 카테고리 조회
@@ -32,11 +33,12 @@ public interface OrgCategoryRepository extends JpaRepository<OrgCategory, Long> 
     boolean existsByCompanyIdAndName(Long companyId, String name);
 
     @Query("""
-                select max(o.orderIndex)
-                from OrgCategory o
-                where o.companyId = :companyId
-            """)
-    Integer findMaxOrderIndexByCompanyId(Long companyId);
+    select max(o.orderIndex)
+    from OrgCategory o
+    where o.companyId = :companyId
+      and o.isActive = true
+""")
+    Integer findMaxActiveOrderIndexByCompanyId(Long companyId);
 
     long countByCompanyIdAndIsActiveTrue(Long companyId);
 

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
@@ -1,9 +1,13 @@
 package com.finalproj.orbitflow.hr.orgCategory.service;
 
 
-import com.finalproj.orbitflow.global.exception.*;
+import com.finalproj.orbitflow.global.exception.BusinessException;
+import com.finalproj.orbitflow.global.exception.InvalidRequestException;
+import com.finalproj.orbitflow.global.exception.InvalidStateException;
+import com.finalproj.orbitflow.global.exception.NotFoundException;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryOrderUpdateReqDto;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryResDto;
+import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryUpdateReqDto;
 import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
@@ -30,13 +34,19 @@ public class OrgCategoryService {
 
     /* ================= 목록 (검색 포함) ================= */
     @Transactional(readOnly = true)
-    public List<OrgCategoryResDto> findAll(Long companyId, String keyword) {
+    public List<OrgCategoryResDto> findAll(Long companyId, String keyword, boolean includeInactive) {
 
-        List<OrgCategory> categories =
-                (keyword == null || keyword.isBlank())
-                        ? repository.findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId)
-                        : repository.findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(
-                        companyId, keyword.trim());
+        List<OrgCategory> categories;
+
+        if (includeInactive) {
+            categories = repository.findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(companyId);
+        } else {
+            categories =
+                    (keyword == null || keyword.isBlank())
+                            ? repository.findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId)
+                            : repository.findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(
+                            companyId, keyword.trim());
+        }
 
         return categories.stream()
                 .map(OrgCategoryResDto::from)
@@ -52,7 +62,7 @@ public class OrgCategoryService {
             throw new BusinessException("이미 존재하는 조직 카테고리입니다.");
         }
 
-        Integer max = repository.findMaxOrderIndexByCompanyId(companyId);
+        Integer max = repository.findMaxActiveOrderIndexByCompanyId(companyId);
         int nextOrder = (max == null) ? 1 : max + 1;
 
         return repository.save(
@@ -60,31 +70,36 @@ public class OrgCategoryService {
         ).getId();
     }
 
-    /* ================= 수정 ================= */
-    public void update(Long companyId, Long id, String rawName) {
-
+    /* ================= 수정 (이름 + 활성/비활성/재활성화) ================= */
+    public void update(Long companyId, Long id, OrgCategoryUpdateReqDto request) {
         OrgCategory category = get(companyId, id);
-        String name = rawName.trim();
 
+        String name = request.getName().trim();
         if (repository.existsByCompanyIdAndNameAndIdNot(companyId, name, id)) {
             throw new BusinessException("이미 존재하는 조직 카테고리입니다.");
         }
 
-        category.updateName(name);
-    }
+        boolean wasInactive = !category.getIsActive();
+        boolean willActivate = Boolean.TRUE.equals(request.getIsActive());
+        boolean willDeactivate = Boolean.FALSE.equals(request.getIsActive());
 
-    /* ================= 비활성화 ================= */
-    public void deactivate(Long companyId, Long id) {
-
-        OrgCategory category = get(companyId, id);
-
-        if (orgRepository.existsByCompanyIdAndCategoryIdAndIsActiveTrue(companyId, id)) {
-            throw new InvalidStateException(
-                    "해당 카테고리를 사용하는 조직이 존재하여 비활성화할 수 없습니다."
-            );
+        // 재활성화
+        if (wasInactive && willActivate) {
+            Integer max = repository.findMaxActiveOrderIndexByCompanyId(companyId);
+            category.activate(max == null ? 1 : max + 1);
         }
 
-        category.deactivate();
+        // 비활성화
+        if (willDeactivate) {
+            if (orgRepository.existsByCompanyIdAndCategoryIdAndIsActiveTrue(companyId, id)) {
+                throw new InvalidStateException(
+                        "해당 카테고리를 사용하는 조직이 존재하여 비활성화할 수 없습니다."
+                );
+            }
+            category.deactivate(); // 내부에서 orderIndex = null 처리
+        }
+
+        category.updateName(name);
     }
 
     /* ================= 순서 변경 ================= */

--- a/src/main/resources/static/css/admin-org-category.css
+++ b/src/main/resources/static/css/admin-org-category.css
@@ -1,0 +1,472 @@
+/* ==================================================
+   admin-org-category.css
+   - 조직 카테고리 관리 (목록 + 모달)
+================================================== */
+
+:root {
+    --bg: #f5f7fb;
+    --card: #ffffff;
+    --line: #eef1f6;
+    --text: #111827;
+    --muted: #6b7280;
+    --primary: #2f6af6;
+    --primary-weak: rgba(47,106,246,.12);
+
+    --success-bg: #dff7e7;
+    --success-text: #137a3a;
+
+    --danger-bg: #fde2e2;
+    --danger-text: #b42318;
+
+    --shadow: 0 12px 36px rgba(16, 24, 40, 0.08);
+}
+
+/* 페이지 바탕 */
+.orgcat-page {
+    padding: 28px 32px;
+    background: var(--bg);
+    min-height: calc(100vh - 64px);
+}
+
+/* 타이틀 */
+.orgcat-title-row {
+    margin-bottom: 18px;
+}
+
+.orgcat-title {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+    color: var(--text);
+    margin: 0;
+}
+
+/* 카드 */
+.orgcat-card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    padding: 18px 18px 14px;
+}
+
+/* 툴바 */
+.orgcat-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 4px 4px 14px;
+}
+
+/* 검색 */
+.orgcat-search {
+    flex: 1;
+    max-width: 460px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0 14px;
+    background: #fbfcff;
+}
+
+.orgcat-search i {
+    color: #9aa3b2;
+    font-size: 14px;
+}
+
+.orgcat-search input {
+    width: 100%;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 13.5px;
+    color: var(--text);
+}
+
+.orgcat-search input::placeholder {
+    color: #9aa3b2;
+}
+
+/* 버튼 공통 */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 42px;
+    padding: 0 16px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-size: 13.5px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform .06s ease, background .15s ease, border-color .15s ease;
+    user-select: none;
+}
+
+.btn:active {
+    transform: translateY(1px);
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 10px 24px rgba(47,106,246,.22);
+}
+
+.btn-primary:hover {
+    filter: brightness(0.98);
+}
+
+.btn-outline {
+    background: #fff;
+    color: var(--primary);
+    border-color: rgba(47,106,246,.35);
+}
+
+.btn-outline:hover {
+    background: var(--primary-weak);
+}
+
+.btn-outline:disabled {
+    cursor: not-allowed;
+    opacity: .45;
+    background: #fff;
+}
+
+.btn-ghost {
+    background: #fff;
+    color: #374151;
+    border-color: #e5e7eb;
+}
+
+.btn-ghost:hover {
+    background: #f3f4f6;
+}
+
+/* 테이블 */
+.orgcat-table-wrap {
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.orgcat-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13.5px;
+}
+
+.orgcat-table thead th {
+    background: #f6f7fb;
+    color: #667085;
+    text-align: left;
+    padding: 14px 16px;
+    font-weight: 800;
+    border-bottom: 1px solid var(--line);
+}
+
+.orgcat-table tbody td {
+    padding: 16px 16px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: middle;
+    color: var(--text);
+}
+
+.orgcat-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.col-order { width: 90px; }
+.col-status { width: 140px; }
+.col-action { width: 140px; }
+
+/* 드래그 핸들(점 6개 느낌) */
+.drag-handle {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    cursor: grab;
+    color: #98a2b3;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-dots {
+    width: 14px;
+    height: 18px;
+    display: grid;
+    grid-template-columns: repeat(2, 4px);
+    grid-template-rows: repeat(3, 4px);
+    gap: 3px;
+}
+
+.drag-dots span {
+    width: 4px;
+    height: 4px;
+    background: #a9b1c3;
+    border-radius: 50%;
+}
+
+/* 상태 배지 */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 64px;
+    height: 30px;
+    padding: 0 12px;
+    border-radius: 999px;
+    font-size: 12.5px;
+    font-weight: 800;
+}
+
+.status-active {
+    background: var(--success-bg);
+    color: var(--success-text);
+}
+
+.status-inactive {
+    background: var(--danger-bg);
+    color: var(--danger-text);
+}
+
+/* 수정 버튼(테이블 내) */
+.table-btn {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #d0d5dd;
+    background: #fff;
+    font-weight: 800;
+    font-size: 13px;
+    color: #344054;
+    cursor: pointer;
+}
+
+.table-btn:hover {
+    background: #f3f4f6;
+}
+
+/* 하단 */
+.orgcat-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 6px 0;
+}
+
+.orgcat-hint {
+    font-size: 12.5px;
+    color: #98a2b3;
+}
+
+/* =========================
+   모달
+========================= */
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    padding: 18px;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-panel {
+    width: 720px;
+    max-width: 92vw;
+    background: #fff;
+    border-radius: 18px;
+    box-shadow: 0 22px 70px rgba(0,0,0,0.32);
+    overflow: hidden;
+}
+
+.modal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 22px 24px 10px;
+}
+
+.modal-head h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 900;
+    color: var(--text);
+}
+
+.modal-sub {
+    margin: 8px 0 0;
+    font-size: 12.5px;
+    color: #98a2b3;
+}
+
+.icon-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid #eef2f7;
+    background: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #667085;
+}
+
+.icon-btn:hover {
+    background: #f3f4f6;
+}
+
+.modal-body {
+    padding: 8px 24px 18px;
+}
+
+.form-group {
+    margin-top: 14px;
+}
+
+.form-label {
+    display: block;
+    font-size: 12.5px;
+    font-weight: 900;
+    color: #667085;
+    margin-bottom: 8px;
+}
+
+.form-input {
+    width: 100%;
+    height: 46px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #e6eaf2;
+    background: #fbfcff;
+    outline: none;
+    font-size: 13.5px;
+    color: var(--text);
+}
+
+.form-input:focus {
+    border-color: rgba(47,106,246,.55);
+    box-shadow: 0 0 0 4px rgba(47,106,246,.12);
+}
+
+.form-help {
+    margin: 8px 2px 0;
+    font-size: 12.5px;
+    color: #ef4444;
+    min-height: 16px;
+}
+
+/* 토글 */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding-top: 6px;
+}
+
+.toggle-text {
+    font-weight: 900;
+    font-size: 13.5px;
+    color: #344054;
+}
+
+/* switch */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 54px;
+    height: 30px;
+}
+.switch input { display: none; }
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: #d0d5dd;
+    border-radius: 999px;
+    transition: .2s;
+}
+.slider:before {
+    content: "";
+    position: absolute;
+    height: 24px;
+    width: 24px;
+    left: 3px;
+    top: 3px;
+    background: white;
+    border-radius: 50%;
+    transition: .2s;
+    box-shadow: 0 8px 18px rgba(0,0,0,.12);
+}
+.switch input:checked + .slider {
+    background: var(--primary);
+}
+.switch input:checked + .slider:before {
+    transform: translateX(24px);
+}
+
+/* 모달 하단 버튼 */
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 24px 22px;
+    border-top: 1px solid #eef2f7;
+}
+
+/* Sortable dragging */
+.sortable-chosen {
+    background: #f7f9ff;
+}
+.sortable-ghost {
+    opacity: .6;
+}
+
+.inactive-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #475467;
+}
+
+
+/* 반응형 */
+@media (max-width: 720px) {
+    .orgcat-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .orgcat-search {
+        max-width: 100%;
+    }
+    .orgcat-footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .orgcat-footer .btn {
+        width: 100%;
+    }
+}

--- a/src/main/resources/static/js/admin-org-category.js
+++ b/src/main/resources/static/js/admin-org-category.js
@@ -1,0 +1,389 @@
+/* ==================================================
+   admin-org-category.js (FINAL)
+   - 조회 (비활성 포함 옵션)
+   - 생성 (항상 활성)
+   - 수정 (활성/비활성 전환 가능)
+   - 순서 저장 (활성만)
+================================================== */
+
+const API_BASE = '/api/admin/org-categories';
+
+let categoryList = [];
+let selectedCategoryId = null;
+
+let sortableInstance = null;
+let isOrderChanged = false;
+
+/* ======================
+   Elements
+====================== */
+const els = {
+    tbody: () => document.getElementById('categoryTableBody'),
+
+    search: () => document.getElementById('searchKeyword'),
+    includeInactive: () => document.getElementById('includeInactive'),
+    btnOpenCreate: () => document.getElementById('btnOpenCreate'),
+    btnSaveOrder: () => document.getElementById('btnSaveOrder'),
+
+    modal: () => document.getElementById('categoryModal'),
+    modalTitle: () => document.getElementById('modalTitle'),
+    categoryId: () => document.getElementById('categoryId'),
+    categoryName: () => document.getElementById('categoryName'),
+    categoryActive: () => document.getElementById('categoryActive'),
+    toggleText: () => document.getElementById('toggleText'),
+    nameHelp: () => document.getElementById('nameHelp'),
+
+    btnCloseModal: () => document.getElementById('btnCloseModal'),
+    btnCancel: () => document.getElementById('btnCancel'),
+    btnSaveCategory: () => document.getElementById('btnSaveCategory'),
+};
+
+/* ======================
+   Init
+====================== */
+document.addEventListener('DOMContentLoaded', () => {
+    bindEvents();
+    loadCategories();
+});
+
+function filterCategories() {
+    const keyword = els.search()?.value.trim().toLowerCase() ?? '';
+    const includeInactive = els.includeInactive()?.checked ?? false;
+
+    const filtered = categoryList.filter(c => {
+        if (!includeInactive && !normalizeActive(c)) return false;
+        return (c.name ?? '').toLowerCase().includes(keyword);
+    });
+
+    const activeCount = renderTable(filtered);
+
+    const hint = document.getElementById('orderHint');
+    if (hint) {
+        hint.style.display = activeCount > 1 ? 'block' : 'none';
+    }
+
+    initSortable();
+}
+
+function bindEvents() {
+    els.search()?.addEventListener('input', filterCategories);
+    els.includeInactive()?.addEventListener('change', loadCategories);
+
+    els.btnOpenCreate()?.addEventListener('click', openCreateModal);
+    els.btnSaveOrder()?.addEventListener('click', saveOrder);
+
+    els.btnCloseModal()?.addEventListener('click', closeModal);
+    els.btnCancel()?.addEventListener('click', closeModal);
+    els.btnSaveCategory()?.addEventListener('click', saveCategory);
+
+    els.categoryActive()?.addEventListener('change', syncToggleText);
+
+    els.categoryName()?.addEventListener('input', () => {
+        els.nameHelp().textContent = '';
+        els.categoryName().classList.remove('is-invalid');
+    });
+
+    document.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && !els.modal().classList.contains('hidden')) {
+            closeModal();
+        }
+    });
+}
+
+/* ======================
+   Load
+====================== */
+async function loadCategories() {
+    try {
+        const includeInactive = els.includeInactive()?.checked ?? false;
+
+        const res = await apiFetch(
+            `${API_BASE}?includeInactive=${includeInactive}`
+        );
+        const result = await res.json();
+
+        if (!res.ok) {
+            alert(result.message || '목록 조회 실패');
+            return;
+        }
+
+        categoryList = Array.isArray(result.data) ? result.data : [];
+
+        filterCategories();
+        resetOrderChanged();
+
+        initSortable();
+        resetOrderChanged();
+
+    } catch (e) {
+        console.error(e);
+        alert('조직 카테고리 조회 중 오류 발생');
+    }
+}
+
+/* ======================
+   Render
+====================== */
+function renderTable(list) {
+    const tbody = els.tbody();
+    tbody.innerHTML = '';
+
+    if (!list.length) {
+        tbody.innerHTML = `
+          <tr>
+            <td colspan="4" style="padding:24px; color:#98a2b3;">
+              등록된 카테고리가 없습니다.
+            </td>
+          </tr>`;
+        return 0; // activeCount = 0
+    }
+
+    const active = list
+        .filter(c => normalizeActive(c))
+        .sort((a, b) => toNumber(a.orderIndex) - toNumber(b.orderIndex));
+
+    const inactive = list.filter(c => !normalizeActive(c));
+
+    active.forEach(renderRow);
+
+    if (inactive.length) {
+        const sep = document.createElement('tr');
+        sep.innerHTML = `
+          <td colspan="4"
+              style="background:#f9fafb; font-weight:800; color:#667085;">
+            비활성 카테고리
+          </td>`;
+        tbody.appendChild(sep);
+
+        inactive.forEach(renderRow);
+    }
+
+    return active.length;
+}
+
+
+function renderRow(category) {
+    const tr = document.createElement('tr');
+    tr.dataset.id = category.id;
+
+    const isActive = normalizeActive(category);
+
+    tr.innerHTML = `
+      <td>${isActive ? dragHandleHtml() : ''}</td>
+      <td><strong>${escapeHtml(category.name)}</strong></td>
+      <td>
+        <span class="status-badge ${isActive ? 'status-active' : 'status-inactive'}">
+          ${isActive ? '활성' : '비활성'}
+        </span>
+      </td>
+      <td>
+        <button class="table-btn" data-edit="${category.id}">수정</button>
+      </td>
+    `;
+
+    els.tbody().appendChild(tr);
+
+    tr.querySelector('[data-edit]').addEventListener('click', () => {
+        openEditModal(category.id);
+    });
+}
+
+function dragHandleHtml() {
+    return `
+      <span class="drag-handle">
+        <span class="drag-dots">
+          <span></span><span></span>
+          <span></span><span></span>
+          <span></span><span></span>
+        </span>
+      </span>`;
+}
+
+/* ======================
+   Sortable (활성만)
+====================== */
+function initSortable() {
+    const tbody = els.tbody();
+    if (!tbody) return;
+
+    if (sortableInstance) sortableInstance.destroy();
+
+    sortableInstance = Sortable.create(tbody, {
+        handle: '.drag-handle',
+        filter: 'tr:not([data-id])', // separator 제외
+        preventOnFilter: false,
+        animation: 160,
+
+        onMove: evt => {
+            const id = evt.related?.dataset?.id;
+            const c = categoryList.find(v => String(v.id) === id);
+            return c && normalizeActive(c);
+        },
+
+        onEnd: markOrderChanged
+    });
+
+}
+
+/* ======================
+   Save Order
+====================== */
+async function saveOrder() {
+    if (!isOrderChanged) return;
+
+    const rows = [...document.querySelectorAll('#categoryTableBody tr[data-id]')]
+        .filter(r => {
+            const c = categoryList.find(v => v.id === toNumber(r.dataset.id));
+            return c && normalizeActive(c);
+        });
+
+    const payload = {
+        orders: rows.map(r => ({id: toNumber(r.dataset.id)}))
+    };
+
+    const res = await apiFetch(`${API_BASE}/order`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+
+    const result = await res.json();
+
+    if (!res.ok) {
+        alert(result.message || '순서 저장 실패');
+        return;
+    }
+
+    resetOrderChanged();
+    loadCategories();
+    toast('순서가 저장되었습니다.');
+}
+
+/* ======================
+   Modal
+====================== */
+function openCreateModal() {
+    selectedCategoryId = null;
+
+    els.modalTitle().textContent = '조직 카테고리 생성';
+    els.categoryId().value = '';
+    els.categoryName().value = '';
+
+    els.categoryActive().checked = true;
+    els.categoryActive().disabled = true;
+
+    syncToggleText();
+    els.nameHelp().textContent = '';
+
+    openModal();
+    setTimeout(() => els.categoryName().focus(), 0);
+}
+
+function openEditModal(id) {
+    const category = categoryList.find(c => c.id === id);
+    if (!category) return;
+
+    selectedCategoryId = id;
+
+    els.modalTitle().textContent = '조직 카테고리 수정';
+    els.categoryId().value = id;
+    els.categoryName().value = category.name ?? '';
+
+    els.categoryActive().checked = normalizeActive(category);
+    els.categoryActive().disabled = false;
+
+    syncToggleText();
+    els.nameHelp().textContent = '';
+
+    openModal();
+}
+
+async function saveCategory() {
+    const name = els.categoryName().value.trim();
+    const isActive = els.categoryActive().checked;
+
+    if (!name) {
+        els.nameHelp().textContent = '카테고리명을 입력해주세요.';
+        return;
+    }
+
+    const payload = {name, isActive};
+
+    const isEdit = !!selectedCategoryId;
+    const url = isEdit ? `${API_BASE}/${selectedCategoryId}` : API_BASE;
+
+    const res = await apiFetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+
+    const result = await res.json();
+
+    if (!res.ok) {
+        alert(result.message || '저장 실패');
+        return;
+    }
+
+    closeModal();
+    loadCategories();
+    toast('저장되었습니다.');
+}
+
+/* ======================
+   Utils
+====================== */
+function openModal() {
+    els.modal().classList.remove('hidden');
+    els.modal().setAttribute('aria-hidden', 'false');
+}
+
+function closeModal() {
+    els.modal().classList.add('hidden');
+    els.modal().setAttribute('aria-hidden', 'true');
+}
+
+function markOrderChanged() {
+    isOrderChanged = true;
+    els.btnSaveOrder().disabled = false;
+}
+
+function resetOrderChanged() {
+    isOrderChanged = false;
+    els.btnSaveOrder().disabled = true;
+}
+
+function syncToggleText() {
+    els.toggleText().textContent =
+        els.categoryActive().checked ? '사용' : '미사용';
+}
+
+function normalizeActive(c) {
+    const v = c.isActive ?? c.active;
+    return v === true || v === 1 || v === 'true';
+}
+
+function toNumber(v) {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function escapeHtml(str) {
+    return String(str)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;');
+}
+
+function toast(msg) {
+    const el = document.createElement('div');
+    el.textContent = msg;
+    el.style.cssText = `
+      position:fixed; right:18px; bottom:18px;
+      background:#111827; color:#fff;
+      padding:10px 14px; border-radius:12px;
+      font-weight:800; z-index:3000;
+    `;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 1400);
+}

--- a/src/main/resources/templates/admin/hr/org-category/list.html
+++ b/src/main/resources/templates/admin/hr/org-category/list.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-admin :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{sidebar/admin-sidebar :: menu},
+        ~{::pageCss},
+        ~{::pageScript}
+      )}">
+
+<!-- ================= 페이지별 CSS ================= -->
+<th:block th:fragment="pageCss">
+  <link rel="stylesheet" th:href="@{/css/admin-org-category.css}">
+</th:block>
+
+<!-- ================= 메인 컨텐츠 ================= -->
+<th:block th:fragment="content">
+
+  <div class="orgcat-page">
+
+    <!-- 상단 타이틀 -->
+    <div class="orgcat-title-row">
+      <h1 class="orgcat-title">조직 카테고리 관리</h1>
+    </div>
+
+    <!-- 메인 카드 -->
+    <section class="orgcat-card">
+
+      <!-- 상단 유틸: 검색 + 추가 버튼 -->
+      <div class="orgcat-toolbar">
+        <div class="orgcat-search">
+          <i class="fa-solid fa-magnifying-glass"></i>
+          <input id="searchKeyword"
+                 type="text"
+                 placeholder="카테고리명 검색"
+                 autocomplete="off">
+        </div>
+
+        <label class="inactive-toggle">
+          <input type="checkbox" id="includeInactive">
+          <span>비활성 포함</span>
+          <small style="margin-left:6px; color:#98a2b3;">
+            (정렬 제외)
+          </small>
+        </label>
+
+
+        <button class="btn btn-primary" id="btnOpenCreate" type="button">
+          <i class="fa-solid fa-plus"></i>
+          <span>카테고리 추가</span>
+        </button>
+      </div>
+
+
+      <!-- 테이블 -->
+      <div class="orgcat-table-wrap">
+        <table class="orgcat-table">
+          <thead>
+          <tr>
+            <th class="col-order">순서</th>
+            <th class="col-name">카테고리명</th>
+            <th class="col-status">상태</th>
+            <th class="col-action">관리</th>
+          </tr>
+          </thead>
+          <tbody id="categoryTableBody">
+          <!-- JS 렌더링 -->
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 하단: 안내 + 저장 버튼 -->
+      <div class="orgcat-footer">
+        <div class="orgcat-hint" id="orderHint">
+          드래그앤드롭으로 순서를 변경할 수 있습니다.
+        </div>
+
+        <button class="btn btn-outline" id="btnSaveOrder" type="button" disabled>
+          변경사항저장
+        </button>
+      </div>
+
+    </section>
+  </div>
+
+  <!-- ================= 모달 ================= -->
+  <div id="categoryModal" class="modal hidden" aria-hidden="true">
+    <div class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+
+      <div class="modal-head">
+        <div class="modal-head-text">
+          <h2 id="modalTitle">조직 카테고리 생성/수정</h2>
+          <p class="modal-sub">
+            회사별로 조직 카테고리를 추가하고, 비활성화할 수 있습니다.
+          </p>
+        </div>
+        <button class="icon-btn" id="btnCloseModal" type="button" aria-label="닫기">
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+
+      <input type="hidden" id="categoryId">
+
+      <div class="modal-body">
+        <!-- 카테고리명 -->
+        <div class="form-group">
+          <label class="form-label" for="categoryName">카테고리명</label>
+          <input class="form-input"
+                 id="categoryName"
+                 type="text"
+                 placeholder="예: 본부 / 팀 / 센터">
+          <p class="form-help" id="nameHelp"></p>
+        </div>
+
+        <!-- 사용 여부 토글 -->
+        <div class="form-group">
+          <label class="form-label">사용여부</label>
+
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="categoryActive" checked>
+              <span class="slider"></span>
+            </label>
+            <span class="toggle-text" id="toggleText">사용</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-actions">
+        <button class="btn btn-ghost" id="btnCancel" type="button">취소</button>
+        <button class="btn btn-primary" id="btnSaveCategory" type="button">저장</button>
+      </div>
+
+    </div>
+  </div>
+
+</th:block>
+
+<!-- ================= 페이지별 JS ================= -->
+<th:block th:fragment="pageScript">
+  <!-- SortableJS (드래그앤드랍) -->
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+  <script th:src="@{/js/admin-org-category.js}"></script>
+</th:block>
+
+</html>

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -100,6 +100,9 @@
             <i class="fas fa-chevron-down arrow"></i>
         </div>
         <ul class="sub-menu">
+            <li th:classappend="${currentMenu == 'org-category'} ? 'selected' : ''">
+                <a th:href="@{/view/admin/org-categories}">조직 카테고리 관리</a>
+            </li>
             <li th:classappend="${currentMenu} == 'organization' ? 'selected' : ''">
                 <a th:href="@{/admin/organization}">조직 구조 관리</a>
             </li>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #213

## 📝 작업 내용
### 조직 카테고리 관리 기능 개선
- 조직 카테고리 활성 / 비활성 상태 관리 기능 추가
- 비활성 카테고리는 목록 하단에 분리 표시되며 정렬 대상에서 제외
- 비활성 카테고리 재활성화 가능
- 카테고리 생성 시 기본 상태를 활성으로 고정 (활성 토글 비활성화)
- 활성 카테고리만 드래그앤드롭으로 순서 변경 가능
- 비활성 포함 여부를 체크박스로 제어
- 검색 기능 개선 (서버 재조회와 클라이언트 필터 분리)

### UI / UX 개선
- 활성 카테고리 2개 이상일 때만 정렬 안내 문구 노출
- 비활성 카테고리 영역 구분 표시
- 모달 접근성(aria-hidden) 경고 해결


## 체크리스트
- [x] 카테고리 생성 시 활성 상태로 생성되는지 확인
- [x] 비활성 카테고리 정렬 불가 확인
- [x] 비활성 포함 체크 시 목록 정상 노출
- [x] 검색 필터 정상 동작
- [x] 수정 버튼 클릭 시 모달 정상 노출
- [x] 순서 변경 후 저장 정상 동작

## 스크린샷 (선택)
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/1149d1c7-0c17-4834-83e8-605c152d116c" />
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/642243e2-f5e0-4653-8320-cc1a2b38f286" />
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/416473ca-ca09-4d60-9293-eb537f3f06c3" />
<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/b21a9caa-d46f-4b0c-a325-bbd22ee2ecf3" />
<img width="1919" height="970" alt="image" src="https://github.com/user-attachments/assets/312f9dd6-51b2-4fe0-acd1-94524a57851d" />


## 💬 리뷰 요구사항(선택)
