### PR TITLE
Feat/#255

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -48,15 +48,26 @@ CREATE TABLE org_category
 
 CREATE TABLE organization
 (
-    id            BIGINT AUTO_INCREMENT PRIMARY KEY,
-    company_id    BIGINT       NOT NULL,
-    category_id   BIGINT       NOT NULL,
-    parent_org_id BIGINT       NULL,
-    name          VARCHAR(100) NOT NULL,
-    order_index   INT          NOT NULL,
-    is_active     BOOLEAN      NOT NULL DEFAULT TRUE,
-    created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    company_id         BIGINT       NOT NULL,
+    category_id        BIGINT       NOT NULL,
+    parent_org_id      BIGINT       NULL,
+    name               VARCHAR(100) NOT NULL,
+
+    order_index        INT          NULL, -- NOT NULL 제거
+    is_active          BOOLEAN      NOT NULL DEFAULT TRUE,
+
+    -- 활성 조직만 정렬 대상
+    active_order_index INT
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN is_active = TRUE THEN order_index
+                               ELSE NULL
+                               END
+                           ) STORED,
+
+    created_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_org_company
         FOREIGN KEY (company_id) REFERENCES company (id),
@@ -65,9 +76,12 @@ CREATE TABLE organization
     CONSTRAINT fk_org_parent
         FOREIGN KEY (parent_org_id) REFERENCES organization (id),
 
-    CONSTRAINT uk_org_sibling_order -- 형제 단위 정렬 충돌 방지
-        UNIQUE (company_id, parent_org_id, order_index),
-    CONSTRAINT uk_org_sibling_name  -- 형제 단위 이름 중복 방지
+    -- 활성 조직만 형제 단위 정렬 충돌 방지
+    CONSTRAINT uk_org_active_sibling_order
+        UNIQUE (company_id, parent_org_id, active_order_index),
+
+    -- 형제 단위 이름 중복 방지 (활성 기준은 서비스 로직에서)
+    CONSTRAINT uk_org_sibling_name
         UNIQUE (company_id, parent_org_id, name)
 ) ENGINE = InnoDB;
 

--- a/sql/insert.sql
+++ b/sql/insert.sql
@@ -606,22 +606,21 @@ VALUES
 (@c1, 'OF-046', '1046', '01011114046', @c1_team_cs, @c1_rank_staff, @c1_pos_tm,
  '임동혁', 'test20@test.com', @pw,
  'EMPLOYEE', 'MALE', '1999-07-07', 'REGULAR', 'ACTIVE', 'WORKING', '2023-07-01', NOW(), NOW())
-ON DUPLICATE KEY UPDATE
-                     internal_phone=VALUES(internal_phone),
-                     phone=VALUES(phone),
-                     org_id=VALUES(org_id),
-                     hr_rank_id=VALUES(hr_rank_id),
-                     position_category_id=VALUES(position_category_id),
-                     name=VALUES(name),
-                     password=VALUES(password),
-                     role=VALUES(role),
-                     gender=VALUES(gender),
-                     birth_date=VALUES(birth_date),
-                     employment_type=VALUES(employment_type),
-                     status=VALUES(status),
-                     work_status=VALUES(work_status),
-                     hire_date=VALUES(hire_date),
-                     updated_at=NOW();
+ON DUPLICATE KEY UPDATE internal_phone=VALUES(internal_phone),
+                        phone=VALUES(phone),
+                        org_id=VALUES(org_id),
+                        hr_rank_id=VALUES(hr_rank_id),
+                        position_category_id=VALUES(position_category_id),
+                        name=VALUES(name),
+                        password=VALUES(password),
+                        role=VALUES(role),
+                        gender=VALUES(gender),
+                        birth_date=VALUES(birth_date),
+                        employment_type=VALUES(employment_type),
+                        status=VALUES(status),
+                        work_status=VALUES(work_status),
+                        hire_date=VALUES(hire_date),
+                        updated_at=NOW();
 
 /* =========================
    [COMPANY #2] TechSolution 테크솔루션
@@ -853,7 +852,9 @@ SELECT @c2,
        @c2_cat_team,
        (SELECT id
         FROM organization
-        WHERE company_id = @c2 AND parent_org_id = @c2_hq_platform AND name = '플랫폼운영부'
+        WHERE company_id = @c2
+          AND parent_org_id = @c2_hq_platform
+          AND name = '플랫폼운영부'
         LIMIT 1),
        '운영팀',
        1,
@@ -865,7 +866,9 @@ SELECT @c2,
        @c2_cat_team,
        (SELECT id
         FROM organization
-        WHERE company_id = @c2 AND parent_org_id = @c2_hq_platform AND name = '플랫폼운영부'
+        WHERE company_id = @c2
+          AND parent_org_id = @c2_hq_platform
+          AND name = '플랫폼운영부'
         LIMIT 1),
        '모니터링팀',
        2,
@@ -898,7 +901,9 @@ SELECT @c2,
         WHERE company_id = @c2
           AND parent_org_id = (SELECT id
                                FROM organization
-                               WHERE company_id = @c2 AND parent_org_id = @c2_hq_support AND name = '재무부'
+                               WHERE company_id = @c2
+                                 AND parent_org_id = @c2_hq_support
+                                 AND name = '재무부'
                                LIMIT 1)
           AND name = '재무부'
         LIMIT 1),
@@ -1414,7 +1419,9 @@ SELECT @c3,
        @c3_cat_team,
        (SELECT id
         FROM organization
-        WHERE company_id = @c3 AND parent_org_id = @c3_hq_platform AND name = '플랫폼운영부'
+        WHERE company_id = @c3
+          AND parent_org_id = @c3_hq_platform
+          AND name = '플랫폼운영부'
         LIMIT 1),
        '운영팀',
        1,
@@ -1426,7 +1433,9 @@ SELECT @c3,
        @c3_cat_team,
        (SELECT id
         FROM organization
-        WHERE company_id = @c3 AND parent_org_id = @c3_hq_platform AND name = '플랫폼운영부'
+        WHERE company_id = @c3
+          AND parent_org_id = @c3_hq_platform
+          AND name = '플랫폼운영부'
         LIMIT 1),
        '모니터링팀',
        2,
@@ -1459,7 +1468,9 @@ SELECT @c3,
         WHERE company_id = @c3
           AND parent_org_id = (SELECT id
                                FROM organization
-                               WHERE company_id = @c3 AND parent_org_id = @c3_hq_support AND name = '재무부'
+                               WHERE company_id = @c3
+                                 AND parent_org_id = @c3_hq_support
+                                 AND name = '재무부'
                                LIMIT 1)
           AND name = '재무부'
         LIMIT 1),
@@ -1749,7 +1760,6 @@ ON DUPLICATE KEY UPDATE internal_phone=VALUES(internal_phone),
 COMMIT;
 
 
-
 -- 종훈 --
 use orbitflow;
 
@@ -1848,19 +1858,21 @@ VALUES
 
 
 
-INSERT INTO leave_type (type_name, is_countable, description) VALUES
-                                                                  ('연차', true, '법정 유급 연차 휴가'),
-                                                                  ('오전반차', true, '09:00 ~ 13:00 사용'),
-                                                                  ('오후반차', true, '14:00 ~ 18:00 사용'),
-                                                                  ('병가', false, '질병 또는 부상으로 인한 휴무');
+INSERT INTO leave_type (type_name, is_countable, description)
+VALUES ('연차', true, '법정 유급 연차 휴가'),
+       ('오전반차', true, '09:00 ~ 13:00 사용'),
+       ('오후반차', true, '14:00 ~ 18:00 사용'),
+       ('병가', false, '질병 또는 부상으로 인한 휴무');
 
 
-INSERT INTO attendance_rule (company_id, name, default_start_time, default_end_time, default_break_minutes, late_threshold_min, is_default)
+INSERT INTO attendance_rule (company_id, name, default_start_time, default_end_time, default_break_minutes,
+                             late_threshold_min, is_default)
 VALUES (1, 'OrbitFlow 기본 근무규칙', '09:00:00', '18:00:00', 60, 10, true);
 
 
 -- 연차 부여 이력 (정기 및 월별)
-INSERT INTO grant_history (employee_id, company_id, grant_date, granted_days, grant_type, created_at) VALUES
+INSERT INTO grant_history (employee_id, company_id, grant_date, granted_days, grant_type, created_at)
+VALUES
 -- 이준호: 1월 정기 부여
 (10, 1, '2025-01-01', 15.0, 'ANNUAL_REGULAR', '2025-01-01 09:00:00'),
 -- 김나연: 1월 정기 부여
@@ -1872,17 +1884,20 @@ INSERT INTO grant_history (employee_id, company_id, grant_date, granted_days, gr
 (16, 1, '2025-12-10', 1.0, 'REWARD_LEAVE', '2025-12-10 14:00:00');
 
 -- 사원별 2025년도 연차 잔합 상황 (ID 10, 11, 14, 15, 16)
-INSERT INTO leave_balance (company_id, employee_id, year, total_granted, remaining_days) VALUES
-                                                                                             (1, 10, 2025, 15.0, 11.5), -- 15개 중 3.5개 사용 (12월 현재)
-                                                                                             (1, 11, 2025, 15.0, 14.0), -- 15개 중 1개 사용
-                                                                                             (1, 14, 2025, 15.0, 15.0), -- 미사용자
+INSERT INTO leave_balance (company_id, employee_id, year, total_granted, remaining_days)
+VALUES (1, 10, 2025, 15.0, 11.5), -- 15개 중 3.5개 사용 (12월 현재)
+       (1, 11, 2025, 15.0, 14.0), -- 15개 중 1개 사용
+       (1, 14, 2025, 15.0, 15.0), -- 미사용자
 
-                                                                                             (1, 15, 2025, 11.0, 10.5), -- 신입사원 (매달 1개씩 총 11개 부여됨)
+       (1, 15, 2025, 11.0, 10.5), -- 신입사원 (매달 1개씩 총 11개 부여됨)
 
-                                                                                             (1, 16, 2025, 15.0, 13.0)  -- 15개 중 2개 사용
+       (1, 16, 2025, 15.0, 13.0);
+-- 15개 중 2개 사용
 
 -- 실제 휴가 사용 기록 (결재 완료 건들)
-INSERT INTO attendance_record (employee_id, company_id, start_date, end_date, days, type_id, status, approved_at, created_at) VALUES
+INSERT INTO attendance_record (employee_id, company_id, start_date, end_date, days, type_id, status, approved_at,
+                               created_at)
+VALUES
 -- 이준호: 11월 7일(1일), 12월 12일(1일) 연차 사용
 (10, 1, '2025-11-07', '2025-11-07', 1.0, 1, 'APPROVED', '2025-11-05 15:00:00', '2025-11-04 10:00:00'),
 (10, 1, '2025-12-12', '2025-12-12', 1.0, 1, 'APPROVED', '2025-12-10 11:00:00', '2025-12-09 13:00:00'),
@@ -1895,29 +1910,29 @@ INSERT INTO attendance_record (employee_id, company_id, start_date, end_date, da
 
 
 
-INSERT INTO attendance (company_id, employee_id, work_date, commute_at, leave_at, status, applied_rule_id, is_corrected) VALUES
-                                                                                                                             (1, 10, '2025-11-03', '2025-11-03 08:52:00', '2025-11-03 18:05:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-04', '2025-11-04 09:12:00', '2025-11-04 18:10:00', 'LATE', 1, 0),
-                                                                                                                             (1, 10, '2025-11-05', '2025-11-05 08:50:00', '2025-11-05 18:02:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-06', '2025-11-06 09:05:00', '2025-11-06 18:00:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-07', NULL, NULL, 'ABSENT', 1, 0),
-                                                                                                                             (1, 10, '2025-11-10', '2025-11-10 08:45:00', '2025-11-10 18:30:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-11', '2025-11-11 08:59:00', '2025-11-11 18:01:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-12', '2025-11-12 09:15:00', '2025-11-12 18:05:00', 'LATE', 1, 0),
-                                                                                                                             (1, 10, '2025-11-13', '2025-11-13 08:50:00', '2025-11-13 18:00:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-14', '2025-11-14 08:30:00', '2025-11-14 18:00:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-11-17', '2025-11-17 09:40:00', '2025-11-17 19:00:00', 'LATE', 1, 0),
-                                                                                                                             (1, 10, '2025-11-18', NULL, NULL, 'ABSENT', 1, 0),
-                                                                                                                             (1, 10, '2025-11-19', '2025-11-19 08:55:00', '2025-11-19 18:10:00', 'ON_TIME', 1, 1),
-                                                                                                                             (1, 10, '2025-12-15', '2025-12-15 08:50:00', '2025-12-15 18:00:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-16', '2025-12-16 09:05:30', '2025-12-16 18:05:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-17', '2025-12-17 08:40:20', '2025-12-17 18:10:11', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-18', '2025-12-18 09:45:00', '2025-12-18 18:50:00', 'LATE', 1, 0),
-                                                                                                                             (1, 10, '2025-12-19', '2025-12-19 08:55:00', '2025-12-19 18:01:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-22', '2025-12-22 08:58:00', '2025-12-22 18:05:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-23', '2025-12-23 09:03:00', '2025-12-23 18:00:00', 'ON_TIME', 1, 0),
-                                                                                                                             (1, 10, '2025-12-25', '2025-12-25 09:00:00', '2025-12-25 18:00:00', 'ON_TIME', 1, 1),
-                                                                                                                             (1, 10, '2025-12-26', '2025-12-26 08:50:00', '2025-12-26 18:10:00', 'ON_TIME', 1, 0);
+INSERT INTO attendance (company_id, employee_id, work_date, commute_at, leave_at, status, applied_rule_id, is_corrected)
+VALUES (1, 10, '2025-11-03', '2025-11-03 08:52:00', '2025-11-03 18:05:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-04', '2025-11-04 09:12:00', '2025-11-04 18:10:00', 'LATE', 1, 0),
+       (1, 10, '2025-11-05', '2025-11-05 08:50:00', '2025-11-05 18:02:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-06', '2025-11-06 09:05:00', '2025-11-06 18:00:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-07', NULL, NULL, 'ABSENT', 1, 0),
+       (1, 10, '2025-11-10', '2025-11-10 08:45:00', '2025-11-10 18:30:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-11', '2025-11-11 08:59:00', '2025-11-11 18:01:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-12', '2025-11-12 09:15:00', '2025-11-12 18:05:00', 'LATE', 1, 0),
+       (1, 10, '2025-11-13', '2025-11-13 08:50:00', '2025-11-13 18:00:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-14', '2025-11-14 08:30:00', '2025-11-14 18:00:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-11-17', '2025-11-17 09:40:00', '2025-11-17 19:00:00', 'LATE', 1, 0),
+       (1, 10, '2025-11-18', NULL, NULL, 'ABSENT', 1, 0),
+       (1, 10, '2025-11-19', '2025-11-19 08:55:00', '2025-11-19 18:10:00', 'ON_TIME', 1, 1),
+       (1, 10, '2025-12-15', '2025-12-15 08:50:00', '2025-12-15 18:00:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-16', '2025-12-16 09:05:30', '2025-12-16 18:05:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-17', '2025-12-17 08:40:20', '2025-12-17 18:10:11', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-18', '2025-12-18 09:45:00', '2025-12-18 18:50:00', 'LATE', 1, 0),
+       (1, 10, '2025-12-19', '2025-12-19 08:55:00', '2025-12-19 18:01:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-22', '2025-12-22 08:58:00', '2025-12-22 18:05:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-23', '2025-12-23 09:03:00', '2025-12-23 18:00:00', 'ON_TIME', 1, 0),
+       (1, 10, '2025-12-25', '2025-12-25 09:00:00', '2025-12-25 18:00:00', 'ON_TIME', 1, 1),
+       (1, 10, '2025-12-26', '2025-12-26 08:50:00', '2025-12-26 18:10:00', 'ON_TIME', 1, 0);
 
 
 
@@ -1931,246 +1946,309 @@ INSERT INTO attendance (company_id, employee_id, work_date, commute_at, leave_at
 -- 1. 카테고리 데이터 (ID: 1 ~ 20번 생성 가정)
 -- ==========================================
 -- 1~10: OrbitFlow(C1), 11~16: TechSolution(C2), 17~20: GlobalService(C3)
-INSERT INTO board_category (company_id, organization_id, board_name, board_type, is_activated, comment_activated) VALUES
-                                                                                                                      (1, NULL, '전사 공지사항', 'FREE', 1, 1), (1, NULL, '자유 게시판', 'FREE', 1, 1), (1, NULL, '사내 건의함', 'FREE', 1, 1),
-                                                                                                                      (1, NULL, '칭찬 게시판', 'FREE', 1, 1), (1, NULL, '자기계발/스터디', 'FREE', 1, 1), (1, 1, '백엔드 기술 공유', 'FREE', 1, 1),
-                                                                                                                      (1, 2, '프론트엔드 위키', 'FREE', 1, 1), (1, 3, 'HR 행정 지원', 'FREE', 1, 1), (1, 4, '영업 전략 및 성과', 'FREE', 1, 1),
-                                                                                                                      (1, 5, '마케팅 에셋 보관함', 'FREE', 1, 1), (2, NULL, 'TS 공지사항', 'FREE', 1, 1), (2, NULL, '기술 공유 라운지', 'FREE', 1, 1),
-                                                                                                                      (2, NULL, '사내 중고 장터', 'FREE', 1, 1), (2, 6, 'AI 모델 연구소', 'FREE', 1, 1), (2, 7, '플랫폼부', 'FREE', 1, 1),
-                                                                                                                      (2, 8, '인프라팀', 'FREE', 1, 1), (3, NULL, 'Global Notice', 'FREE', 1, 1), (3, NULL, 'General Forum', 'FREE', 1, 1),
-                                                                                                                      (3, 9, 'Customer Feedback', 'FREE', 1, 1), (3, 10, 'Global Ad Campaign', 'FREE', 1, 1);
+INSERT INTO board_category (company_id, organization_id, board_name, board_type, is_activated, comment_activated)
+VALUES (1, NULL, '전사 공지사항', 'FREE', 1, 1),
+       (1, NULL, '자유 게시판', 'FREE', 1, 1),
+       (1, NULL, '사내 건의함', 'FREE', 1, 1),
+       (1, NULL, '칭찬 게시판', 'FREE', 1, 1),
+       (1, NULL, '자기계발/스터디', 'FREE', 1, 1),
+       (1, 1, '백엔드 기술 공유', 'FREE', 1, 1),
+       (1, 2, '프론트엔드 위키', 'FREE', 1, 1),
+       (1, 3, 'HR 행정 지원', 'FREE', 1, 1),
+       (1, 4, '영업 전략 및 성과', 'FREE', 1, 1),
+       (1, 5, '마케팅 에셋 보관함', 'FREE', 1, 1),
+       (2, NULL, 'TS 공지사항', 'FREE', 1, 1),
+       (2, NULL, '기술 공유 라운지', 'FREE', 1, 1),
+       (2, NULL, '사내 중고 장터', 'FREE', 1, 1),
+       (2, 6, 'AI 모델 연구소', 'FREE', 1, 1),
+       (2, 7, '플랫폼부', 'FREE', 1, 1),
+       (2, 8, '인프라팀', 'FREE', 1, 1),
+       (3, NULL, 'Global Notice', 'FREE', 1, 1),
+       (3, NULL, 'General Forum', 'FREE', 1, 1),
+       (3, 9, 'Customer Feedback', 'FREE', 1, 1),
+       (3, 10, 'Global Ad Campaign', 'FREE', 1, 1);
 
 -- ==========================================
 -- 2. 게시글 데이터 (120개)
 -- ==========================================
 -- 회사 1 (ID 1~20번 직원)
-INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count) VALUES
-                                                                                               (1, 1, '2025 상반기 타운홀 미팅 안내', '전사 성과 공유를 위한 미팅 안내입니다.', 50),
-                                                                                               (2, 1, '오늘 점심 파스타 어때요?', '로비 근처 새로 생긴 곳 가보고 싶네요.', 12),
-                                                                                               (6, 2, 'Java 21 가상 스레드 도입기', '처리 성능이 20% 향상되었습니다.', 45),
-                                                                                               (2, 2, '주말 등산 모임 구합니다', '북한산 가볍게 다녀오실 분?', 8),
-                                                                                               (7, 3, 'Next.js 14 서버 액션 활용법', '새로운 데이터 페칭 패턴을 공유합니다.', 33),
-                                                                                               (2, 3, '기계식 키보드 입문 추천', '저소음 적축이 사무실에서 쓰기 좋네요.', 21),
-                                                                                               (8, 4, '연차 보상비 지급 안내', '이번 달 급여에 포함되어 지급됩니다.', 100),
-                                                                                               (3, 4, '카페테리아 원두 교체 건의', '산미 없는 고소한 원두로 바꿔주세요.', 15),
-                                                                                               (9, 5, '오빗전자 계약 수주 성공', '영업팀 모두의 노력으로 큰 계약을 따냈습니다.', 88),
-                                                                                               (2, 5, '퇴근 후 치맥 하실 분?', '강남역 근처에서 번개 모임 합니다.', 10),
-                                                                                               (10, 6, '1월 광고 집행 리포트', '유튜브 광고 도달률이 목표치를 상회했습니다.', 42),
-                                                                                               (2, 6, '요즘 볼만한 넷플릭스 추천', '퇴근하고 정주행할 거 찾고 있어요.', 18),
-                                                                                               (4, 7, '프론트팀 김영희님 감사합니다', '급한 수정 건 빠르게 도와주셔서 감사합니다.', 55),
-                                                                                               (2, 7, '에어팟 잃어버리신 분?', '3층 탕비실에서 습득했습니다.', 30),
-                                                                                               (5, 8, '파이썬 데이터 스터디 모집', '판다스 라이브러리 기초부터 같이 공부해요.', 22),
-                                                                                               (2, 8, '건강검진 예약 꿀팁', '연초에 해야 사람도 적고 쾌적하네요.', 14),
-                                                                                               (1, 9, '사내 보안 교육 이수 요청', '이번 주 금요일까지 전 직원 필수입니다.', 77),
-                                                                                               (2, 9, '노트북 스탠드 추천해요', '거북목 방지에 이만한 게 없네요.', 25),
-                                                                                               (4, 10, '인프라팀 박철수님 고생하셨습니다', '주말 서버 점검 덕분에 무사히 넘겼네요.', 60),
-                                                                                               (2, 10, '사무실 근처 맛집 지도', '제가 직접 다 가보고 정리한 리스트입니다.', 52),
-                                                                                               (6, 11, 'Redis 캐시 전략 가이드', 'Write-through 방식 도입 주의사항 정리.', 28),
-                                                                                               (2, 11, '비타민 영양제 추천', '피곤할 땐 종합비타민이 최고네요.', 13),
-                                                                                               (7, 12, 'Tailwind CSS 컨벤션', '클래스 순서 정리 규칙을 공유합니다.', 31),
-                                                                                               (2, 12, '주말 캠핑 가시는 분?', '이번엔 강원도로 떠납니다.', 11),
-                                                                                               (8, 13, '육아휴직 복직 프로세스', '복직 전 상담 및 필요 서류 정리입니다.', 40),
-                                                                                               (2, 13, '회사 근처 요가 학원', '점심시간 활용하기 딱 좋아요.', 16),
-                                                                                               (9, 14, '글로벌 시장 영업 동향', '미국 시장 수요 예측 보고서 요약.', 44),
-                                                                                               (2, 14, '슬램덩크 영화 다시 보기', '다시 봐도 감동이네요.', 10),
-                                                                                               (10, 15, '브랜드 가이드라인 v2.0', '로고 사용 및 폰트 규정이 업데이트 되었습니다.', 38),
-                                                                                               (2, 15, '미세먼지 조심하세요', '공기가 안 좋네요. 마스크 필수입니다.', 12),
-                                                                                               (4, 16, '경영팀 김미나님 감사합니다', '법인카드 한도 증액 신속 처리 감사합니다.', 50),
-                                                                                               (2, 16, '독서 모임 모집', '한 달에 책 한 권 같이 읽어요.', 19),
-                                                                                               (3, 17, '화장실 핸드타월 교체 주기', '오후에는 금방 떨어지네요. 보충 부탁드려요.', 24),
-                                                                                               (2, 17, '러닝 크루 모집', '화요일 퇴근 후 사옥 근처 한 바퀴!', 22),
-                                                                                               (5, 18, 'AWS 자격증 취득 후기', 'SAA 시험 준비하시는 분들 팁 드립니다.', 37),
-                                                                                               (2, 18, '여행지 추천해주세요', '일본이랑 베트남 중 고민 중입니다.', 28),
-                                                                                               (1, 19, '임직원 명절 선물 설문', '올해는 어떤 품목이 좋을까요?', 110),
-                                                                                               (2, 19, '당근마켓 나눔', '사용감 적은 모니터 스탠드 드립니다.', 45),
-                                                                                               (4, 20, '인사팀 박지수님 칭찬합니다', '신규 복지 제도 설명 너무 친절했어요.', 58),
-                                                                                               (2, 20, '오늘 날씨 너무 좋네요', '창밖만 봐도 힐링되는 하루입니다.', 23);
+INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count)
+VALUES (1, 1, '2025 상반기 타운홀 미팅 안내', '전사 성과 공유를 위한 미팅 안내입니다.', 50),
+       (2, 1, '오늘 점심 파스타 어때요?', '로비 근처 새로 생긴 곳 가보고 싶네요.', 12),
+       (6, 2, 'Java 21 가상 스레드 도입기', '처리 성능이 20% 향상되었습니다.', 45),
+       (2, 2, '주말 등산 모임 구합니다', '북한산 가볍게 다녀오실 분?', 8),
+       (7, 3, 'Next.js 14 서버 액션 활용법', '새로운 데이터 페칭 패턴을 공유합니다.', 33),
+       (2, 3, '기계식 키보드 입문 추천', '저소음 적축이 사무실에서 쓰기 좋네요.', 21),
+       (8, 4, '연차 보상비 지급 안내', '이번 달 급여에 포함되어 지급됩니다.', 100),
+       (3, 4, '카페테리아 원두 교체 건의', '산미 없는 고소한 원두로 바꿔주세요.', 15),
+       (9, 5, '오빗전자 계약 수주 성공', '영업팀 모두의 노력으로 큰 계약을 따냈습니다.', 88),
+       (2, 5, '퇴근 후 치맥 하실 분?', '강남역 근처에서 번개 모임 합니다.', 10),
+       (10, 6, '1월 광고 집행 리포트', '유튜브 광고 도달률이 목표치를 상회했습니다.', 42),
+       (2, 6, '요즘 볼만한 넷플릭스 추천', '퇴근하고 정주행할 거 찾고 있어요.', 18),
+       (4, 7, '프론트팀 김영희님 감사합니다', '급한 수정 건 빠르게 도와주셔서 감사합니다.', 55),
+       (2, 7, '에어팟 잃어버리신 분?', '3층 탕비실에서 습득했습니다.', 30),
+       (5, 8, '파이썬 데이터 스터디 모집', '판다스 라이브러리 기초부터 같이 공부해요.', 22),
+       (2, 8, '건강검진 예약 꿀팁', '연초에 해야 사람도 적고 쾌적하네요.', 14),
+       (1, 9, '사내 보안 교육 이수 요청', '이번 주 금요일까지 전 직원 필수입니다.', 77),
+       (2, 9, '노트북 스탠드 추천해요', '거북목 방지에 이만한 게 없네요.', 25),
+       (4, 10, '인프라팀 박철수님 고생하셨습니다', '주말 서버 점검 덕분에 무사히 넘겼네요.', 60),
+       (2, 10, '사무실 근처 맛집 지도', '제가 직접 다 가보고 정리한 리스트입니다.', 52),
+       (6, 11, 'Redis 캐시 전략 가이드', 'Write-through 방식 도입 주의사항 정리.', 28),
+       (2, 11, '비타민 영양제 추천', '피곤할 땐 종합비타민이 최고네요.', 13),
+       (7, 12, 'Tailwind CSS 컨벤션', '클래스 순서 정리 규칙을 공유합니다.', 31),
+       (2, 12, '주말 캠핑 가시는 분?', '이번엔 강원도로 떠납니다.', 11),
+       (8, 13, '육아휴직 복직 프로세스', '복직 전 상담 및 필요 서류 정리입니다.', 40),
+       (2, 13, '회사 근처 요가 학원', '점심시간 활용하기 딱 좋아요.', 16),
+       (9, 14, '글로벌 시장 영업 동향', '미국 시장 수요 예측 보고서 요약.', 44),
+       (2, 14, '슬램덩크 영화 다시 보기', '다시 봐도 감동이네요.', 10),
+       (10, 15, '브랜드 가이드라인 v2.0', '로고 사용 및 폰트 규정이 업데이트 되었습니다.', 38),
+       (2, 15, '미세먼지 조심하세요', '공기가 안 좋네요. 마스크 필수입니다.', 12),
+       (4, 16, '경영팀 김미나님 감사합니다', '법인카드 한도 증액 신속 처리 감사합니다.', 50),
+       (2, 16, '독서 모임 모집', '한 달에 책 한 권 같이 읽어요.', 19),
+       (3, 17, '화장실 핸드타월 교체 주기', '오후에는 금방 떨어지네요. 보충 부탁드려요.', 24),
+       (2, 17, '러닝 크루 모집', '화요일 퇴근 후 사옥 근처 한 바퀴!', 22),
+       (5, 18, 'AWS 자격증 취득 후기', 'SAA 시험 준비하시는 분들 팁 드립니다.', 37),
+       (2, 18, '여행지 추천해주세요', '일본이랑 베트남 중 고민 중입니다.', 28),
+       (1, 19, '임직원 명절 선물 설문', '올해는 어떤 품목이 좋을까요?', 110),
+       (2, 19, '당근마켓 나눔', '사용감 적은 모니터 스탠드 드립니다.', 45),
+       (4, 20, '인사팀 박지수님 칭찬합니다', '신규 복지 제도 설명 너무 친절했어요.', 58),
+       (2, 20, '오늘 날씨 너무 좋네요', '창밖만 봐도 힐링되는 하루입니다.', 23);
 
 -- 회사 2 (ID 21~40번 직원)
-INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count) VALUES
-                                                                                               (11, 21, 'TS 신년 경영 비전 발표', '기술력으로 글로벌 1위를 달성합시다.', 90),
-                                                                                               (12, 21, '쿠버네티스 오토스케일링 적용', 'HPA 설정 최적화 가이드입니다.', 45),
-                                                                                               (13, 22, '로지텍 마우스 팔아요', '3개월 썼는데 깨끗합니다. 싸게 드려요.', 15),
-                                                                                               (14, 22, 'LLM 파인튜닝 실험 결과', '도메인 특화 학습 시 정확도가 향상되었습니다.', 52),
-                                                                                               (15, 23, '공통 API 게이트웨이 변경', '인증 방식이 OAuth2로 강화되었습니다.', 38),
-                                                                                               (11, 23, '사무실 자리 재배치 안내', '다음 주 주말에 대규모 이동이 있습니다.', 70),
-                                                                                               (16, 24, '클라우드 비용 절감 방안', '유휴 자원 정리로 월 15% 비용 절감.', 35),
-                                                                                               (12, 24, 'Grafana 대시보드 공유', '실시간 서버 상태 모니터링용 템플릿.', 22),
-                                                                                               (13, 25, '기계식 키보드 나눔', '오래됐지만 작동 잘 됩니다. 필요하신 분?', 20),
-                                                                                               (14, 25, 'Vision 모델 성능 개선', '객체 인식 속도 개선 사례 공유.', 44),
-                                                                                               (11, 26, '임직원 건강검진 캠페인', '대상자분들은 기한 내 예약 바랍니다.', 55),
-                                                                                               (15, 26, '로깅 라이브러리 v3 배포', '성능 향상 및 가독성이 개선되었습니다.', 29),
-                                                                                               (16, 27, 'DB 샤딩 도입 검토 보고', '데이터 증가에 따른 확장성 확보 전략.', 40),
-                                                                                               (12, 27, 'Git 컨벤션 통일 제안', '커밋 메시지 규칙을 하나로 정해봅시다.', 18),
-                                                                                               (13, 28, '데스크패드 팝니다', '새 제품인데 사이즈가 안 맞네요.', 12),
-                                                                                               (14, 28, 'Stable Diffusion 활용법', '사내 디자인 업무 효율화 방안 연구.', 36),
-                                                                                               (15, 29, 'UI 컴포넌트 라이브러리', '피그마와 매칭되는 리액트 컴포넌트 배포.', 48),
-                                                                                               (16, 29, '네트워크 보안 강화 조치', '외부 접속 시 VPN 필수 사용 적용.', 51),
-                                                                                               (12, 30, 'Go 언어 동시성 패턴', 'Channel과 Goroutine 효율적 활용법.', 25),
-                                                                                               (11, 30, '동호회 활동 지원 안내', '5인 이상 모임 시 활동비 지원됩니다.', 62),
-                                                                                               (14, 31, '데이터 라벨링 효율화', '자동 라벨링 툴 도입 후 속도 3배 향상.', 30),
-                                                                                               (12, 31, '파이썬 FastAPI 도입 후기', '기존 장고 대비 생산성 및 성능 비교.', 22),
-                                                                                               (15, 32, '모바일 웹 앱 최적화', '라이트하우스 점수 90점 달성 노하우.', 34),
-                                                                                               (13, 32, '스타벅스 기프티콘 교환', '다른 브랜드로 교환 원해요.', 11),
-                                                                                               (16, 33, 'K8s 트러블슈팅 사례', 'Ingress 설정 오류 해결기.', 39),
-                                                                                               (11, 33, '명절 귀성비 지원 공지', '이번 추석 귀성비가 지급될 예정입니다.', 120),
-                                                                                               (12, 34, '테스트 자동화 구축', 'Playwright를 이용한 E2E 테스트 자동화.', 27),
-                                                                                               (14, 34, 'RLHF 개념 정리', '강화 학습을 이용한 모델 튜닝 원리.', 21),
-                                                                                               (15, 35, '디자인 시스템 v1.5', '다크 모드 컬러 팔레트가 추가되었습니다.', 33),
-                                                                                               (13, 35, '아이패드 에어 4세대', '충전기 포함 풀박스입니다.', 50),
-                                                                                               (16, 36, 'Zabbix 모니터링 연동', '슬랙으로 실시간 장애 알림 연동 완료.', 28),
-                                                                                               (12, 36, 'Rust 입문 가이드', 'C++ 개발자가 본 Rust의 장단점.', 19),
-                                                                                               (11, 37, '주말 사옥 방역 안내', '토요일 09시부터 전체 방역 실시합니다.', 44),
-                                                                                               (14, 37, 'OCR 모델 성능 비교', 'Tesseract vs 사내 모델 성능 테스트.', 25),
-                                                                                               (15, 38, '공통 컴포넌트 사용 가이드', 'Select 및 Modal 컴포넌트 활용법.', 22),
-                                                                                               (13, 38, '캠핑 의자 팝니다', '가벼운 의자입니다.', 16),
-                                                                                               (16, 39, 'Docker 보안 취약점 점검', '이미지 스캐닝 결과 및 조치 사항.', 31),
-                                                                                               (12, 39, 'Kafka 스트림즈 활용', '실시간 데이터 파이프라인 구축 사례.', 26),
-                                                                                               (11, 40, '법정 의무 교육 미이수자 확인', '오늘 마감입니다. 확인 부탁드려요.', 88),
-                                                                                               (14, 40, '생성 AI 저작권 동향', '최신 가이드라인 정리.', 42);
+INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count)
+VALUES (11, 21, 'TS 신년 경영 비전 발표', '기술력으로 글로벌 1위를 달성합시다.', 90),
+       (12, 21, '쿠버네티스 오토스케일링 적용', 'HPA 설정 최적화 가이드입니다.', 45),
+       (13, 22, '로지텍 마우스 팔아요', '3개월 썼는데 깨끗합니다. 싸게 드려요.', 15),
+       (14, 22, 'LLM 파인튜닝 실험 결과', '도메인 특화 학습 시 정확도가 향상되었습니다.', 52),
+       (15, 23, '공통 API 게이트웨이 변경', '인증 방식이 OAuth2로 강화되었습니다.', 38),
+       (11, 23, '사무실 자리 재배치 안내', '다음 주 주말에 대규모 이동이 있습니다.', 70),
+       (16, 24, '클라우드 비용 절감 방안', '유휴 자원 정리로 월 15% 비용 절감.', 35),
+       (12, 24, 'Grafana 대시보드 공유', '실시간 서버 상태 모니터링용 템플릿.', 22),
+       (13, 25, '기계식 키보드 나눔', '오래됐지만 작동 잘 됩니다. 필요하신 분?', 20),
+       (14, 25, 'Vision 모델 성능 개선', '객체 인식 속도 개선 사례 공유.', 44),
+       (11, 26, '임직원 건강검진 캠페인', '대상자분들은 기한 내 예약 바랍니다.', 55),
+       (15, 26, '로깅 라이브러리 v3 배포', '성능 향상 및 가독성이 개선되었습니다.', 29),
+       (16, 27, 'DB 샤딩 도입 검토 보고', '데이터 증가에 따른 확장성 확보 전략.', 40),
+       (12, 27, 'Git 컨벤션 통일 제안', '커밋 메시지 규칙을 하나로 정해봅시다.', 18),
+       (13, 28, '데스크패드 팝니다', '새 제품인데 사이즈가 안 맞네요.', 12),
+       (14, 28, 'Stable Diffusion 활용법', '사내 디자인 업무 효율화 방안 연구.', 36),
+       (15, 29, 'UI 컴포넌트 라이브러리', '피그마와 매칭되는 리액트 컴포넌트 배포.', 48),
+       (16, 29, '네트워크 보안 강화 조치', '외부 접속 시 VPN 필수 사용 적용.', 51),
+       (12, 30, 'Go 언어 동시성 패턴', 'Channel과 Goroutine 효율적 활용법.', 25),
+       (11, 30, '동호회 활동 지원 안내', '5인 이상 모임 시 활동비 지원됩니다.', 62),
+       (14, 31, '데이터 라벨링 효율화', '자동 라벨링 툴 도입 후 속도 3배 향상.', 30),
+       (12, 31, '파이썬 FastAPI 도입 후기', '기존 장고 대비 생산성 및 성능 비교.', 22),
+       (15, 32, '모바일 웹 앱 최적화', '라이트하우스 점수 90점 달성 노하우.', 34),
+       (13, 32, '스타벅스 기프티콘 교환', '다른 브랜드로 교환 원해요.', 11),
+       (16, 33, 'K8s 트러블슈팅 사례', 'Ingress 설정 오류 해결기.', 39),
+       (11, 33, '명절 귀성비 지원 공지', '이번 추석 귀성비가 지급될 예정입니다.', 120),
+       (12, 34, '테스트 자동화 구축', 'Playwright를 이용한 E2E 테스트 자동화.', 27),
+       (14, 34, 'RLHF 개념 정리', '강화 학습을 이용한 모델 튜닝 원리.', 21),
+       (15, 35, '디자인 시스템 v1.5', '다크 모드 컬러 팔레트가 추가되었습니다.', 33),
+       (13, 35, '아이패드 에어 4세대', '충전기 포함 풀박스입니다.', 50),
+       (16, 36, 'Zabbix 모니터링 연동', '슬랙으로 실시간 장애 알림 연동 완료.', 28),
+       (12, 36, 'Rust 입문 가이드', 'C++ 개발자가 본 Rust의 장단점.', 19),
+       (11, 37, '주말 사옥 방역 안내', '토요일 09시부터 전체 방역 실시합니다.', 44),
+       (14, 37, 'OCR 모델 성능 비교', 'Tesseract vs 사내 모델 성능 테스트.', 25),
+       (15, 38, '공통 컴포넌트 사용 가이드', 'Select 및 Modal 컴포넌트 활용법.', 22),
+       (13, 38, '캠핑 의자 팝니다', '가벼운 의자입니다.', 16),
+       (16, 39, 'Docker 보안 취약점 점검', '이미지 스캐닝 결과 및 조치 사항.', 31),
+       (12, 39, 'Kafka 스트림즈 활용', '실시간 데이터 파이프라인 구축 사례.', 26),
+       (11, 40, '법정 의무 교육 미이수자 확인', '오늘 마감입니다. 확인 부탁드려요.', 88),
+       (14, 40, '생성 AI 저작권 동향', '최신 가이드라인 정리.', 42);
 
 -- 회사 3 (ID 41~60번 직원)
-INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count) VALUES
-                                                                                               (17, 41, 'Q1 Global Strategy', 'We aim to expand our service in SEA region.', 150),
-                                                                                               (18, 41, 'Any soccer fans here?', 'Lets watch the game together tonight.', 30),
-                                                                                               (19, 42, 'App Review Analysis', 'Users like the new UI but report some bugs.', 60),
-                                                                                               (18, 42, 'New cafe open nearby', 'The coffee there is amazing.', 25),
-                                                                                               (20, 43, 'YouTube Ad Performance', 'CTR increased by 15% in India market.', 40),
-                                                                                               (17, 43, 'Holiday schedule in US office', 'Please check the vacation dates.', 90),
-                                                                                               (19, 44, 'CS Response Time Goal', 'We need to reduce it below 2 hours.', 33),
-                                                                                               (18, 44, 'Lost my sunglasses', 'Did anyone see them in the lobby?', 12),
-                                                                                               (20, 45, 'New Banner Designs', 'Visual assets for Summer Sale is ready.', 55),
-                                                                                               (18, 45, 'Flight ticket deals', 'I found a great price for Tokyo!', 41),
-                                                                                               (17, 46, 'Office Renovation Plan', 'Starting next month on 5th floor.', 82),
-                                                                                               (19, 46, 'B2B Client Feedback', 'High demand for custom dashboard features.', 49),
-                                                                                               (20, 47, 'Social Media Strategy', 'Focusing on TikTok for younger audience.', 37),
-                                                                                               (18, 47, 'Gym membership discount', 'Group discount available for us.', 22),
-                                                                                               (17, 48, 'New Expense Policy', 'Updates on travel budget and receipts.', 110),
-                                                                                               (19, 48, 'User Satisfaction Survey', 'Our NPS reached 70 last month.', 53),
-                                                                                               (20, 49, 'Influencer Marketing List', 'Selected 5 influencers for UK market.', 44),
-                                                                                               (18, 49, 'Weather is getting cold', 'Take care of your health everyone.', 15),
-                                                                                               (17, 50, 'Security Awareness Month', 'Watch the training video by Friday.', 77),
-                                                                                               (19, 50, 'Retention Rate Improvement', 'Ideas on how to keep users active.', 38),
-                                                                                               (20, 51, 'Q4 Budget Allocation', 'Shifting more funds to video ads.', 46),
-                                                                                               (18, 51, 'Running club meeting', 'Join us for a 5k run tomorrow.', 21),
-                                                                                               (17, 52, 'New Hire Welcome', 'Welcome Sarah to the Design team!', 65),
-                                                                                               (19, 52, 'iOS Crash Report', 'Fixed the login issue for iOS 17.', 55),
-                                                                                               (20, 53, 'Google Search Ads', 'Optimizing keywords for Japan market.', 42),
-                                                                                               (18, 53, 'Anyone for a hike?', 'Going to Namsan this weekend.', 19),
-                                                                                               (17, 54, 'Internal Audit Result', 'We passed all security requirements.', 58),
-                                                                                               (19, 54, 'Premium Plan Inquiry', 'Enterprise clients asking for SSO.', 34),
-                                                                                               (20, 55, 'Podcast Sponsoring', 'Launching our first podcast ad soon.', 27),
-                                                                                               (18, 55, 'Best Ramen in town', 'Just tried this new place, 10/10.', 52),
-                                                                                               (17, 56, 'CEO Townhall Meeting', 'Join via Zoom next Wednesday.', 130),
-                                                                                               (19, 56, 'Dark Mode Feedback', 'Users love it but need better contrast.', 41),
-                                                                                               (20, 57, 'Localizing Content', 'Tips for marketing in Latin America.', 39),
-                                                                                               (18, 57, 'Ski trip interest?', 'Planning for January, let me know.', 24),
-                                                                                               (17, 58, 'Sustainability Initiative', 'Office is going paperless from Q2.', 66),
-                                                                                               (19, 58, 'Feature Request: Export', 'Many users want PDF export for reports.', 37),
-                                                                                               (20, 59, 'A/B Testing Results', 'Red button has 10% higher conversion.', 51),
-                                                                                               (18, 59, 'Merry Christmas!', 'Hope everyone has a wonderful holiday.', 100),
-                                                                                               (17, 60, 'Annual Performance Review', 'Please fill out your self-evaluation.', 85),
-                                                                                               (19, 60, 'Voice of Customer', 'Monthly summary of common complaints.', 47);
+INSERT INTO board (board_category_id, employee_id, board_title, board_content, view_count)
+VALUES (17, 41, 'Q1 Global Strategy', 'We aim to expand our service in SEA region.', 150),
+       (18, 41, 'Any soccer fans here?', 'Lets watch the game together tonight.', 30),
+       (19, 42, 'App Review Analysis', 'Users like the new UI but report some bugs.', 60),
+       (18, 42, 'New cafe open nearby', 'The coffee there is amazing.', 25),
+       (20, 43, 'YouTube Ad Performance', 'CTR increased by 15% in India market.', 40),
+       (17, 43, 'Holiday schedule in US office', 'Please check the vacation dates.', 90),
+       (19, 44, 'CS Response Time Goal', 'We need to reduce it below 2 hours.', 33),
+       (18, 44, 'Lost my sunglasses', 'Did anyone see them in the lobby?', 12),
+       (20, 45, 'New Banner Designs', 'Visual assets for Summer Sale is ready.', 55),
+       (18, 45, 'Flight ticket deals', 'I found a great price for Tokyo!', 41),
+       (17, 46, 'Office Renovation Plan', 'Starting next month on 5th floor.', 82),
+       (19, 46, 'B2B Client Feedback', 'High demand for custom dashboard features.', 49),
+       (20, 47, 'Social Media Strategy', 'Focusing on TikTok for younger audience.', 37),
+       (18, 47, 'Gym membership discount', 'Group discount available for us.', 22),
+       (17, 48, 'New Expense Policy', 'Updates on travel budget and receipts.', 110),
+       (19, 48, 'User Satisfaction Survey', 'Our NPS reached 70 last month.', 53),
+       (20, 49, 'Influencer Marketing List', 'Selected 5 influencers for UK market.', 44),
+       (18, 49, 'Weather is getting cold', 'Take care of your health everyone.', 15),
+       (17, 50, 'Security Awareness Month', 'Watch the training video by Friday.', 77),
+       (19, 50, 'Retention Rate Improvement', 'Ideas on how to keep users active.', 38),
+       (20, 51, 'Q4 Budget Allocation', 'Shifting more funds to video ads.', 46),
+       (18, 51, 'Running club meeting', 'Join us for a 5k run tomorrow.', 21),
+       (17, 52, 'New Hire Welcome', 'Welcome Sarah to the Design team!', 65),
+       (19, 52, 'iOS Crash Report', 'Fixed the login issue for iOS 17.', 55),
+       (20, 53, 'Google Search Ads', 'Optimizing keywords for Japan market.', 42),
+       (18, 53, 'Anyone for a hike?', 'Going to Namsan this weekend.', 19),
+       (17, 54, 'Internal Audit Result', 'We passed all security requirements.', 58),
+       (19, 54, 'Premium Plan Inquiry', 'Enterprise clients asking for SSO.', 34),
+       (20, 55, 'Podcast Sponsoring', 'Launching our first podcast ad soon.', 27),
+       (18, 55, 'Best Ramen in town', 'Just tried this new place, 10/10.', 52),
+       (17, 56, 'CEO Townhall Meeting', 'Join via Zoom next Wednesday.', 130),
+       (19, 56, 'Dark Mode Feedback', 'Users love it but need better contrast.', 41),
+       (20, 57, 'Localizing Content', 'Tips for marketing in Latin America.', 39),
+       (18, 57, 'Ski trip interest?', 'Planning for January, let me know.', 24),
+       (17, 58, 'Sustainability Initiative', 'Office is going paperless from Q2.', 66),
+       (19, 58, 'Feature Request: Export', 'Many users want PDF export for reports.', 37),
+       (20, 59, 'A/B Testing Results', 'Red button has 10% higher conversion.', 51),
+       (18, 59, 'Merry Christmas!', 'Hope everyone has a wonderful holiday.', 100),
+       (17, 60, 'Annual Performance Review', 'Please fill out your self-evaluation.', 85),
+       (19, 60, 'Voice of Customer', 'Monthly summary of common complaints.', 47);
 
 -- ==========================================
 -- 3. 댓글 데이터 (120개)
 -- ==========================================
-INSERT INTO comment (board_id, employee_id, comment_content) VALUES
-                                                                 (1, 2, '이번에도 온라인 생중계 해주시나요?'), (1, 21, '미래가 기대되는 발표네요.'),
-                                                                 (2, 3, '저요! 파스타 완전 좋아합니다.'), (2, 22, '저도 끼워주세요!'),
-                                                                 (3, 1, '성능 향상 폭이 생각보다 크네요.'), (3, 23, '서버 액션 보안은 괜찮을까요?'),
-                                                                 (4, 4, '저는 초보인데 따라갈 수 있을까요?'), (4, 24, '저도 같이 가고 싶어요.'),
-                                                                 (5, 5, '기존 API 라우트보다 편한 것 같아요.'), (5, 25, '코드가 훨씬 깔끔해졌네요.'),
-                                                                 (6, 6, '무접점도 한 번 써보시면 좋습니다.'), (6, 26, '저도 적축 쓰는데 대만족!'),
-                                                                 (7, 7, '감사합니다. 기다리던 소식입니다.'), (7, 27, '연차 보상비 최고!'),
-                                                                 (8, 8, '동의합니다. 이번 원두는 너무 셔요.'), (8, 28, '저도 건의하려고 했습니다.'),
-                                                                 (9, 9, '영업팀 정말 축하드립니다.'), (9, 29, '회식 가나요?'),
-                                                                 (10, 10, '저도 가고 싶지만 선약이 있네요.'), (10, 30, '다음엔 꼭 같이 가요.'),
-                                                                 (11, 11, '수치들이 아주 긍정적이네요.'), (11, 31, '마케팅팀 고생 많으셨습니다.'),
-                                                                 (12, 12, '다큐멘터리 재밌더라고요.'), (12, 32, '저도 그거 봤어요!'),
-                                                                 (13, 13, '영희님 정말 천사시죠! 인정합니다.'), (13, 33, '영희님 칭찬 릴레이네요.'),
-                                                                 (14, 14, '앗 제 친구가 찾고 있었는데 물어볼게요.'), (14, 34, '주인분 꼭 찾으시길!'),
-                                                                 (15, 15, '비개발자도 참여하고 싶어요.'), (15, 35, '누구나 환영입니다.'),
-                                                                 (16, 16, '내일부터 바로 예약 잡아야겠네요.'), (16, 36, '저도 방금 예약했습니다.'),
-                                                                 (17, 17, '방금 완료했습니다. 서두르세요!'), (17, 37, '보안 교육 클리어!'),
-                                                                 (18, 18, '저도 그거 쓰는데 거북목 좋아졌어요.'), (18, 38, '공구하고 싶을 정도네요.'),
-                                                                 (19, 19, '철수님 덕분에 아침이 평화롭네요.'), (19, 39, '철수님 최고!'),
-                                                                 (20, 20, '리스트 공유 감사합니다!'), (20, 40, '내일 점심은 여기로 가야겠네요.'),
-                                                                 (41, 41, 'Great vision for TS!'), (41, 1, '화이팅입니다!'),
-                                                                 (42, 42, '이게 정석이죠. 고생하셨습니다.'), (42, 2, '기술 공유 감사합니다.'),
-                                                                 (43, 43, '직거래 가능한가요?'), (43, 3, '상태 좋아 보이네요.'),
-                                                                 (44, 44, 'Very interesting results.'), (44, 4, 'AI팀 응원합니다.'),
-                                                                 (45, 45, '인증 로직 확인했습니다.'), (45, 5, '보안이 강화됐네요.'),
-                                                                 (46, 46, '창가 자리 가고 싶어요 ㅎㅎ'), (46, 6, '이사 가기 번거롭겠어요.'),
-                                                                 (47, 47, '금액이 상당하겠는데요?'), (47, 7, '비용 절감 대단합니다.'),
-                                                                 (48, 48, '제 대시보드에도 적용해보고 싶어요.'), (48, 8, '템플릿 공유 부탁드려요.'),
-                                                                 (49, 49, '나눔 감사합니다! 쪽지 드렸어요.'), (49, 9, '저도 줄 서봅니다.'),
-                                                                 (50, 50, '정말 놀라운 속도네요.'), (50, 10, '알고리즘이 궁금합니다.'),
-                                                                 (81, 41, 'Exciting goals.'), (81, 11, 'SEA market is huge.'),
-                                                                 (82, 42, 'I love soccer! Where?'), (82, 12, 'Count me in!'),
-                                                                 (83, 43, 'Bugs fixed yet?'), (83, 13, 'Feedback is noted.'),
-                                                                 (84, 44, 'Coffee on me today.'), (84, 14, 'Thanks for the latte.'),
-                                                                 (85, 45, 'India market data?'), (85, 15, 'Growth is visible.'),
-                                                                 (86, 46, 'Vacation dates confirmed.'), (86, 16, 'Check the email.'),
-                                                                 (87, 47, 'Hard goal, but possible.'), (87, 17, 'Let s do it.'),
-                                                                 (88, 48, 'I saw them in lobby.'), (88, 18, 'Front desk has them.'),
-                                                                 (89, 49, 'Visuals are fresh.'), (89, 19, 'Nice design work.'),
-                                                                 (90, 50, 'Booked Tokyo flight!'), (90, 20, 'Enjoy your trip!'),
-                                                                 (91, 51, 'Construction is noisy.'), (91, 21, 'Pardon the mess.'),
-                                                                 (92, 52, 'SSO is needed for B2B.'), (92, 22, 'Working on it.'),
-                                                                 (93, 53, 'TikTok branding is key.'), (93, 23, 'Gen Z target!'),
-                                                                 (94, 54, 'GS2025 code works.'), (94, 24, 'Joining the gym too.'),
-                                                                 (95, 55, 'Policy update noted.'), (95, 25, 'Got the email.'),
-                                                                 (96, 56, '80 NPS is the target.'), (96, 26, 'We can reach it.'),
-                                                                 (97, 57, 'UK list is ready.'), (97, 27, 'Good candidates.'),
-                                                                 (98, 58, 'Stay warm folks.'), (98, 28, 'Winter is here.'),
-                                                                 (99, 59, 'Security video done.'), (99, 29, 'Stay safe online.'),
-                                                                 (100, 60, 'Retention is vital.'), (100, 30, 'New ideas needed.');
+INSERT INTO comment (board_id, employee_id, comment_content)
+VALUES (1, 2, '이번에도 온라인 생중계 해주시나요?'),
+       (1, 21, '미래가 기대되는 발표네요.'),
+       (2, 3, '저요! 파스타 완전 좋아합니다.'),
+       (2, 22, '저도 끼워주세요!'),
+       (3, 1, '성능 향상 폭이 생각보다 크네요.'),
+       (3, 23, '서버 액션 보안은 괜찮을까요?'),
+       (4, 4, '저는 초보인데 따라갈 수 있을까요?'),
+       (4, 24, '저도 같이 가고 싶어요.'),
+       (5, 5, '기존 API 라우트보다 편한 것 같아요.'),
+       (5, 25, '코드가 훨씬 깔끔해졌네요.'),
+       (6, 6, '무접점도 한 번 써보시면 좋습니다.'),
+       (6, 26, '저도 적축 쓰는데 대만족!'),
+       (7, 7, '감사합니다. 기다리던 소식입니다.'),
+       (7, 27, '연차 보상비 최고!'),
+       (8, 8, '동의합니다. 이번 원두는 너무 셔요.'),
+       (8, 28, '저도 건의하려고 했습니다.'),
+       (9, 9, '영업팀 정말 축하드립니다.'),
+       (9, 29, '회식 가나요?'),
+       (10, 10, '저도 가고 싶지만 선약이 있네요.'),
+       (10, 30, '다음엔 꼭 같이 가요.'),
+       (11, 11, '수치들이 아주 긍정적이네요.'),
+       (11, 31, '마케팅팀 고생 많으셨습니다.'),
+       (12, 12, '다큐멘터리 재밌더라고요.'),
+       (12, 32, '저도 그거 봤어요!'),
+       (13, 13, '영희님 정말 천사시죠! 인정합니다.'),
+       (13, 33, '영희님 칭찬 릴레이네요.'),
+       (14, 14, '앗 제 친구가 찾고 있었는데 물어볼게요.'),
+       (14, 34, '주인분 꼭 찾으시길!'),
+       (15, 15, '비개발자도 참여하고 싶어요.'),
+       (15, 35, '누구나 환영입니다.'),
+       (16, 16, '내일부터 바로 예약 잡아야겠네요.'),
+       (16, 36, '저도 방금 예약했습니다.'),
+       (17, 17, '방금 완료했습니다. 서두르세요!'),
+       (17, 37, '보안 교육 클리어!'),
+       (18, 18, '저도 그거 쓰는데 거북목 좋아졌어요.'),
+       (18, 38, '공구하고 싶을 정도네요.'),
+       (19, 19, '철수님 덕분에 아침이 평화롭네요.'),
+       (19, 39, '철수님 최고!'),
+       (20, 20, '리스트 공유 감사합니다!'),
+       (20, 40, '내일 점심은 여기로 가야겠네요.'),
+       (41, 41, 'Great vision for TS!'),
+       (41, 1, '화이팅입니다!'),
+       (42, 42, '이게 정석이죠. 고생하셨습니다.'),
+       (42, 2, '기술 공유 감사합니다.'),
+       (43, 43, '직거래 가능한가요?'),
+       (43, 3, '상태 좋아 보이네요.'),
+       (44, 44, 'Very interesting results.'),
+       (44, 4, 'AI팀 응원합니다.'),
+       (45, 45, '인증 로직 확인했습니다.'),
+       (45, 5, '보안이 강화됐네요.'),
+       (46, 46, '창가 자리 가고 싶어요 ㅎㅎ'),
+       (46, 6, '이사 가기 번거롭겠어요.'),
+       (47, 47, '금액이 상당하겠는데요?'),
+       (47, 7, '비용 절감 대단합니다.'),
+       (48, 48, '제 대시보드에도 적용해보고 싶어요.'),
+       (48, 8, '템플릿 공유 부탁드려요.'),
+       (49, 49, '나눔 감사합니다! 쪽지 드렸어요.'),
+       (49, 9, '저도 줄 서봅니다.'),
+       (50, 50, '정말 놀라운 속도네요.'),
+       (50, 10, '알고리즘이 궁금합니다.'),
+       (81, 41, 'Exciting goals.'),
+       (81, 11, 'SEA market is huge.'),
+       (82, 42, 'I love soccer! Where?'),
+       (82, 12, 'Count me in!'),
+       (83, 43, 'Bugs fixed yet?'),
+       (83, 13, 'Feedback is noted.'),
+       (84, 44, 'Coffee on me today.'),
+       (84, 14, 'Thanks for the latte.'),
+       (85, 45, 'India market data?'),
+       (85, 15, 'Growth is visible.'),
+       (86, 46, 'Vacation dates confirmed.'),
+       (86, 16, 'Check the email.'),
+       (87, 47, 'Hard goal, but possible.'),
+       (87, 17, 'Let s do it.'),
+       (88, 48, 'I saw them in lobby.'),
+       (88, 18, 'Front desk has them.'),
+       (89, 49, 'Visuals are fresh.'),
+       (89, 19, 'Nice design work.'),
+       (90, 50, 'Booked Tokyo flight!'),
+       (90, 20, 'Enjoy your trip!'),
+       (91, 51, 'Construction is noisy.'),
+       (91, 21, 'Pardon the mess.'),
+       (92, 52, 'SSO is needed for B2B.'),
+       (92, 22, 'Working on it.'),
+       (93, 53, 'TikTok branding is key.'),
+       (93, 23, 'Gen Z target!'),
+       (94, 54, 'GS2025 code works.'),
+       (94, 24, 'Joining the gym too.'),
+       (95, 55, 'Policy update noted.'),
+       (95, 25, 'Got the email.'),
+       (96, 56, '80 NPS is the target.'),
+       (96, 26, 'We can reach it.'),
+       (97, 57, 'UK list is ready.'),
+       (97, 27, 'Good candidates.'),
+       (98, 58, 'Stay warm folks.'),
+       (98, 28, 'Winter is here.'),
+       (99, 59, 'Security video done.'),
+       (99, 29, 'Stay safe online.'),
+       (100, 60, 'Retention is vital.'),
+       (100, 30, 'New ideas needed.');
 
 -- ==========================================
 -- 4. 쪽지 데이터 (120개)
 -- ==========================================
-INSERT INTO message (company_id, employee_id, message_title, message_content) VALUES
-                                                                                  (1, 1, '영수증 제출 요청', '김철수님, 지난주 식비 영수증 한 장이 누락되었습니다.'),
-                                                                                  (1, 1, '회의실 변경 알림', '오후 2시 미팅 장소가 회의실 B로 변경되었습니다.'),
-                                                                                  (1, 2, '코드 리뷰 완료', '지수님, PR 리뷰 남겼습니다. 확인 부탁드려요.'),
-                                                                                  (1, 2, '점심 메뉴 추천', '오늘 근처 돈까스 집 어떠세요?'),
-                                                                                  (1, 3, '디자인 수정 건', '로그인 페이지 아이콘 크기 조금만 키워주세요.'),
-                                                                                  (1, 3, '연차 사용 문의', '다음 주 목요일 연차 가능한지 확인 부탁드려요.'),
-                                                                                  (1, 4, '보상비 입금 확인', '민지님, 연차 보상비 오늘 입금 예정 맞나요?'),
-                                                                                  (1, 4, '헬스장 할인 등록', '도윤님, 헬스장 단체 할인 명단에 넣어주세요.'),
-                                                                                  (1, 5, '오빗전자 미팅 준비', '영업부 미나님, 내일 미팅 자료 최종본입니다.'),
-                                                                                  (1, 5, '번개 모임 장소', '오늘 치맥 장소는 회사 앞 치킨집입니다.'),
-                                                                                  (1, 6, '유튜브 광고 지표', '1월 광고 데이터 정리본 메일 보냈습니다.'),
-                                                                                  (1, 6, '노트북 스탠드 모델명', '아까 게시판에 올리신 거 모델명 알려주세요.'),
-                                                                                  (1, 7, '정수기 필터 교체', '필터 점검 오늘 오후 3시에 온답니다.'),
-                                                                                  (1, 7, '습득물 보관', '찾으시는 분 없으면 안내데스크에 맡길게요.'),
-                                                                                  (1, 8, '파이썬 스터디 시간', '매주 화요일 오후 7시에 회의실 C입니다.'),
-                                                                                  (1, 8, '건강검진 예약 완료', '덕분에 빨리 잡았네요. 감사합니다.'),
-                                                                                  (1, 9, '보안 교육 기간', '교육 기간 연장 안 되나요? 너무 바쁘네요.'),
-                                                                                  (1, 9, '스탠드 구매 링크', '제가 쓰는 스탠드 링크 쪽지로 보냅니다.'),
-                                                                                  (1, 10, '서버 점검 보고서', '주말 작업 내역 정리해서 올렸습니다.'),
-                                                                                  (1, 10, '맛집 리스트 공유', '제가 만든 맛집 지도 파일 보냅니다.'),
-                                                                                  (2, 21, '경영 비전 PPT', '발표 자료 수정본입니다.'),
-                                                                                  (2, 21, 'K8s 설정 오류', 'HPA 설정 임계치 확인 부탁해요.'),
-                                                                                  (2, 22, '중고 마우스 상태', '클릭 씹히는 거 없이 쌩쌩합니다.'),
-                                                                                  (2, 22, 'LLM 데이터 전처리', '학습용 텍스트 클리닝 마쳤습니다.'),
-                                                                                  (2, 23, 'API 키 갱신', '기존 키는 다음 주 만료됩니다.'),
-                                                                                  (2, 23, '자리 배치 불만', '에어컨 바로 아래는 피하고 싶습니다.'),
-                                                                                  (2, 24, '클라우드 예산 오버', '이번 달 예상치 초과 확인 요망.'),
-                                                                                  (2, 24, '그라파나 연동', '웹훅 주소 알려주시면 연동할게요.'),
-                                                                                  (2, 25, '기계식 키보드 문의', '청축인가요 갈축인가요?'),
-                                                                                  (2, 25, 'Vision 모델 정확도', '98% 리포트 확인하세요.'),
-                                                                                  (3, 41, 'Strategy Meeting', 'Meet at 2 PM today.'),
-                                                                                  (3, 41, 'Soccer Match Ticket', 'Tickets are ready!'),
-                                                                                  (3, 42, 'Bug Report Summary', '5 major bugs found.'),
-                                                                                  (3, 42, 'Coffee on me', 'Thanks for the help.'),
-                                                                                  (3, 43, 'Ads Budget Plan', '50k for India market.'),
-                                                                                  (3, 43, 'Vacation Policy', 'Submit leave by Friday.'),
-                                                                                  (3, 44, 'Response Time Issue', 'Night shift volume high.'),
-                                                                                  (3, 44, 'Sunglasses Found', 'Check security office.'),
-                                                                                  (3, 45, 'Banner Approval', 'Designs approved.'),
-                                                                                  (3, 45, 'Tokyo Travel Tips', 'Sushi restaurant list.');
+INSERT INTO message (company_id, employee_id, message_title, message_content)
+VALUES (1, 1, '영수증 제출 요청', '김철수님, 지난주 식비 영수증 한 장이 누락되었습니다.'),
+       (1, 1, '회의실 변경 알림', '오후 2시 미팅 장소가 회의실 B로 변경되었습니다.'),
+       (1, 2, '코드 리뷰 완료', '지수님, PR 리뷰 남겼습니다. 확인 부탁드려요.'),
+       (1, 2, '점심 메뉴 추천', '오늘 근처 돈까스 집 어떠세요?'),
+       (1, 3, '디자인 수정 건', '로그인 페이지 아이콘 크기 조금만 키워주세요.'),
+       (1, 3, '연차 사용 문의', '다음 주 목요일 연차 가능한지 확인 부탁드려요.'),
+       (1, 4, '보상비 입금 확인', '민지님, 연차 보상비 오늘 입금 예정 맞나요?'),
+       (1, 4, '헬스장 할인 등록', '도윤님, 헬스장 단체 할인 명단에 넣어주세요.'),
+       (1, 5, '오빗전자 미팅 준비', '영업부 미나님, 내일 미팅 자료 최종본입니다.'),
+       (1, 5, '번개 모임 장소', '오늘 치맥 장소는 회사 앞 치킨집입니다.'),
+       (1, 6, '유튜브 광고 지표', '1월 광고 데이터 정리본 메일 보냈습니다.'),
+       (1, 6, '노트북 스탠드 모델명', '아까 게시판에 올리신 거 모델명 알려주세요.'),
+       (1, 7, '정수기 필터 교체', '필터 점검 오늘 오후 3시에 온답니다.'),
+       (1, 7, '습득물 보관', '찾으시는 분 없으면 안내데스크에 맡길게요.'),
+       (1, 8, '파이썬 스터디 시간', '매주 화요일 오후 7시에 회의실 C입니다.'),
+       (1, 8, '건강검진 예약 완료', '덕분에 빨리 잡았네요. 감사합니다.'),
+       (1, 9, '보안 교육 기간', '교육 기간 연장 안 되나요? 너무 바쁘네요.'),
+       (1, 9, '스탠드 구매 링크', '제가 쓰는 스탠드 링크 쪽지로 보냅니다.'),
+       (1, 10, '서버 점검 보고서', '주말 작업 내역 정리해서 올렸습니다.'),
+       (1, 10, '맛집 리스트 공유', '제가 만든 맛집 지도 파일 보냅니다.'),
+       (2, 21, '경영 비전 PPT', '발표 자료 수정본입니다.'),
+       (2, 21, 'K8s 설정 오류', 'HPA 설정 임계치 확인 부탁해요.'),
+       (2, 22, '중고 마우스 상태', '클릭 씹히는 거 없이 쌩쌩합니다.'),
+       (2, 22, 'LLM 데이터 전처리', '학습용 텍스트 클리닝 마쳤습니다.'),
+       (2, 23, 'API 키 갱신', '기존 키는 다음 주 만료됩니다.'),
+       (2, 23, '자리 배치 불만', '에어컨 바로 아래는 피하고 싶습니다.'),
+       (2, 24, '클라우드 예산 오버', '이번 달 예상치 초과 확인 요망.'),
+       (2, 24, '그라파나 연동', '웹훅 주소 알려주시면 연동할게요.'),
+       (2, 25, '기계식 키보드 문의', '청축인가요 갈축인가요?'),
+       (2, 25, 'Vision 모델 정확도', '98% 리포트 확인하세요.'),
+       (3, 41, 'Strategy Meeting', 'Meet at 2 PM today.'),
+       (3, 41, 'Soccer Match Ticket', 'Tickets are ready!'),
+       (3, 42, 'Bug Report Summary', '5 major bugs found.'),
+       (3, 42, 'Coffee on me', 'Thanks for the help.'),
+       (3, 43, 'Ads Budget Plan', '50k for India market.'),
+       (3, 43, 'Vacation Policy', 'Submit leave by Friday.'),
+       (3, 44, 'Response Time Issue', 'Night shift volume high.'),
+       (3, 44, 'Sunglasses Found', 'Check security office.'),
+       (3, 45, 'Banner Approval', 'Designs approved.'),
+       (3, 45, 'Tokyo Travel Tips', 'Sushi restaurant list.');
 
 -- 중략된 부분 포함하여 나머지 쪽지도 유사하게 ID 1~120까지 순차 삽입됨을 가정
 -- (지면 관계상 핵심 패턴 유지하며 120개 분량의 구조 확보)
@@ -2179,14 +2257,13 @@ INSERT INTO message (company_id, employee_id, message_title, message_content) VA
 -- 5. 쪽지 수신자 데이터 (120개)
 -- ==========================================
 INSERT INTO message_recipient (company_id, message_id, employee_id, is_read)
-SELECT
-    m.company_id,
-    m.id,
-    CASE
-        WHEN m.employee_id = 20 THEN 1
-        WHEN m.employee_id = 40 THEN 21
-        WHEN m.employee_id = 60 THEN 41
-        ELSE m.employee_id + 1
-        END,
-    1
+SELECT m.company_id,
+       m.id,
+       CASE
+           WHEN m.employee_id = 20 THEN 1
+           WHEN m.employee_id = 40 THEN 21
+           WHEN m.employee_id = 60 THEN 41
+           ELSE m.employee_id + 1
+           END,
+       1
 FROM message m;

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
@@ -2,10 +2,7 @@ package com.finalproj.orbitflow.hr.organization.controller;
 
 import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
-import com.finalproj.orbitflow.hr.organization.dto.OrgCreateReqDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgResDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgUpdateReqDto;
+import com.finalproj.orbitflow.hr.organization.dto.*;
 import com.finalproj.orbitflow.hr.organization.service.OrgService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,14 +45,16 @@ public class OrgController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDto<List<OrgResDto>>> list() {
+    public ResponseEntity<ResponseDto<List<OrgResDto>>> list(
+            @RequestParam(defaultValue = "false") boolean includeInactive
+    ) {
         Long companyId = SecurityUtils.getCompanyId();
 
         return ResponseEntity.ok(
-                new ResponseDto(
+                new ResponseDto<>(
                         HttpStatus.OK,
                         "조직 목록 조회",
-                        orgService.findAll(companyId)
+                        orgService.findAll(companyId, includeInactive)
                 )
         );
     }
@@ -67,7 +66,7 @@ public class OrgController {
     ) {
         orgService.update(SecurityUtils.getCompanyId(), id, request);
         return ResponseEntity.ok(
-                new ResponseDto(HttpStatus.OK, "조직 수정 완료", null)
+                new ResponseDto(HttpStatus.OK, "조직 정보 변경 완료", null)
         );
     }
 
@@ -82,6 +81,7 @@ public class OrgController {
         );
     }
 
+    // 프론트에서 사용하지 않는 api -> 추후 목록에서 바로 비활성화 같은 기능용으로 일단 보류
     @DeleteMapping("/{id}")
     public ResponseEntity<ResponseDto<Void>> deactivate(@PathVariable Long id) {
         Long companyId = SecurityUtils.getCompanyId();
@@ -114,5 +114,21 @@ public class OrgController {
                 new ResponseDto<>(HttpStatus.OK, "소속 조직도 조회 성공", orgsByEmployeeId)
         );
     }
+
+    @GetMapping("/{id}/deactivate-check")
+    public ResponseEntity<ResponseDto<OrgDeactivateCheckResDto>> checkDeactivate(
+            @PathVariable Long id
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "비활성화 가능 여부 조회",
+                        orgService.checkDeactivatable(companyId, id)
+                )
+        );
+    }
+
 }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgViewController.java
@@ -1,0 +1,28 @@
+package com.finalproj.orbitflow.hr.organization.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgViewController
+ * @since : 2025-12-26 금요일
+ */
+@Controller
+@RequestMapping("/view/admin/organizations")
+public class OrgViewController {
+
+    @GetMapping
+    public String orgList(Model model) {
+
+        model.addAttribute("pageTitle", "조직 관리");
+        model.addAttribute("currentMenu", "organization");
+        model.addAttribute("sidebarFragment", "admin-sidebar");
+
+        return "admin/hr/organization/list";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgDeactivateCheckResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgDeactivateCheckResDto.java
@@ -1,0 +1,18 @@
+package com.finalproj.orbitflow.hr.organization.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgDeactivateCheckResDto
+ * @since : 2025-12-26 금요일
+ */
+@Getter
+@AllArgsConstructor
+public class OrgDeactivateCheckResDto {
+    private boolean canDeactivate;
+    private String reason; // null이면 가능
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgUpdateReqDto.java
@@ -20,4 +20,5 @@ public class OrgUpdateReqDto {
     @Size(max = 100)
     private String name;
 
+    private Boolean isActive;
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/entity/Organization.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/entity/Organization.java
@@ -38,7 +38,7 @@ public class Organization extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String name;       // 조직명
 
-    @Column(name = "order_index", nullable = false)
+    @Column(name = "order_index")
     private Integer orderIndex; // 정렬 순서
 
     @Column(name = "is_active", nullable = false)
@@ -53,7 +53,7 @@ public class Organization extends BaseEntity {
         org.categoryId = companyCategoryId;
         org.parentOrgId = null;     // 루트
         org.name = company.getName(); // 또는 "회사"
-        org.orderIndex = 0;
+        org.orderIndex = 1;
         org.isActive = true;
         return org;
     }
@@ -86,5 +86,11 @@ public class Organization extends BaseEntity {
 
     public void deactivate() {
         this.isActive = false;
+        this.orderIndex = null;
+    }
+
+    public void activate(Integer newOrderIndex) {
+        this.isActive = true;
+        this.orderIndex = newOrderIndex;
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrgRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/repository/OrgRepository.java
@@ -20,7 +20,13 @@ public interface OrgRepository extends JpaRepository<Organization, Long> {
     /**
      * 회사별 전체 조직 조회 (트리 구성용) - 활성만
      */
-    List<Organization> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
+    List<Organization> findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(Long companyId);
+
+    /**
+     * 회사별 전체 조직 조회 - 비활성까지 포함
+     */
+    List<Organization> findByCompanyIdOrderByIsActiveDescParentOrgIdAscOrderIndexAsc(Long companyId);
+
 
     Optional<Organization> findByCompanyIdAndId(Long companyId, Long id);
 
@@ -105,5 +111,16 @@ public interface OrgRepository extends JpaRepository<Organization, Long> {
     List<OrgResView> findHierarchy(@Param("orgId") Long orgId);
 
 
+    @Query("""
+    SELECT COALESCE(MAX(o.orderIndex), 0)
+    FROM Organization o
+    WHERE o.companyId = :companyId
+      AND o.parentOrgId = :parentOrgId
+      AND o.isActive = true
+""")
+    int findMaxOrderIndex(
+            @Param("companyId") Long companyId,
+            @Param("parentOrgId") Long parentOrgId
+    );
 
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -9,10 +9,7 @@ import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
-import com.finalproj.orbitflow.hr.organization.dto.OrgCreateReqDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgResDto;
-import com.finalproj.orbitflow.hr.organization.dto.OrgUpdateReqDto;
+import com.finalproj.orbitflow.hr.organization.dto.*;
 import com.finalproj.orbitflow.hr.organization.entity.Organization;
 import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
 import com.finalproj.orbitflow.hr.organization.repository.OrgResView;
@@ -64,24 +61,31 @@ public class OrgService {
         }
 
         // 다음 orderIndex (형제 단위)
-        int nextOrderIndex = (int) orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, parentOrgId) + 1;
+        int nextOrderIndex =
+                (int) orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(
+                        companyId, parentOrgId) + 1;
 
-        Organization org = Organization.create(companyId, categoryId, parentOrgId, name, nextOrderIndex);
+        Organization org =
+                Organization.create(companyId, categoryId, parentOrgId, name, nextOrderIndex);
+
         Organization saved = orgRepository.save(org);
 
         // 조직 게시판 카테고리 자동 생성
-        organizationBoardCategorySyncService.createIfAbsent(companyId, saved.getId(), saved.getName());
+        organizationBoardCategorySyncService.createIfAbsent(
+                companyId, saved.getId(), saved.getName());
 
         return saved.getId();
     }
 
     /* ================= 조회 ================= */
     @Transactional(readOnly = true)
-    public List<OrgResDto> findAll(Long companyId) {
+    public List<OrgResDto> findAll(Long companyId, boolean includeInactive) {
 
-        return orgRepository
-                .findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId)
-                .stream()
+        List<Organization> orgs = includeInactive
+                ? orgRepository.findByCompanyIdOrderByIsActiveDescParentOrgIdAscOrderIndexAsc(companyId)
+                : orgRepository.findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(companyId);
+
+        return orgs.stream()
                 .map(OrgResDto::from)
                 .toList();
     }
@@ -94,20 +98,22 @@ public class OrgService {
 
         Long newParentId = request.getParentOrgId();
         String newName = normalizeNameOrThrow(request.getName());
+        Boolean reqActive = request.getIsActive();
+
+        // 비활성화 요청 처리
+        if (Boolean.FALSE.equals(reqActive) && Boolean.TRUE.equals(org.getIsActive())) {
+            deactivateInternal(companyId, org);
+            return;
+        }
 
         // 자기 자신을 상위로 금지
         if (newParentId != null && Objects.equals(newParentId, organizationId)) {
             throw new InvalidRequestException("자기 자신을 상위 조직으로 지정할 수 없습니다.");
         }
 
-        // 상위 조직 검증(존재/회사/활성)
-        if (newParentId != null) {
-            getActiveOrgInCompanyOrThrow(companyId, newParentId);
-        }
-
         // 순환 참조 방지: newParent의 조상 중에 organizationId가 있으면 금지
         if (newParentId != null && isCycle(companyId, organizationId, newParentId)) {
-            throw new InvalidStateException("조직 트리에 순환 구조가 발생할 수 있어 상위 조직을 변경할 수 없습니다.");
+            throw new InvalidStateException("조직 트리에 순환 구조가 발생할 수 있습니다.");
         }
 
         // 형제 단위 이름 중복 (수정: 자기 자신 제외)
@@ -116,51 +122,42 @@ public class OrgService {
             throw new InvalidStateException("이미 존재하는 조직명입니다.");
         }
 
-        // 부모가 바뀌면: 새 부모의 마지막 순번으로 이동
-        boolean parentChanged = !Objects.equals(org.getParentOrgId(), newParentId);
-        if (parentChanged) {
-            int nextOrderIndex = (int) orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, newParentId) + 1;
-            org.updateOrderIndex(nextOrderIndex);
+        // ===== 재활성 여부 판단 =====
+        boolean reactivated =
+                Boolean.TRUE.equals(reqActive)
+                        && Boolean.FALSE.equals(org.getIsActive());
+
+        if (reactivated) {
+
+            Long parentId = org.getParentOrgId();
+
+            int nextOrderIndex =
+                    orgRepository.findMaxOrderIndex(companyId, parentId) + 1;
+
+            org.activate(nextOrderIndex);
         }
 
-        org.update(newParentId, newName); // categoryId는 변경 불가이므로 기존 값 유지
+        // 실제 값 반영
+        org.update(org.getParentOrgId(), newName);
 
         // 이름이 바뀐 경우에만 게시판 카테고리명 동기화 (정책 선택)
         if (!oldName.equals(newName)) {
-            organizationBoardCategorySyncService.syncBoardName(companyId, organizationId, newName);
+            organizationBoardCategorySyncService
+                    .syncBoardName(companyId, organizationId, newName);
         }
     }
 
     /* ================= 비활성화 ================= */
     public void deactivate(Long companyId, Long organizationId) {
-
         Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
-
-        // 하위 조직 존재하면 비활성화 불가(트리 무결성)
-        if (orgRepository.existsByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, organizationId)) {
-            throw new InvalidStateException("하위 조직이 존재하여 비활성화할 수 없습니다.");
-        }
-
-        // 기존 정책: 조직에 재직/정지/임시 계정이 남아 있으면 비활성화 불가
-        if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
-                companyId,
-                organizationId,
-                EmployeeStatus.RESIGNED
-        )) {
-            throw new InvalidStateException("해당 조직에 소속된 재직 중인 사원이 존재하여 비활성화할 수 없습니다.");
-        }
-
-        orgPositionUsageRepository.deleteByCompany_IdAndOrganization_Id(companyId, organizationId);
-
-        org.deactivate();
-
-        // 조직 게시판도 비활성화(삭제 대신)
-        organizationBoardCategorySyncService.deactivateBoard(companyId, organizationId);
+        deactivateInternal(companyId, org);
     }
 
 
 
+
     /* ================= 정렬 ================= */
+    @Transactional
     public void updateOrder(Long companyId, List<OrgOrderUpdateReqDto.OrderItem> orders) {
 
         if (orders == null || orders.isEmpty()) {
@@ -177,42 +174,36 @@ public class OrgService {
             throw new InvalidRequestException("중복된 조직 ID가 존재합니다.");
         }
 
-        // 같은 parentOrgId인지 검증 + 활성 검증
+        // 회사 소속 + 활성 조직 검증
+        List<Organization> orgs = orders.stream()
+                .map(o -> getOrgInCompanyOrThrow(companyId, o.getId()))
+                .toList();
+
         Long parentOrgId = null;
 
-        for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
-
+        for (Organization org : orgs) {
             if (!Boolean.TRUE.equals(org.getIsActive())) {
-                throw new InvalidStateException("비활성 조직은 정렬 대상이 될 수 없습니다.");
+                throw new InvalidStateException("비활성 조직은 정렬할 수 없습니다.");
             }
 
             if (parentOrgId == null) {
                 parentOrgId = org.getParentOrgId();
             } else if (!Objects.equals(parentOrgId, org.getParentOrgId())) {
-                throw new InvalidStateException("서로 다른 상위 조직의 조직은 함께 정렬할 수 없습니다.");
+                throw new InvalidStateException("서로 다른 상위 조직은 함께 정렬할 수 없습니다.");
             }
         }
 
-        // 정렬 대상 개수 검증(형제 단위)
-        long activeCount = orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, parentOrgId);
-        if (activeCount != orders.size()) {
-            throw new InvalidStateException("정렬 대상 개수가 일치하지 않습니다.");
-        }
 
-        // 임시 orderIndex 할당 (충돌 방지)
-        int tempIndex = -1;
-        for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
-            org.updateOrderIndex(tempIndex--);
+        // 임시 orderIndex (충돌 방지)
+        int temp = -1;
+        for (Organization org : orgs) {
+            org.updateOrderIndex(temp--);
         }
-
         orgRepository.flush();
 
-        // 최종 orderIndex 재할당
+        // 최종 orderIndex 재할당 (프론트 순서 그대로)
         int orderIndex = 1;
-        for (OrgOrderUpdateReqDto.OrderItem item : orders) {
-            Organization org = getOrgInCompanyOrThrow(companyId, item.getId());
+        for (Organization org : orgs) {
             org.updateOrderIndex(orderIndex++);
         }
     }
@@ -245,20 +236,16 @@ public class OrgService {
     private boolean isCycle(Long companyId, Long targetOrgId, Long newParentId) {
         Long cursor = newParentId;
         while (cursor != null) {
-            if (Objects.equals(cursor, targetOrgId)) {
-                return true;
-            }
-            Organization parent = getOrgInCompanyOrThrow(companyId, cursor);
-            cursor = parent.getParentOrgId();
+            if (Objects.equals(cursor, targetOrgId)) return true;
+            cursor = getOrgInCompanyOrThrow(companyId, cursor).getParentOrgId();
         }
         return false;
     }
 
     private void validateCategoryActiveInCompany(Long companyId, Long categoryId) {
         // OrgCategory 엔티티 구조가 companyId를 갖고 있으니 이 방식으로 검증 가능
-        com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory category =
-                orgCategoryRepository.findById(categoryId)
-                        .orElseThrow(() -> new NotFoundException("조직 카테고리를 찾을 수 없습니다."));
+        var category = orgCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException("조직 카테고리를 찾을 수 없습니다."));
 
         if (!Objects.equals(category.getCompanyId(), companyId)) {
             throw new ForbiddenException("해당 회사의 조직 카테고리가 아닙니다.");
@@ -293,6 +280,51 @@ public class OrgService {
                         v.getIsActive() != null && v.getIsActive() == 1
                 ))
                 .toList();
+    }
+
+    private void deactivateInternal(Long companyId, Organization org) {
+
+        Long organizationId = org.getId();
+
+        if (orgRepository.existsByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, organizationId)) {
+            throw new InvalidStateException("하위 조직이 존재하여 비활성화할 수 없습니다.");
+        }
+
+        if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
+                companyId, organizationId, EmployeeStatus.RESIGNED)) {
+            throw new InvalidStateException("재직 중인 사원이 존재하여 비활성화할 수 없습니다.");
+        }
+
+        orgPositionUsageRepository
+                .deleteByCompany_IdAndOrganization_Id(companyId, organizationId);
+
+        org.deactivate();
+        organizationBoardCategorySyncService.
+                deactivateBoard(companyId, organizationId);
+    }
+
+
+    @Transactional(readOnly = true)
+    public OrgDeactivateCheckResDto checkDeactivatable(Long companyId, Long orgId) {
+
+        // 하위 조직 존재
+        if (orgRepository.existsByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, orgId)) {
+            return new OrgDeactivateCheckResDto(
+                    false,
+                    "하위 조직이 존재하여 비활성화할 수 없습니다."
+            );
+        }
+
+        // 재직 중 사원 존재
+        if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
+                companyId, orgId, EmployeeStatus.RESIGNED)) {
+            return new OrgDeactivateCheckResDto(
+                    false,
+                    "재직 중인 사원이 존재하여 비활성화할 수 없습니다."
+            );
+        }
+
+        return new OrgDeactivateCheckResDto(true, null);
     }
 
 }

--- a/src/main/resources/static/css/admin-organization.css
+++ b/src/main/resources/static/css/admin-organization.css
@@ -1,0 +1,162 @@
+/* ==================================================
+   admin-organization.css (FINAL – PRODUCTION)
+   - admin-org-category.css 위에 덮어쓰는 조직 트리 전용 스타일
+   - DIV 기반 트리 + 토글 + 정렬 모드 대응
+================================================== */
+
+/* ===== 트리 컨테이너 ===== */
+#orgTree {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+/* ===== 조직 노드 ===== */
+.org-node {
+    user-select: none;
+}
+
+.org-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 46px;
+    padding: 6px 12px;
+    border-radius: 10px;
+    transition: background .12s ease;
+}
+
+.org-row:hover {
+    background: #f6f8fc;
+}
+
+/* ===== 드래그 핸들 ===== */
+.org-row .drag-handle {
+    flex-shrink: 0;
+    margin-right: 2px;
+}
+
+/* ===== 토글 ===== */
+.org-toggle {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 900;
+    color: #667085;
+    cursor: pointer;
+    border-radius: 6px;
+}
+
+.org-toggle:hover {
+    background: #eef2ff;
+    color: var(--primary);
+}
+
+.org-toggle-placeholder {
+    width: 18px;
+    height: 18px;
+    display: inline-block;
+}
+
+/* ===== 조직명 ===== */
+.org-label {
+    flex: 1;
+    font-size: 13.5px;
+    font-weight: 800;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ===== 상태 배지 보정 ===== */
+.org-row .status-badge {
+    margin-left: auto;
+}
+
+/* ===== 수정 버튼 위치 안정화 ===== */
+.org-row .table-btn {
+    margin-left: 6px;
+}
+
+/* ===== 깊이 표현 ===== */
+.org-node {
+    position: relative;
+}
+
+.org-node::before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: #e5e7eb;
+}
+
+/* 루트는 라인 제거 */
+.org-node[data-parent-id="root"]::before {
+    display: none;
+}
+
+/* ===== 정렬 모드 ===== */
+.sortable-chosen .org-row {
+    background: #f2f6ff;
+}
+
+.sortable-ghost {
+    opacity: 0.45;
+}
+
+.sortable-chosen .org-toggle {
+    pointer-events: none;
+    opacity: 0.4;
+}
+
+
+/* ===== 드래그 중 서브트리 ===== */
+.dragging-subtree .org-row {
+    background: #f8fafc;
+    opacity: 0.9;
+}
+
+/* ===== 비활성 조직 ===== */
+.org-node:not([data-active="true"]) .org-label {
+    color: #98a2b3;
+}
+
+/* 비활성 조직 전체 */
+.org-node[data-active="false"] .org-row {
+    opacity: 0.55;
+}
+
+/* 비활성 조직은 hover도 약하게 */
+.org-node[data-active="false"] .org-row:hover {
+    background: transparent;
+}
+
+/* 비활성 조직은 드래그 핸들 숨김 */
+.org-node[data-active="false"] .drag-handle {
+    display: none;
+}
+
+/* ===== 반응형 보정 ===== */
+@media (max-width: 720px) {
+    .org-row {
+        padding: 8px 10px;
+    }
+
+    .org-label {
+        font-size: 13px;
+    }
+}
+
+.org-highlight {
+    background: #fff3bf;
+    color: #b54708;
+    padding: 0 2px;
+    border-radius: 4px;
+}

--- a/src/main/resources/static/css/admin-organization.css
+++ b/src/main/resources/static/css/admin-organization.css
@@ -154,9 +154,13 @@
     }
 }
 
+.org-focus .org-row {
+    background: #fff7ed;
+    outline: 2px solid #fdba74;
+}
+
 .org-highlight {
-    background: #fff3bf;
-    color: #b54708;
+    background: #ffe066;
+    border-radius: 3px;
     padding: 0 2px;
-    border-radius: 4px;
 }

--- a/src/main/resources/static/js/admin-org-category.js
+++ b/src/main/resources/static/js/admin-org-category.js
@@ -228,15 +228,13 @@ function dragHandleHtml() {
    Sortable (활성만)
 ====================== */
 function initSortable() {
-    const tbody = els.tbody();
-    if (!tbody) return;
+    if (sortableInstance) {
+        sortableInstance.destroy();
+        sortableInstance = null;
+    }
 
-    if (sortableInstance) sortableInstance.destroy();
-
-    sortableInstance = Sortable.create(tbody, {
+    sortableInstance = Sortable.create(els.tbody(), {
         handle: '.drag-handle',
-        filter: 'tr:not([data-id])', // separator 제외
-        preventOnFilter: false,
         animation: 160,
 
         onMove: evt => {
@@ -245,9 +243,10 @@ function initSortable() {
             return c && normalizeActive(c);
         },
 
-        onEnd: markOrderChanged
+        onEnd: () => {
+            markOrderChanged();
+        }
     });
-
 }
 
 /* ======================

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -1,0 +1,440 @@
+/* ==================================================
+   admin-organization.js (FINAL)
+   - 정렬 모드 제거
+   - 항상 Drag & Drop 가능
+   - 형제 단위 정렬 + 서브트리 동반 이동
+   - DOM 순서 기준 저장
+================================================== */
+
+const API_BASE = '/api/admin/organizations';
+
+let allOrgList = [];
+let filteredOrgList = [];
+let selectedOrgId = null;
+let isEditMode = false;
+let isOrderChanged = false;
+let sortable = null;
+let orgCategories = [];
+
+const expandedSet = new Set();
+
+/* ======================
+   Elements
+====================== */
+const els = {
+    tree: () => document.getElementById('orgTree'),
+    search: () => document.getElementById('searchKeyword'),
+    includeInactive: () => document.getElementById('includeInactive'),
+    btnSearch: () => document.getElementById('btnSearch'),
+    btnCreate: () => document.getElementById('btnOpenCreate'),
+    btnSaveOrder: () => document.getElementById('btnSaveOrder'),
+
+    modal: () => document.getElementById('orgModal'),
+    modalTitle: () => document.getElementById('modalTitle'),
+    orgName: () => document.getElementById('orgName'),
+    parentSelect: () => document.getElementById('parentOrgSelect'),
+    btnSave: () => document.getElementById('btnSaveOrg'),
+    btnCloseIcon: () => document.getElementById('btnModalCloseIcon'),
+    btnCancel: () => document.getElementById('btnModalCancel'),
+};
+
+/* ======================
+   Init
+====================== */
+document.addEventListener('DOMContentLoaded', async () => {
+    bindEvents();
+    await loadOrgCategories();
+    await loadOrganizations();
+});
+
+/* ======================
+   Load
+====================== */
+async function loadOrganizations() {
+    const includeInactive = els.includeInactive().checked;
+
+    const res = await apiFetch(
+        `${API_BASE}?includeInactive=${includeInactive}`
+    );
+
+    const json = await res.json();
+    allOrgList = json.data || [];
+    applyFilterAndRender();
+    resetOrderChanged();
+}
+
+async function loadOrgCategories() {
+    const res = await apiFetch('/api/admin/org-categories');
+    const json = await res.json();
+    orgCategories = (json.data || []).filter(c => c.isActive === true);
+}
+
+/* ======================
+   Filter + Render
+====================== */
+function applyFilterAndRender() {
+    const keyword = els.search().value.trim().toLowerCase();
+    const includeInactive = els.includeInactive().checked;
+
+    let base = allOrgList.filter(o => {
+        if (!includeInactive && !normalizeActive(o)) return false;
+        return true;
+    });
+
+
+    if (!keyword) {
+        filteredOrgList = base;
+        renderTree();
+        initSortable();
+        return;
+    }
+
+    // 검색 중 → 정렬 불가
+    destroySortable();           // 드래그 완전 차단
+    resetOrderChanged();         // 저장 버튼 비활성화
+
+    const matched = base.filter(o =>
+        o.name.toLowerCase().includes(keyword)
+    );
+
+    const withParents = new Map();
+    matched.forEach(o => {
+        let cur = o;
+        while (cur) {
+            withParents.set(cur.id, cur);
+            cur = allOrgList.find(p => p.id === cur.parentOrgId);
+        }
+    });
+
+    filteredOrgList = [...withParents.values()];
+    renderTree();
+}
+
+
+/* ======================
+   Render Tree
+====================== */
+function renderTree() {
+    const container = els.tree();
+    container.innerHTML = '';
+
+    const list = filteredOrgList;
+
+    if (!list.length) {
+        container.innerHTML = `
+            <div class="org-empty">
+                검색 결과가 없습니다.
+            </div>
+        `;
+        return;
+    }
+
+    list
+        .filter(o => o.parentOrgId === null)
+        .sort((a, b) => a.orderIndex - b.orderIndex)
+        .forEach(o => renderNode(o, 0, container));
+}
+
+
+function renderNode(org, depth, container) {
+    const hasChildren = allOrgList.some(o => o.parentOrgId === org.id);
+    const isExpanded = expandedSet.has(org.id);
+
+    const node = document.createElement('div');
+    node.className = 'org-node';
+    node.dataset.id = org.id;
+    node.dataset.parentId = org.parentOrgId ?? 'root';
+    node.dataset.active = normalizeActive(org);
+    node.style.marginLeft = `${depth * 20}px`;
+
+    const keyword = els.search().value.trim();
+
+    node.innerHTML = `
+      <div class="org-row">
+        ${normalizeActive(org) ? dragHandleHtml() : ''}
+        ${
+        hasChildren
+            ? `<span class="org-toggle">${isExpanded ? '▾' : '▸'}</span>`
+            : `<span class="org-toggle-placeholder"></span>`
+    }
+        <span class="org-label">${highlight(org.name, keyword)}</span>
+        <span class="status-badge ${normalizeActive(org) ? 'status-active' : 'status-inactive'}">
+            ${normalizeActive(org) ? '활성' : '비활성'}
+        </span>
+        <button class="table-btn">수정</button>
+      </div>
+    `;
+
+    container.appendChild(node);
+
+    node.querySelector('.table-btn').onclick = () => openEdit(org.id);
+
+    const toggle = node.querySelector('.org-toggle');
+    if (toggle) {
+        toggle.onclick = e => {
+            e.stopPropagation();
+            expandedSet.has(org.id) ? expandedSet.delete(org.id) : expandedSet.add(org.id);
+            renderTree();
+            initSortable();
+        };
+    }
+
+    if (hasChildren && isExpanded) {
+        allOrgList
+            .filter(o => o.parentOrgId === org.id)
+            .sort((a, b) => a.orderIndex - b.orderIndex)
+            .forEach(child => renderNode(child, depth + 1, container));
+    }
+}
+
+/* ======================
+   Sortable
+====================== */
+function initSortable() {
+    destroySortable();
+
+    sortable = Sortable.create(els.tree(), {
+        handle: '.drag-handle',
+        draggable: '.org-node',
+        animation: 160,
+
+        onStart(evt) {
+            const subtree = collectSubtreeNodes(evt.item);
+            evt.item._subtree = subtree;
+            subtree.forEach(n => n.classList.add('dragging-subtree'));
+        },
+
+        onMove(evt) {
+            return evt.dragged.dataset.parentId === evt.related?.dataset.parentId;
+        },
+
+        onEnd(evt) {
+            const subtree = evt.item._subtree || [evt.item];
+            subtree.forEach(n => n.classList.remove('dragging-subtree'));
+
+            const anchor = evt.item.nextElementSibling;
+            subtree.forEach(n => els.tree().insertBefore(n, anchor));
+
+            markOrderChanged();
+        }
+    });
+}
+
+function destroySortable() {
+    if (sortable) {
+        sortable.destroy();
+        sortable = null;
+    }
+}
+
+/* ======================
+   Save Order
+====================== */
+async function saveOrder() {
+    if (els.search().value.trim()) {
+        alert('검색 중에는 순서를 변경할 수 없습니다.');
+        return;
+    }
+
+    if (!isOrderChanged) return;
+
+    const nodes = [...els.tree().querySelectorAll('.org-node')];
+    const groups = {};
+
+    nodes.forEach(n => {
+        const pid = n.dataset.parentId ?? 'root';
+        groups[pid] ??= [];
+        groups[pid].push({ id: Number(n.dataset.id) });
+    });
+
+    for (const orders of Object.values(groups)) {
+        await apiFetch(`${API_BASE}/order`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ orders })
+        });
+    }
+
+    resetOrderChanged();
+    await loadOrganizations();
+}
+
+/* ======================
+   Events
+====================== */
+function bindEvents() {
+    els.search().addEventListener('input', applyFilterAndRender);
+    els.includeInactive().addEventListener('change', loadOrganizations);
+    els.btnSearch().addEventListener('click', applyFilterAndRender);
+
+    els.btnCreate().addEventListener('click', openCreate);
+    els.btnSaveOrder().addEventListener('click', saveOrder);
+    els.btnCloseIcon().addEventListener('click', closeModal);
+    els.btnCancel().addEventListener('click', closeModal);
+    els.btnSave().addEventListener('click', saveOrg);
+}
+
+/* ======================
+   CRUD / Utils
+====================== */
+function openCreate() {
+    isEditMode = false;
+    selectedOrgId = null;
+
+    els.modalTitle().textContent = '조직 생성';
+    els.orgName().value = '';
+
+    buildCategorySelect(null);
+    buildParentSelect(null);
+
+    // 생성 시: 카테고리 / 부모조직 활성화
+    document.getElementById('categorySelect').disabled = false;
+    els.parentSelect().disabled = false;
+
+    // 생성 시: 사용 여부는 항상 활성 + 잠금
+    const toggle = document.getElementById('activeToggle');
+    toggle.checked = true;
+    toggle.disabled = true;
+
+    document.getElementById('inactiveHelp').style.display = 'none';
+
+    openModal();
+}
+
+async function openEdit(id) {
+    isEditMode = true;
+
+    const org = allOrgList.find(o => o.id === id);
+    if (!org) return;
+
+    selectedOrgId = id;
+
+    els.modalTitle().textContent = '조직 수정';
+    els.orgName().value = org.name ?? '';
+
+    buildCategorySelect(org.categoryId);
+    buildParentSelect(org.parentOrgId ?? null);
+
+    // 수정 시: 카테고리 / 부모조직 수정 불가
+    document.getElementById('categorySelect').disabled = true;
+    els.parentSelect().disabled = true;
+
+    const toggle = document.getElementById('activeToggle');
+    const help = document.getElementById('inactiveHelp');
+
+    toggle.checked = normalizeActive(org);
+    toggle.disabled = false;
+    help.style.display = 'none';
+
+    // 활성 상태일 때만 "비활성화 가능 여부" 체크
+    if (normalizeActive(org)) {
+        const res = await apiFetch(`/api/admin/organizations/${id}/deactivate-check`);
+        const json = await res.json();
+        const check = json.data;
+
+        if (!check.canDeactivate) {
+            toggle.disabled = true;
+            help.textContent = check.reason;
+            help.style.display = 'block';
+        }
+    }
+
+    openModal();
+}
+
+async function saveOrg() {
+    const name = els.orgName().value.trim();
+    if (!name) return alert('조직명을 입력해주세요.');
+
+    const payload = {
+        name,
+        isActive: isEditMode ? document.getElementById('activeToggle').checked : true
+    };
+
+    const url = selectedOrgId ? `${API_BASE}/${selectedOrgId}` : API_BASE;
+    const method = selectedOrgId ? 'PUT' : 'POST';
+
+    await apiFetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+
+    closeModal();
+    await loadOrganizations();
+}
+
+function buildCategorySelect(selectedId) {
+    const select = document.getElementById('categorySelect');
+    select.innerHTML = orgCategories.map(c =>
+        `<option value="${c.id}" ${c.id === selectedId ? 'selected' : ''}>${c.name}</option>`
+    ).join('');
+}
+
+function buildParentSelect(selected) {
+    els.parentSelect().innerHTML = `
+      <option value="">상위 조직 없음</option>
+      ${allOrgList
+        .filter(o => normalizeActive(o) && o.id !== selectedOrgId)
+        .map(o => `<option value="${o.id}" ${o.id === selected ? 'selected' : ''}>${escapeHtml(o.name)}</option>`)
+        .join('')}
+    `;
+}
+
+function openModal() {
+    els.modal().classList.remove('hidden');
+}
+function closeModal() {
+    els.modal().classList.add('hidden');
+}
+
+function markOrderChanged() {
+    isOrderChanged = true;
+    els.btnSaveOrder().disabled = false;
+}
+function resetOrderChanged() {
+    isOrderChanged = false;
+    els.btnSaveOrder().disabled = true;
+}
+
+function normalizeActive(o) {
+    return o.isActive === true || o.isActive === 1;
+}
+function escapeHtml(str) {
+    return String(str).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+function dragHandleHtml() {
+    return `<span class="drag-handle"><span class="drag-dots">
+        <span></span><span></span><span></span><span></span><span></span><span></span>
+    </span></span>`;
+}
+
+function collectSubtreeNodes(startNode) {
+    const nodes = [startNode];
+    const startId = startNode.dataset.id;
+
+    let next = startNode.nextElementSibling;
+    while (next && isDescendantOf(next, startId)) {
+        nodes.push(next);
+        next = next.nextElementSibling;
+    }
+    return nodes;
+}
+
+function isDescendantOf(node, ancestorId) {
+    let pid = node.dataset.parentId;
+    while (pid && pid !== 'root') {
+        if (pid === ancestorId) return true;
+        const parent = document.querySelector(`.org-node[data-id="${pid}"]`);
+        pid = parent?.dataset.parentId;
+    }
+    return false;
+}
+
+function highlight(text, keyword) {
+    if (!keyword) return escapeHtml(text);
+
+    const escaped = escapeHtml(text);
+    const reg = new RegExp(`(${keyword})`, 'ig');
+    return escaped.replace(reg, '<mark class="org-highlight">$1</mark>');
+}

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -25,6 +25,7 @@ const els = {
     tree: () => document.getElementById('orgTree'),
     search: () => document.getElementById('searchKeyword'),
     includeInactive: () => document.getElementById('includeInactive'),
+    includeDescendants: () => document.getElementById('includeDescendants'),
     btnSearch: () => document.getElementById('btnSearch'),
     btnCreate: () => document.getElementById('btnOpenCreate'),
     btnSaveOrder: () => document.getElementById('btnSaveOrder'),
@@ -76,38 +77,39 @@ function applyFilterAndRender() {
     const keyword = els.search().value.trim().toLowerCase();
     const includeInactive = els.includeInactive().checked;
 
-    let base = allOrgList.filter(o => {
-        if (!includeInactive && !normalizeActive(o)) return false;
-        return true;
-    });
-
-
+    // 검색어 없을 때 → 기존 전체 트리
     if (!keyword) {
-        filteredOrgList = base;
+        filteredOrgList = allOrgList.filter(o =>
+            includeInactive || normalizeActive(o)
+        );
+
         renderTree();
         initSortable();
         return;
     }
 
-    // 검색 중 → 정렬 불가
-    destroySortable();           // 드래그 완전 차단
-    resetOrderChanged();         // 저장 버튼 비활성화
+    // 검색어 있을 때
+    const includeDescendants = els.includeDescendants().checked;
+    const visibleIds = collectMatchedOrgIds(keyword, includeDescendants);
 
-    const matched = base.filter(o =>
-        o.name.toLowerCase().includes(keyword)
-    );
+    filteredOrgList = allOrgList.filter(o => {
+        // 회사(최상위 parent=null)는 제외
+        if (o.parentOrgId === null) return false;
 
-    const withParents = new Map();
-    matched.forEach(o => {
-        let cur = o;
-        while (cur) {
-            withParents.set(cur.id, cur);
-            cur = allOrgList.find(p => p.id === cur.parentOrgId);
-        }
+        if (!includeInactive && !normalizeActive(o)) return false;
+
+        return visibleIds.has(o.id);
     });
 
-    filteredOrgList = [...withParents.values()];
+    // 부모 자동 펼침
+    filteredOrgList.forEach(o => expandParents(o));
+
     renderTree();
+
+    // 검색 중 정렬 비활성화
+    destroySortable();
+    els.btnSaveOrder().disabled = true;
+    isOrderChanged = false;
 }
 
 
@@ -129,15 +131,19 @@ function renderTree() {
         return;
     }
 
-    list
-        .filter(o => o.parentOrgId === null)
+    const visibleIds = new Set(list.map(o => o.id));
+
+    // 검색 결과 기준 루트 노드 찾기
+    const roots = list.filter(o => !visibleIds.has(o.parentOrgId));
+
+    roots
         .sort((a, b) => a.orderIndex - b.orderIndex)
         .forEach(o => renderNode(o, 0, container));
 }
 
 
 function renderNode(org, depth, container) {
-    const hasChildren = allOrgList.some(o => o.parentOrgId === org.id);
+    const hasChildren = filteredOrgList.some(o => o.parentOrgId === org.id);
     const isExpanded = expandedSet.has(org.id);
 
     const node = document.createElement('div');
@@ -180,7 +186,7 @@ function renderNode(org, depth, container) {
     }
 
     if (hasChildren && isExpanded) {
-        allOrgList
+        filteredOrgList
             .filter(o => o.parentOrgId === org.id)
             .sort((a, b) => a.orderIndex - b.orderIndex)
             .forEach(child => renderNode(child, depth + 1, container));
@@ -272,6 +278,8 @@ function bindEvents() {
     els.btnCloseIcon().addEventListener('click', closeModal);
     els.btnCancel().addEventListener('click', closeModal);
     els.btnSave().addEventListener('click', saveOrg);
+
+    els.includeDescendants().addEventListener('change', applyFilterAndRender);
 }
 
 /* ======================
@@ -437,4 +445,105 @@ function highlight(text, keyword) {
     const escaped = escapeHtml(text);
     const reg = new RegExp(`(${keyword})`, 'ig');
     return escaped.replace(reg, '<mark class="org-highlight">$1</mark>');
+}
+
+function expandParents(org) {
+    let cur = org;
+    while (cur?.parentOrgId) {
+        expandedSet.add(cur.parentOrgId);
+        cur = allOrgList.find(o => o.id === cur.parentOrgId);
+    }
+}
+
+function focusFirstMatch(keyword) {
+    const match = allOrgList.find(o =>
+        o.name.toLowerCase().includes(keyword)
+    );
+    if (!match) return;
+
+    expandParents(match);
+
+    // 다시 렌더링 (부모 열린 상태 반영)
+    renderTree();
+
+    // DOM에서 해당 노드 찾기
+    const el = document.querySelector(`.org-node[data-id="${match.id}"]`);
+    if (!el) return;
+
+    el.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+    });
+
+    el.classList.add('org-focus');
+    setTimeout(() => el.classList.remove('org-focus'), 1500);
+}
+
+function groupHasKeyword(root, keyword) {
+    const stack = [root];
+
+    while (stack.length) {
+        const cur = stack.pop();
+
+        if (cur.name.toLowerCase().includes(keyword)) {
+            return true;
+        }
+
+        const children = allOrgList.filter(o => o.parentOrgId === cur.id);
+        stack.push(...children);
+    }
+
+    return false;
+}
+
+function expandParentsByKeyword(root, keyword) {
+    const stack = [root];
+
+    while (stack.length) {
+        const cur = stack.pop();
+
+        if (cur.name.toLowerCase().includes(keyword)) {
+            expandParents(cur);
+        }
+
+        const children = allOrgList.filter(o => o.parentOrgId === cur.id);
+        stack.push(...children);
+    }
+}
+
+function collectMatchedOrgIds(keyword, includeDescendants) {
+    const result = new Set();
+
+    allOrgList.forEach(org => {
+        if (!org.name.toLowerCase().includes(keyword)) return;
+
+        // 1. 자기 자신
+        result.add(org.id);
+
+        // 2. 부모 체인
+        let cur = org;
+        while (cur.parentOrgId) {
+            const parent = allOrgList.find(o => o.id === cur.parentOrgId);
+            if (!parent) break;
+            result.add(parent.id);
+            cur = parent;
+        }
+
+        // 3. 하위 조직 (옵션 ON일 때만)
+        if (includeDescendants) {
+            collectDescendants(org.id, result);
+        }
+    });
+
+    return result;
+}
+
+function collectDescendants(parentId, set) {
+    allOrgList
+        .filter(o => o.parentOrgId === parentId)
+        .forEach(child => {
+            if (set.has(child.id)) return;
+            set.add(child.id);
+            collectDescendants(child.id, set);
+        });
 }

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -17,23 +17,49 @@ const SESSION_WARNING_SHOWN_KEY = 'sessionWarningShown';
 ========================= */
 async function apiFetch(url, options = {}) {
     const accessToken = sessionStorage.getItem('accessToken');
-    options.headers = {
+
+    // 토큰 없으면 즉시 로그인
+    if (!accessToken) {
+        location.href = '/login';
+        throw new Error('NO_TOKEN');
+    }
+
+    const headers = {
         ...(options.headers || {}),
-        ...(accessToken && { 'Authorization': `Bearer ${accessToken}` })
+        Authorization: `Bearer ${accessToken}`
     };
 
-    let res = await fetch(url, options);
+    const fetchOptions = {
+        ...options,
+        headers,
+        credentials: 'include' // refresh 쿠키 필수
+    };
+
+    let res = await fetch(url, fetchOptions);
     if (res.status !== 401) return res;
 
+    /* ===== refresh 중이면 대기 ===== */
     if (isRefreshing) {
         return new Promise((resolve, reject) => {
             refreshSubscribers.push(async () => {
-                options.headers.Authorization = `Bearer ${sessionStorage.getItem('accessToken')}`;
-                try { resolve(await fetch(url, options)); } catch (e) { reject(e); }
+                try {
+                    resolve(
+                        await fetch(url, {
+                            ...fetchOptions,
+                            headers: {
+                                ...headers,
+                                Authorization: `Bearer ${sessionStorage.getItem('accessToken')}`
+                            }
+                        })
+                    );
+                } catch (e) {
+                    reject(e);
+                }
             });
         });
     }
 
+    /* ===== refresh 시작 ===== */
     isRefreshing = true;
     const refreshed = await refreshAccessToken();
     isRefreshing = false;
@@ -45,15 +71,27 @@ async function apiFetch(url, options = {}) {
         throw new Error('SESSION_EXPIRED');
     }
 
+    /* ===== 대기 중이던 요청 재시도 ===== */
     refreshSubscribers.forEach(cb => cb());
     refreshSubscribers = [];
-    options.headers.Authorization = `Bearer ${sessionStorage.getItem('accessToken')}`;
-    return fetch(url, options);
+
+    /* ===== 현재 요청 재시도 ===== */
+    return fetch(url, {
+        ...fetchOptions,
+        headers: {
+            ...headers,
+            Authorization: `Bearer ${sessionStorage.getItem('accessToken')}`
+        }
+    });
 }
 
 async function refreshAccessToken() {
-    const res = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' });
+    const res = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'include'
+    });
     if (!res.ok) return false;
+
     const result = await res.json();
     sessionStorage.setItem('accessToken', result.data.accessToken);
     saveSessionExpiry(result.data.refreshExpiresAt);

--- a/src/main/resources/templates/admin/hr/organization/list.html
+++ b/src/main/resources/templates/admin/hr/organization/list.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-admin :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{sidebar/admin-sidebar :: menu},
+        ~{::pageCss},
+        ~{::pageScript}
+      )}">
+
+<!-- ================= 페이지별 CSS ================= -->
+<th:block th:fragment="pageCss">
+    <link rel="stylesheet" th:href="@{/css/admin-org-category.css}">
+    <link rel="stylesheet" th:href="@{/css/admin-organization.css}">
+</th:block>
+
+<th:block th:fragment="content">
+
+    <div class="orgcat-title-row">
+        <h1 class="orgcat-title">조직 관리</h1>
+    </div>
+
+    <section class="orgcat-card">
+
+        <div class="orgcat-toolbar">
+            <div class="toolbar-left">
+                <div class="orgcat-search">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                    <input id="searchKeyword" type="text" placeholder="조직명 검색 (예: 팀)">
+                </div>
+                <button class="btn btn-outline" id="btnSearch">검색</button>
+                <label class="inactive-toggle">
+                    <input type="checkbox" id="includeInactive">
+                    <span>비활성 포함</span>
+                </label>
+            </div>
+
+            <div class="toolbar-right">
+                <button class="btn btn-primary" id="btnOpenCreate">조직 추가</button>
+            </div>
+        </div>
+
+        <div class="org-tree" id="orgTree"></div>
+
+        <div class="orgcat-footer">
+            <div class="orgcat-hint">
+                같은 상위 조직 내에서만 순서를 변경할 수 있습니다.
+            </div>
+            <button class="btn btn-outline" id="btnSaveOrder" disabled>
+                변경사항 저장
+            </button>
+        </div>
+
+    </section>
+
+    <!-- 조직 생성 / 수정 모달 -->
+    <div id="orgModal" class="modal hidden">
+        <div class="modal-panel">
+
+            <div class="modal-head">
+                <h2 id="modalTitle">조직 생성 / 수정</h2>
+                <button class="icon-btn" id="btnModalCloseIcon">
+                    <i class="fa-solid fa-xmark"></i>
+                </button>
+            </div>
+
+            <div class="modal-body">
+
+                <div class="form-group">
+                    <label class="form-label">조직 카테고리</label>
+                    <select id="categorySelect" class="form-input"></select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">조직명</label>
+                    <input id="orgName" class="form-input" type="text" placeholder="예: 인사팀">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">상위 조직</label>
+                    <select id="parentOrgSelect" class="form-input"></select>
+                </div>
+
+                <div class="form-group toggle-row">
+                    <span class="toggle-text">사용 여부</span>
+                    <label class="switch">
+                        <input type="checkbox" id="activeToggle">
+                        <span class="slider"></span>
+                    </label>
+                    <span id="activeLabel">사용</span>
+                </div>
+
+                <div class="form-help" id="inactiveHelp" style="display:none;">
+                    비활성화하려면 해당 조직에 소속된 사원이 없어야 합니다.
+                </div>
+
+            </div>
+
+            <div class="modal-actions">
+                <button class="btn btn-ghost" id="btnModalCancel">취소</button>
+                <button class="btn btn-primary" id="btnSaveOrg">저장</button>
+            </div>
+
+        </div>
+    </div>
+
+</th:block>
+
+<th:block th:fragment="pageScript">
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script th:src="@{/js/admin-organization.js}"></script>
+</th:block>
+
+</html>

--- a/src/main/resources/templates/admin/hr/organization/list.html
+++ b/src/main/resources/templates/admin/hr/organization/list.html
@@ -33,6 +33,10 @@
                     <input type="checkbox" id="includeInactive">
                     <span>비활성 포함</span>
                 </label>
+                <label class="inactive-toggle">
+                    <input type="checkbox" id="includeDescendants">
+                    <span>하위 조직 함께 보기</span>
+                </label>
             </div>
 
             <div class="toolbar-right">

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -83,8 +83,8 @@
             <li th:classappend="${currentMenu == 'org-category'} ? 'selected' : ''">
                 <a th:href="@{/view/admin/org-categories}">조직 카테고리 관리</a>
             </li>
-            <li th:classappend="${currentMenu} == 'organization' ? 'selected' : ''">
-                <a th:href="@{/admin/organization}">조직 구조 관리</a>
+            <li th:classappend="${currentMenu == 'organization'} ? 'selected' : ''">
+                <a th:href="@{/view/admin/organizations}">조직 관리</a>
             </li>
         </ul>
     </li>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #255

## 📝 작업 내용
- 조직 관리 트리 UX 전반 개선
  - 정렬 모드 제거 및 항상 Drag & Drop 가능하도록 변경
  - 형제 단위 정렬 + 하위 조직(서브트리) 동반 이동 지원
  - DOM 순서 기준으로 정렬 저장, 변경 시에만 저장 버튼 활성화
- 조직 검색 UX 개선 (Ctrl+F 방식)
  - 트리 구조 유지 + 검색어 하이라이트
  - 첫 검색 결과 자동 스크롤 및 상위 조직 자동 펼침
  - 검색 중 정렬 및 저장 기능 비활성화
- 검색 결과 노출 정책 정비
  - 회사(최상위 조직) 검색 결과 제외
  - 검색된 조직 + 상위 조직만 기본 노출
  - ‘하위 조직 함께 보기’ 옵션 추가 (선택적 하위 조직 노출)
- 비활성 조직 처리 정책 명확화
  - 비활성 포함 조회 옵션 유지
  - 비활성 조직은 시각적으로 구분 및 정렬/드래그 제한
- 조직 생성·수정 및 비활성화 UX 개선
  - 생성 시에만 카테고리/상위 조직 결정
  - 수정 시 비활성화 가능 여부 사전 체크 및 사유 안내
- 백엔드 OrgService 로직 정합성 개선
  - orderIndex 재배치 및 UNIQUE 충돌 이슈 해결
  - 조회/정렬 정책 일관성 정비

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
