### PR TITLE
feat(Rank): 직책 crud 고도화 + 화면 구현

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -91,7 +91,7 @@ CREATE TABLE hr_rank
     company_id        BIGINT      NOT NULL,
     parent_hr_rank_id BIGINT      NULL,
     name              VARCHAR(50) NOT NULL,
-    order_index       INT         NOT NULL,
+    order_index       INT,
     is_active         BOOLEAN     NOT NULL DEFAULT TRUE,
     created_at        TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at        TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/sql/insert.sql
+++ b/sql/insert.sql
@@ -431,19 +431,23 @@ SET @c1_rank_head := (SELECT id
                       LIMIT 1);
 
 UPDATE hr_rank
-SET parent_hr_rank_id=@c1_rank_staff
+SET parent_hr_rank_id = @c1_rank_asst
+WHERE company_id = @c1
+  AND name = '사원';
+UPDATE hr_rank
+SET parent_hr_rank_id = @c1_rank_mgr
 WHERE company_id = @c1
   AND name = '대리';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c1_rank_asst
+SET parent_hr_rank_id = @c1_rank_sr
 WHERE company_id = @c1
   AND name = '과장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c1_rank_mgr
+SET parent_hr_rank_id = @c1_rank_head
 WHERE company_id = @c1
   AND name = '차장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c1_rank_sr
+SET parent_hr_rank_id = NULL
 WHERE company_id = @c1
   AND name = '부장';
 
@@ -1031,19 +1035,23 @@ SET @c2_rank_head := (SELECT id
                       LIMIT 1);
 
 UPDATE hr_rank
-SET parent_hr_rank_id=@c2_rank_staff
+SET parent_hr_rank_id = @c2_rank_asst
+WHERE company_id = @c2
+  AND name = '사원';
+UPDATE hr_rank
+SET parent_hr_rank_id = @c2_rank_mgr
 WHERE company_id = @c2
   AND name = '대리';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c2_rank_asst
+SET parent_hr_rank_id = @c2_rank_sr
 WHERE company_id = @c2
   AND name = '과장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c2_rank_mgr
+SET parent_hr_rank_id = @c2_rank_head
 WHERE company_id = @c2
   AND name = '차장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c2_rank_sr
+SET parent_hr_rank_id = NULL
 WHERE company_id = @c2
   AND name = '부장';
 
@@ -1598,19 +1606,23 @@ SET @c3_rank_head := (SELECT id
                       LIMIT 1);
 
 UPDATE hr_rank
-SET parent_hr_rank_id=@c3_rank_staff
+SET parent_hr_rank_id = @c3_rank_asst
+WHERE company_id = @c3
+  AND name = '사원';
+UPDATE hr_rank
+SET parent_hr_rank_id = @c3_rank_mgr
 WHERE company_id = @c3
   AND name = '대리';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c3_rank_asst
+SET parent_hr_rank_id = @c3_rank_sr
 WHERE company_id = @c3
   AND name = '과장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c3_rank_mgr
+SET parent_hr_rank_id = @c3_rank_head
 WHERE company_id = @c3
   AND name = '차장';
 UPDATE hr_rank
-SET parent_hr_rank_id=@c3_rank_sr
+SET parent_hr_rank_id = NULL
 WHERE company_id = @c3
   AND name = '부장';
 

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/controller/RankController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/controller/RankController.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/ranks")
+@RequestMapping("/api/admin/ranks")
 public class RankController {
 
     private final RankService rankService;

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/controller/RankViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/controller/RankViewController.java
@@ -1,0 +1,31 @@
+package com.finalproj.orbitflow.hr.rank.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : RankViewController
+ * @since : 2025-12-27 토요일
+ */
+@Controller
+@RequestMapping("/view/admin/ranks")
+public class RankViewController {
+
+    /**
+     * 직급 관리 목록 화면
+     */
+    @GetMapping
+    public String orgCategoryList(Model model) {
+
+        model.addAttribute("pageTitle", "직급 관리");
+        model.addAttribute("currentMenu", "rank");
+        model.addAttribute("sidebarFragment", "admin-sidebar");
+
+        return "admin/hr/rank/list";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/entity/HrRank.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/entity/HrRank.java
@@ -40,8 +40,8 @@ public class HrRank extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name; // 대리 / 과장 등
 
-    @Column(name = "order_index", nullable = false)
-    private Integer orderIndex;
+    @Column(name = "order_index")
+    private Integer orderIndex; // null 허용
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
@@ -58,21 +58,22 @@ public class HrRank extends BaseEntity {
     }
 
     // ====== 도메인 메서드 ======
-    public void update(String name, HrRank parentHrRank, Boolean isActive) {
+    public void update(String name, HrRank parentHrRank) {
         this.name = name;
         this.parentHrRank = parentHrRank;
-        this.isActive = isActive;
     }
 
     public void changeOrderIndex(Integer orderIndex) {
         this.orderIndex = orderIndex;
     }
 
-    public void activate() {
+    public void activate(Integer newOrderIndex) {
         this.isActive = true;
+        this.orderIndex = newOrderIndex;
     }
 
     public void deactivate() {
         this.isActive = false;
+        this.orderIndex = null;
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/repository/RankRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/repository/RankRepository.java
@@ -2,6 +2,7 @@ package com.finalproj.orbitflow.hr.rank.repository;
 
 import com.finalproj.orbitflow.hr.rank.entity.HrRank;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -14,26 +15,25 @@ import java.util.List;
  */
 public interface RankRepository extends JpaRepository<HrRank, Long> {
 
-    // 목록 - 비활성 제외
+
     List<HrRank> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
 
-    // 목록 - 비활성 포함
-    List<HrRank> findByCompanyIdOrderByOrderIndexAsc(Long companyId);
+    List<HrRank> findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(Long companyId);
 
-    // 검색 - 비활성 제외
-    List<HrRank> findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(Long companyId, String keyword);
+    List<HrRank> findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(
+            Long companyId, String keyword);
 
-    // 검색 - 비활성 포함
-    List<HrRank> findByCompanyIdAndNameContainingIgnoreCaseOrderByOrderIndexAsc(Long companyId, String keyword);
-
-    // 중복 체크
     boolean existsByCompanyIdAndName(Long companyId, String name);
 
-    // 수정 시 중복 체크 (자기 자신 제외)
     boolean existsByCompanyIdAndNameAndIdNot(Long companyId, String name, Long id);
 
-    // 상위 직급 선택용(활성만, 자기 자신 제외)
-    List<HrRank> findByCompanyIdAndIsActiveTrueAndIdNotOrderByOrderIndexAsc(Long companyId, Long id);
-
     long countByCompanyIdAndIsActiveTrue(Long companyId);
+
+    @Query("""
+                select max(r.orderIndex)
+                from HrRank r
+                where r.company.id = :companyId
+                  and r.isActive = true
+            """)
+    Integer findMaxActiveOrderIndex(Long companyId);
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
@@ -25,29 +25,30 @@ import java.util.List;
  */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class RankService {
 
     private final RankRepository rankRepository;
     private final CompanyRepository companyRepository;
     private final EmployeeRepository employeeRepository;
 
+    /* ================= 목록 ================= */
+    @Transactional(readOnly = true)
     public List<RankResDto> getRanks(Long companyId, String keyword, boolean includeInactive) {
 
-        boolean hasKeyword = keyword != null && !keyword.isBlank();
         List<HrRank> ranks;
 
-        if (hasKeyword) {
-            ranks = includeInactive
-                    ? rankRepository.findByCompanyIdAndNameContainingIgnoreCaseOrderByOrderIndexAsc(companyId, keyword.trim())
-                    : rankRepository.findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(companyId, keyword.trim());
+        if (includeInactive) {
+            ranks = rankRepository
+                    .findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(companyId);
         } else {
-            ranks = includeInactive
-                    ? rankRepository.findByCompanyIdOrderByOrderIndexAsc(companyId)
-                    : rankRepository.findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId);
+            ranks = (keyword == null || keyword.isBlank())
+                    ? rankRepository.findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId)
+                    : rankRepository
+                    .findByCompanyIdAndIsActiveTrueAndNameContainingIgnoreCaseOrderByOrderIndexAsc(
+                            companyId, keyword.trim());
         }
 
-        // employeeCount 포함
         return ranks.stream()
                 .map(rank -> RankResDto.builder()
                         .id(rank.getId())
@@ -61,7 +62,7 @@ public class RankService {
                 .toList();
     }
 
-    @Transactional
+    /* ================= 생성 ================= */
     public Long createRank(Long companyId, RankCreateReqDto req) {
 
         String name = req.getName().trim();
@@ -81,12 +82,14 @@ public class RankService {
             }
         }
 
-        Integer orderIndex = calcNextOrder(companyId);
-        HrRank saved = rankRepository.save(HrRank.create(company, parent, name, orderIndex));
-        return saved.getId();
+        Integer max = rankRepository.findMaxActiveOrderIndex(companyId);
+        int nextOrder = (max == null) ? 1 : max + 1;
+
+        HrRank rank = HrRank.create(company, parent, name, nextOrder);
+        return rankRepository.save(rank).getId();
     }
 
-    @Transactional
+    /* ================= 수정 ================= */
     public void updateRank(Long companyId, Long rankId, RankUpdateReqDto req) {
 
         HrRank rank = getRank(companyId, rankId);
@@ -99,60 +102,49 @@ public class RankService {
         HrRank parent = null;
         if (req.getParentRankId() != null) {
             if (req.getParentRankId().equals(rankId)) {
-                throw new BusinessException("자기 자신을 상위 직급으로 설정할 수 없습니다.");
+                throw new BusinessException("자기 자신을 상위 직급으로 지정할 수 없습니다.");
             }
             parent = getRank(companyId, req.getParentRankId());
-            if (!parent.getIsActive()) {
-                throw new BusinessException("비활성 직급은 상위 직급으로 지정할 수 없습니다.");
+        }
+
+        // ===== 활성/비활성 =====
+        if (req.getIsActive() != null) {
+
+            // 비활성화
+            if (!req.getIsActive()) {
+                long count = employeeRepository.countByCompanyIdAndRank_Id(companyId, rankId);
+                if (count > 0) {
+                    throw new BusinessException("부여 인원이 있는 직급은 비활성화할 수 없습니다.");
+                }
+                rank.deactivate();
+            }
+
+            // 재활성화
+            if (req.getIsActive() && !rank.getIsActive()) {
+                Integer max = rankRepository.findMaxActiveOrderIndex(companyId);
+                rank.activate(max == null ? 1 : max + 1);
             }
         }
 
-        if (Boolean.FALSE.equals(req.getIsActive())) {
-            long count = employeeRepository.countByCompanyIdAndRank_Id(companyId, rankId);
-            if (count > 0) {
-                throw new BusinessException("부여 인원이 있는 직급은 비활성화할 수 없습니다.");
-            }
-        }
-
-        rank.update(name, parent,
-                req.getIsActive() != null ? req.getIsActive() : rank.getIsActive());
+        // 이름/상위 직급만 변경
+        rank.update(name, parent);
     }
 
 
-    @Transactional
+    /* ================= 순서 ================= */
     public void updateOrder(Long companyId, List<RankOrderUpdateReqDto.OrderItem> orders) {
-
-        if (orders == null || orders.isEmpty()) {
-            throw new BusinessException("순서 정보가 비어 있습니다.");
-        }
-
-        long distinctCount = orders.stream()
-                .map(RankOrderUpdateReqDto.OrderItem::getId)
-                .distinct()
-                .count();
-
-        if (distinctCount != orders.size()) {
-            throw new BusinessException("중복된 직급 ID가 존재합니다.");
-        }
 
         long activeCount = rankRepository.countByCompanyIdAndIsActiveTrue(companyId);
         if (activeCount != orders.size()) {
             throw new BusinessException("정렬 대상 개수가 일치하지 않습니다.");
         }
 
-        // 1단계: 임시 orderIndex
         int temp = -1;
         for (var item : orders) {
-            HrRank rank = getRank(companyId, item.getId());
-            if (!rank.getIsActive()) {
-                throw new BusinessException("비활성 직급은 순서 변경 대상이 될 수 없습니다.");
-            }
-            rank.changeOrderIndex(temp--);
+            getRank(companyId, item.getId()).changeOrderIndex(temp--);
         }
-
         rankRepository.flush();
 
-        // 2단계: 최종 orderIndex
         int index = 1;
         for (var item : orders) {
             HrRank rank = getRank(companyId, item.getId());
@@ -160,22 +152,12 @@ public class RankService {
         }
     }
 
-
-
-    private HrRank getRank(Long companyId, Long rankId) {
-        HrRank rank = rankRepository.findById(rankId)
+    private HrRank getRank(Long companyId, Long id) {
+        HrRank rank = rankRepository.findById(id)
                 .orElseThrow(() -> new BusinessException("직급을 찾을 수 없습니다."));
         if (!rank.getCompany().getId().equals(companyId)) {
             throw new BusinessException("해당 회사의 직급이 아닙니다.");
         }
         return rank;
-    }
-
-    private Integer calcNextOrder(Long companyId) {
-        return rankRepository.findByCompanyIdOrderByOrderIndexAsc(companyId)
-                .stream()
-                .map(HrRank::getOrderIndex)
-                .max(Integer::compareTo)
-                .orElse(0) + 1;
     }
 }

--- a/src/main/resources/static/css/admin-rank.css
+++ b/src/main/resources/static/css/admin-rank.css
@@ -1,0 +1,515 @@
+/* ==================================================
+   admin-rank.css
+   - 직급 관리 화면 전용 CSS (독립 파일)
+================================================== */
+
+:root {
+    --bg: #f5f7fb;
+    --card: #ffffff;
+    --line: #eef1f6;
+    --text: #111827;
+    --muted: #6b7280;
+
+    --primary: #2f6af6;
+    --primary-weak: rgba(47, 106, 246, .12);
+
+    --success-bg: #dff7e7;
+    --success-text: #137a3a;
+
+    --danger-bg: #fde2e2;
+    --danger-text: #b42318;
+
+    --shadow: 0 12px 36px rgba(16, 24, 40, 0.08);
+}
+
+/* =========================
+   Title
+========================= */
+.rank-title-row {
+    margin-bottom: 18px;
+}
+
+.rank-title {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+    color: var(--text);
+    margin: 0;
+}
+
+/* =========================
+   Card
+========================= */
+.rank-card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    padding: 18px 18px 14px;
+}
+
+/* =========================
+   Toolbar
+========================= */
+.rank-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.toolbar-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.toolbar-right {
+    display: flex;
+    align-items: center;
+}
+
+/* =========================
+   Search
+========================= */
+.rank-search {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0 14px;
+    background: #fbfcff;
+}
+
+.rank-search i {
+    color: #9aa3b2;
+    font-size: 14px;
+    pointer-events: none;
+}
+
+.rank-search input {
+    width: 220px;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 13.5px;
+    color: var(--text);
+    pointer-events: auto;
+    position: relative;
+    z-index: 1;
+}
+
+.rank-search input::placeholder {
+    color: #9aa3b2;
+}
+
+/* =========================
+   Buttons
+========================= */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 42px;
+    padding: 0 16px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-size: 13.5px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform .06s ease, background .15s ease, border-color .15s ease;
+}
+
+.btn:active {
+    transform: translateY(1px);
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 10px 24px rgba(47, 106, 246, .22);
+}
+
+.btn-primary:hover {
+    filter: brightness(0.98);
+}
+
+.btn-outline {
+    background: #fff;
+    color: var(--primary);
+    border-color: rgba(47, 106, 246, .35);
+}
+
+.btn-outline:hover {
+    background: var(--primary-weak);
+}
+
+.btn-outline:disabled {
+    cursor: not-allowed;
+    opacity: .45;
+}
+
+.btn-ghost {
+    background: #fff;
+    color: #374151;
+    border-color: #e5e7eb;
+}
+
+.btn-ghost:hover {
+    background: #f3f4f6;
+}
+
+/* =========================
+   Inactive toggle
+========================= */
+.inactive-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #475467;
+}
+
+.inactive-toggle small {
+    font-weight: 500;
+    color: #98a2b3;
+}
+
+/* =========================
+   Table
+========================= */
+.rank-table-wrap {
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.rank-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13.5px;
+}
+
+.rank-table thead th {
+    background: #f6f7fb;
+    color: #667085;
+    text-align: left;
+    padding: 14px 16px;
+    font-weight: 800;
+    border-bottom: 1px solid var(--line);
+}
+
+.rank-table tbody td {
+    padding: 16px 16px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: middle;
+    color: var(--text);
+}
+
+.rank-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.col-order {
+    width: 90px;
+}
+
+.col-status {
+    width: 120px;
+}
+
+.col-action {
+    width: 120px;
+}
+
+/* =========================
+   Drag handle
+========================= */
+.drag-handle {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    cursor: grab;
+    color: #98a2b3;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-dots {
+    width: 14px;
+    height: 18px;
+    display: grid;
+    grid-template-columns: repeat(2, 4px);
+    grid-template-rows: repeat(3, 4px);
+    gap: 3px;
+}
+
+.drag-dots span {
+    width: 4px;
+    height: 4px;
+    background: #a9b1c3;
+    border-radius: 50%;
+}
+
+/* =========================
+   Status badge
+========================= */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 64px;
+    height: 30px;
+    padding: 0 12px;
+    border-radius: 999px;
+    font-size: 12.5px;
+    font-weight: 800;
+}
+
+.status-active {
+    background: var(--success-bg);
+    color: var(--success-text);
+}
+
+.status-inactive {
+    background: var(--danger-bg);
+    color: var(--danger-text);
+}
+
+/* =========================
+   Table button
+========================= */
+.table-btn {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #d0d5dd;
+    background: #fff;
+    font-weight: 800;
+    font-size: 13px;
+    color: #344054;
+    cursor: pointer;
+}
+
+.table-btn:hover {
+    background: #f3f4f6;
+}
+
+/* =========================
+   Footer
+========================= */
+.rank-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 6px 0;
+}
+
+.rank-hint {
+    font-size: 12.5px;
+    color: #98a2b3;
+}
+
+/* =========================
+   Modal
+========================= */
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    padding: 18px;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-panel {
+    width: 720px;
+    max-width: 92vw;
+    background: #fff;
+    border-radius: 18px;
+    box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
+    overflow: hidden;
+}
+
+.modal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 22px 24px 10px;
+}
+
+.modal-head h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 900;
+}
+
+.icon-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid #eef2f7;
+    background: #fff;
+    cursor: pointer;
+}
+
+.icon-btn:hover {
+    background: #f3f4f6;
+}
+
+.modal-body {
+    padding: 8px 24px 18px;
+}
+
+/* =========================
+   Form
+========================= */
+.form-group {
+    margin-top: 14px;
+}
+
+.form-label {
+    display: block;
+    font-size: 12.5px;
+    font-weight: 900;
+    color: #667085;
+    margin-bottom: 8px;
+}
+
+.form-input {
+    width: 100%;
+    height: 46px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #e6eaf2;
+    background: #fbfcff;
+    font-size: 13.5px;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: rgba(47, 106, 246, .55);
+    box-shadow: 0 0 0 4px rgba(47, 106, 246, .12);
+}
+
+.form-help {
+    margin-top: 6px;
+    font-size: 12.5px;
+    color: #ef4444;
+}
+
+/* =========================
+   Toggle switch
+========================= */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.toggle-text {
+    font-weight: 900;
+    font-size: 13.5px;
+}
+
+.switch {
+    position: relative;
+    width: 54px;
+    height: 30px;
+}
+
+.switch input {
+    display: none;
+}
+
+.slider {
+    position: absolute;
+    inset: 0;
+    background: #d0d5dd;
+    border-radius: 999px;
+    transition: .2s;
+}
+
+.slider::before {
+    content: "";
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    left: 3px;
+    top: 3px;
+    background: #fff;
+    border-radius: 50%;
+    transition: .2s;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, .12);
+}
+
+.switch input:checked + .slider {
+    background: var(--primary);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(24px);
+}
+
+/* =========================
+   Modal actions
+========================= */
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 24px 22px;
+    border-top: 1px solid #eef2f7;
+}
+
+/* =========================
+   Sortable
+========================= */
+.sortable-chosen {
+    background: #f7f9ff;
+}
+
+.sortable-ghost {
+    opacity: .6;
+}
+
+/* =========================
+   Responsive
+========================= */
+@media (max-width: 720px) {
+    .rank-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .rank-search {
+        width: 100%;
+    }
+
+    .rank-footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .rank-footer .btn {
+        width: 100%;
+    }
+}

--- a/src/main/resources/static/js/admin-rank.js
+++ b/src/main/resources/static/js/admin-rank.js
@@ -1,0 +1,247 @@
+const API_BASE = '/api/admin/ranks';
+
+let rankList = [];
+let selectedRankId = null;
+let sortable = null;
+let isOrderChanged = false;
+
+const els = {
+    tbody: () => document.getElementById('rankTableBody'),
+    search: () => document.getElementById('searchKeyword'),
+    btnSearch: () => document.getElementById('btnSearch'),
+    includeInactive: () => document.getElementById('includeInactive'),
+    btnOpenCreate: () => document.getElementById('btnOpenCreate'),
+    btnSaveOrder: () => document.getElementById('btnSaveOrder'),
+
+    modal: () => document.getElementById('rankModal'),
+    modalTitle: () => document.getElementById('modalTitle'),
+    rankId: () => document.getElementById('rankId'),
+    rankName: () => document.getElementById('rankName'),
+    parentRank: () => document.getElementById('parentRank'),
+    rankActive: () => document.getElementById('rankActive'),
+    toggleText: () => document.getElementById('toggleText'),
+    nameHelp: () => document.getElementById('nameHelp'),
+
+    btnSaveRank: () => document.getElementById('btnSaveRank'),
+    btnCancel: () => document.getElementById('btnCancel'),
+    btnCloseModal: () => document.getElementById('btnCloseModal'),
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    bindEvents();
+    loadRanks();
+});
+
+function bindEvents() {
+    els.btnSearch().onclick = filterRanks;
+    els.search().addEventListener('keydown', e => {
+        e.stopPropagation();
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            filterRanks();
+        }
+    });
+    els.includeInactive().onchange = loadRanks;
+
+    els.btnOpenCreate().onclick = openCreateModal;
+    els.btnSaveRank().onclick = saveRank;
+    els.btnSaveOrder().onclick = saveOrder;
+
+    els.btnCancel().onclick = closeModal;
+    els.btnCloseModal().onclick = closeModal;
+
+    els.rankActive().onchange = () =>
+        els.toggleText().textContent = els.rankActive().checked ? '사용' : '미사용';
+}
+
+async function loadRanks() {
+    const includeInactive = els.includeInactive().checked;
+    const res = await apiFetch(`${API_BASE}?includeInactive=${includeInactive}`);
+    const json = await res.json();
+    rankList = json.data || [];
+    filterRanks();
+    resetOrder();
+}
+
+function filterRanks() {
+    const keyword = els.search().value.trim().toLowerCase();
+    const includeInactive = els.includeInactive().checked;
+
+    const filtered = rankList.filter(r => {
+        if (!includeInactive && !r.isActive) return false;
+        return r.name.toLowerCase().includes(keyword);
+    });
+
+    renderTable(filtered);
+
+    if (!isSearchMode()) initSortable();
+    else destroySortable();
+}
+
+function isSearchMode() {
+    return els.search().value.trim().length > 0 || els.includeInactive().checked;
+}
+
+function renderTable(list) {
+    const tbody = els.tbody();
+    tbody.innerHTML = '';
+
+    const active = list.filter(r => r.isActive)
+        .sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0));
+    const inactive = list.filter(r => !r.isActive);
+
+    active.forEach(renderRow);
+
+    if (inactive.length) {
+        tbody.insertAdjacentHTML('beforeend',
+            `<tr><td colspan="6" class="inactive-sep">비활성 직급</td></tr>`);
+        inactive.forEach(renderRow);
+    }
+}
+
+function renderRow(r) {
+    const tr = document.createElement('tr');
+    tr.dataset.id = r.id;
+
+    tr.innerHTML = `
+      <td>${r.isActive && !isSearchMode() ? dragHandle() : ''}</td>
+      <td><strong>${r.name}</strong></td>
+      <td>${r.parentRankName ?? '-'}</td>
+      <td>${r.employeeCount}</td>
+      <td>
+        <span class="status-badge ${r.isActive ? 'status-active' : 'status-inactive'}">
+          ${r.isActive ? '활성' : '비활성'}
+        </span>
+      </td>
+      <td>
+        <button class="table-btn">수정</button>
+      </td>
+    `;
+
+    tr.querySelector('.table-btn').onclick = () => openEditModal(r.id);
+    els.tbody().appendChild(tr);
+}
+
+function dragHandle() {
+    return `
+      <span class="drag-handle">
+        <span class="drag-dots">
+          <span></span><span></span><span></span>
+          <span></span><span></span><span></span>
+        </span>
+      </span>`;
+}
+
+function initSortable() {
+    destroySortable();
+    sortable = Sortable.create(els.tbody(), {
+        handle: '.drag-handle',
+        animation: 150,
+        onEnd: () => {
+            isOrderChanged = true;
+            els.btnSaveOrder().disabled = false;
+        }
+    });
+}
+
+function destroySortable() {
+    sortable?.destroy();
+    sortable = null;
+}
+
+async function saveOrder() {
+    if (!isOrderChanged) return;
+
+    const rows = [...els.tbody().querySelectorAll('tr[data-id]')];
+    const payload = {
+        orders: rows.map(r => ({id: Number(r.dataset.id)}))
+    };
+
+    await apiFetch(`${API_BASE}/order`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+
+    loadRanks();
+}
+
+function openCreateModal() {
+    selectedRankId = null;
+    els.modalTitle().textContent = '직급 추가';
+    els.rankName().value = '';
+    els.rankActive().checked = true;
+    els.rankActive().disabled = true;
+    fillParentOptions();
+    openModal();
+}
+
+function openEditModal(id) {
+    const r = rankList.find(v => v.id === id);
+    selectedRankId = id;
+
+    els.modalTitle().textContent = '직급 수정';
+    els.rankName().value = r.name;
+
+    els.rankActive().checked = r.isActive;
+    els.rankActive().disabled = r.employeeCount > 0;
+
+    if (r.employeeCount > 0) {
+        els.toggleText().textContent = '사용 (부여 인원 존재)';
+    } else {
+        els.toggleText().textContent = r.isActive ? '사용' : '미사용';
+    }
+
+    fillParentOptions(id);
+
+    if (r.parentRankId) {
+        els.parentRank().value = String(r.parentRankId);
+    }
+
+    openModal();
+}
+
+function fillParentOptions(excludeId) {
+    els.parentRank().innerHTML = `<option value="">없음</option>`;
+    rankList.filter(r => r.isActive && r.id !== excludeId)
+        .forEach(r => {
+            els.parentRank().insertAdjacentHTML(
+                'beforeend',
+                `<option value="${r.id}">${r.name}</option>`
+            );
+        });
+}
+
+async function saveRank() {
+    const payload = {
+        name: els.rankName().value.trim(),
+        parentRankId: els.parentRank().value || null,
+        isActive: els.rankActive().checked
+    };
+
+    const url = selectedRankId
+        ? `${API_BASE}/${selectedRankId}`
+        : API_BASE;
+
+    await apiFetch(url, {
+        method: selectedRankId ? 'PUT' : 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+
+    closeModal();
+    loadRanks();
+}
+
+function openModal() {
+    els.modal().classList.remove('hidden');
+}
+
+function closeModal() {
+    els.modal().classList.add('hidden');
+}
+
+function resetOrder() {
+    isOrderChanged = false;
+    els.btnSaveOrder().disabled = true;
+}

--- a/src/main/resources/templates/admin/hr/rank/list.html
+++ b/src/main/resources/templates/admin/hr/rank/list.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-admin :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{sidebar/admin-sidebar :: menu},
+        ~{::pageCss},
+        ~{::pageScript}
+      )}">
+
+<th:block th:fragment="pageCss">
+  <link rel="stylesheet" th:href="@{/css/admin-rank.css}">
+</th:block>
+
+<th:block th:fragment="content">
+
+  <!-- 타이틀 -->
+  <div class="rank-title-row">
+    <h1 class="rank-title">직급 관리</h1>
+  </div>
+
+  <section class="rank-card">
+
+    <!-- ===== Toolbar ===== -->
+    <div class="rank-toolbar">
+
+      <div class="toolbar-left">
+
+        <div class="rank-search">
+          <i class="fa-solid fa-magnifying-glass"></i>
+          <input id="searchKeyword"
+                 type="text"
+                 placeholder="직급명 검색">
+        </div>
+
+        <button class="btn btn-outline" id="btnSearch">검색</button>
+
+        <label class="inactive-toggle">
+          <input type="checkbox" id="includeInactive">
+          <span>비활성 포함</span>
+          <small>(정렬 제외)</small>
+        </label>
+
+      </div>
+
+      <div class="toolbar-right">
+        <button class="btn btn-primary" id="btnOpenCreate">
+          + 직급 추가
+        </button>
+      </div>
+
+    </div>
+
+    <!-- ===== Table ===== -->
+    <div class="rank-table-wrap">
+      <table class="rank-table">
+        <thead>
+        <tr>
+          <th class="col-order">순서</th>
+          <th>직급명</th>
+          <th>상위 직급</th>
+          <th>부여 인원</th>
+          <th class="col-status">상태</th>
+          <th class="col-action">관리</th>
+        </tr>
+        </thead>
+        <tbody id="rankTableBody"></tbody>
+      </table>
+    </div>
+
+    <!-- ===== Footer ===== -->
+    <div class="rank-footer">
+      <div class="rank-hint" id="orderHint">
+        드래그앤드롭으로 순서를 변경할 수 있습니다.
+      </div>
+      <button class="btn btn-outline"
+              id="btnSaveOrder"
+              disabled>
+        변경사항저장
+      </button>
+    </div>
+
+  </section>
+
+  <!-- ===== Modal ===== -->
+  <div id="rankModal" class="modal hidden">
+    <div class="modal-panel" role="dialog">
+
+      <div class="modal-head">
+        <h2 id="modalTitle">직급 추가 / 수정</h2>
+        <button class="icon-btn" id="btnCloseModal">
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+
+      <input type="hidden" id="rankId">
+
+      <div class="modal-body">
+
+        <div class="form-group">
+          <label class="form-label">직급명</label>
+          <input id="rankName" class="form-input" type="text">
+          <p class="form-help" id="nameHelp"></p>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">상위 직급</label>
+          <select id="parentRank" class="form-input"></select>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">사용 여부</label>
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="rankActive" checked>
+              <span class="slider"></span>
+            </label>
+            <span class="toggle-text" id="toggleText">사용</span>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="modal-actions">
+        <button class="btn btn-ghost" id="btnCancel">취소</button>
+        <button class="btn btn-primary" id="btnSaveRank">저장</button>
+      </div>
+
+    </div>
+  </div>
+
+</th:block>
+
+<th:block th:fragment="pageScript">
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+  <script th:src="@{/js/admin-rank.js}"></script>
+</th:block>
+
+</html>

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -86,6 +86,9 @@
             <li th:classappend="${currentMenu == 'organization'} ? 'selected' : ''">
                 <a th:href="@{/view/admin/organizations}">조직 관리</a>
             </li>
+            <li th:classappend="${currentMenu == 'rank'} ? 'selected' : ''">
+                <a th:href="@{/view/admin/ranks}">조직 관리</a>
+            </li>
         </ul>
     </li>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #267

## 📝 작업 내용
- 관리자 > 직책 관리 화면 구현
- 직책 목록 조회 (비활성 포함 옵션)
- 직책 생성 / 수정
- 직책 비활성화 / 재활성화
  - 부여 인원 존재 시 비활성화 제한
- 활성 직책 대상 Drag & Drop 정렬
- 비활성 직책은 정렬 대상에서 제외

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 참고사항
- 관리자 공통 인증 타이밍(common.js) 이슈로 콘솔에 401/403 로그가 발생할 수 있으나, 기능 동작에는 영향 없음
- 해당 이슈는 추후 공통 영역에서 별도 PR로 정리 예정