### PR TITLE
feat(PositionCategory, OrgPositionUsage): 조직 유형 기반 직책 계층 및 조직별 직책 사용 …

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -108,6 +108,7 @@ CREATE TABLE position_category
     id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
     company_id         BIGINT      NOT NULL,
     org_category_id    BIGINT      NOT NULL, -- 조직 카테고리 귀속
+    parent_position_id BIGINT      NULL,     -- 상위 직책 (self join)
     name               VARCHAR(50) NOT NULL, -- 사장 / 본부장 / 부장 / 팀장
     order_index        INT,                  -- 비활성 항목 때문에 NULL 허용
     is_head            BOOLEAN     NOT NULL DEFAULT FALSE,
@@ -134,7 +135,12 @@ CREATE TABLE position_category
         FOREIGN KEY (company_id) REFERENCES company (id),
 
     CONSTRAINT fk_pos_cat_org_category
-        FOREIGN KEY (org_category_id) REFERENCES org_category (id)
+        FOREIGN KEY (org_category_id) REFERENCES org_category (id),
+
+    CONSTRAINT fk_pos_cat_parent
+        FOREIGN KEY (parent_position_id)
+            REFERENCES position_category (id)
+            ON DELETE SET NULL
 ) ENGINE = InnoDB;
 
 

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -183,19 +183,19 @@ public class CompanyService {
             OrgCategory teamCat
     ) {
         positionCategoryRepository.save(
-                PositionCategory.create(company, companyCat, "사장", 1, true)
+                PositionCategory.create(company, companyCat, null, "사장", 1, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, hqCat, "본부장", 2, true)
+                PositionCategory.create(company, hqCat, null, "본부장", 2, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, deptCat, "부장", 3, true)
+                PositionCategory.create(company, deptCat, null, "부장", 3, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, teamCat, "팀장", 4, true)
+                PositionCategory.create(company, teamCat, null, "팀장", 4, true)
         );
         positionCategoryRepository.save(
-                PositionCategory.create(company, teamCat, "팀원", 5, true)
+                PositionCategory.create(company, teamCat, null, "팀원", 5, false)
         );
     }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
@@ -96,11 +96,11 @@ public class OrgPositionUsageService {
             }
 
             // 조직 카테고리 일치 검증
-            if (!category.getOrgCategory().getId().equals(org.getCategoryId())) {
-                throw new InvalidStateException(
-                        "해당 조직 유형에서 사용할 수 없는 직책 카테고리입니다."
-                );
-            }
+//            if (!category.getOrgCategory().getId().equals(org.getCategoryId())) {
+//                throw new InvalidStateException(
+//                        "해당 조직 유형에서 사용할 수 없는 직책 카테고리입니다."
+//                );
+//            }
 
             repository.save(
                     OrgPositionUsage.create(company, org, category)

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
  * @filename : PositionCategoryController
  * @since : 2025-12-22 월요일
  */
+@PreAuthorize("hasAnyRole('ADMIN','COMPANY_ADMIN')")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/position-categories")
@@ -46,7 +48,10 @@ public class PositionCategoryController {
                 new ResponseDto<>(
                         HttpStatus.OK,
                         "직책 카테고리 전체 조회 완료",
-                        positionCategoryService.findAll(SecurityUtils.getCompanyId(), includeInactive)
+                        positionCategoryService.findAllWithAssignedCount(
+                                SecurityUtils.getCompanyId(),
+                                includeInactive
+                        )
                 )
         );
     }
@@ -67,11 +72,14 @@ public class PositionCategoryController {
         );
     }
 
-    @PostMapping("/order")
+    @PutMapping("/order")
     public ResponseEntity<ResponseDto> updateOrder(
             @RequestBody @Valid PositionCategoryOrderUpdateReqDto request
     ) {
-        positionCategoryService.updateOrder(SecurityUtils.getCompanyId(), request.getOrders());
+        positionCategoryService.updateOrder(
+                SecurityUtils.getCompanyId(),
+                request.getOrders()
+        );
         return ResponseEntity.ok(
                 new ResponseDto<>(
                         HttpStatus.OK,

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryViewController.java
@@ -1,0 +1,26 @@
+package com.finalproj.orbitflow.hr.positionCategory.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryViewController
+ * @since : 2025-12-28 일요일
+ */
+@Controller
+@RequestMapping("/view/admin/position-categories")
+public class PositionCategoryViewController {
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("pageTitle", "직책 관리");
+        model.addAttribute("currentMenu", "position-category");
+        model.addAttribute("sidebarFragment", "admin-sidebar");
+        return "admin/hr/position-category/list";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryListDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryListDto.java
@@ -1,0 +1,26 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+/**
+ * 직책 관리 목록 + 조직 정책용 DTO
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryListDto
+ * @since : 2025-12-29 월요일
+ */
+
+public record PositionCategoryListDto(
+        Long id,
+        String name,
+
+        Long orgCategoryId,
+        String orgCategoryName,
+
+        Long parentPositionId,
+        String parentPositionName,
+
+        Boolean isHead,
+        Boolean isActive,
+
+        Long assignedCount,
+        Integer orderIndex
+) {}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryReqDto.java
@@ -1,5 +1,8 @@
 package com.finalproj.orbitflow.hr.positionCategory.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,8 +16,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PositionCategoryReqDto {
+    @NotBlank
+    @Size(max = 50)
     private String name;
+
+    @NotNull
     private Long orgCategoryId;
+
+    private Long parentPositionId;
+
+    @NotNull
     private Boolean isHead;
+
+    // 수정 시만 사용 (create 시 null 허용)
     private Boolean isActive;
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryResDto.java
@@ -18,16 +18,17 @@ public class PositionCategoryResDto {
     private Long id;
     private String name;
     private Integer orderIndex;
+    private Boolean isHead;
     private Boolean isActive;
 
 
     public static PositionCategoryResDto from(PositionCategory entity) {
-        return PositionCategoryResDto.builder()
-                .id(entity.getId())
-                .name(entity.getName())
-                .orderIndex(entity.getOrderIndex())
-                .isActive(entity.getIsActive())
-                .build();
+        return new PositionCategoryResDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getOrderIndex(),
+                entity.getIsHead(),
+                entity.getIsActive()
+        );
     }
-
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/entity/PositionCategory.java
@@ -21,14 +21,14 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "position_category",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"company_id", "name"})
+                @UniqueConstraint(columnNames = {"company_id", "org_category_id", "name"})
         }
 )
 public class PositionCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // 카테고리 ID
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id", nullable = false)
@@ -37,6 +37,10 @@ public class PositionCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "org_category_id", nullable = false)
     private OrgCategory orgCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_position_id")
+    private PositionCategory parent;
 
     @Column(nullable = false, length = 50)
     private String name; // 본부장 / 팀장 등
@@ -55,27 +59,43 @@ public class PositionCategory extends BaseEntity {
     public static PositionCategory create(
             Company company,
             OrgCategory orgCategory,
+            PositionCategory parent,
             String name,
-            int orderIndex,
+            Integer orderIndex,
             boolean isHead
     ) {
-        PositionCategory category = new PositionCategory();
-        category.company = company;
-        category.orgCategory = orgCategory;
-        category.name = name;
-        category.orderIndex = orderIndex;
-        category.isHead = isHead;
-        category.isActive = true;
-        return category;
+        PositionCategory pc = new PositionCategory();
+        pc.company = company;
+        pc.orgCategory = orgCategory;
+        pc.parent = parent;
+        pc.name = name;
+        pc.orderIndex = orderIndex;
+        pc.isHead = isHead;
+        pc.isActive = true;
+        return pc;
+    }
+
+    /* ========= 상태 변경 ========= */
+    public void activate(Integer newOrderIndex) {
+        this.isActive = true;
+        this.orderIndex = newOrderIndex;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        this.orderIndex = null;
     }
 
     /* ========= 수정 ========= */
-    public void update(String name, Boolean isActive) {
+    public void updateName(String name) {
         this.name = name;
-        this.isActive = isActive;
     }
 
     public void updateOrderIndex(Integer orderIndex) {
         this.orderIndex = orderIndex;
+    }
+
+    public void updateParent(PositionCategory parent) {
+        this.parent = parent;
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
@@ -1,5 +1,6 @@
 package com.finalproj.orbitflow.hr.positionCategory.repository;
 
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryListDto;
 import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,8 +24,6 @@ public interface PositionCategoryRepository extends JpaRepository<PositionCatego
 
     long countByCompanyIdAndIsActiveTrue(Long companyId);
 
-    boolean existsByCompanyIdAndName(Long companyId, String name);
-
     @Query("""
                 select max(pc.orderIndex)
                 from PositionCategory pc
@@ -47,4 +46,46 @@ public interface PositionCategoryRepository extends JpaRepository<PositionCatego
             @Param("orgCategoryId") Long orgCategoryId
     );
 
+    /* 목록 */
+    List<PositionCategory> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
+
+    /* 중복 */
+    boolean existsByCompanyIdAndName(Long companyId, String name);
+
+    boolean existsByCompanyIdAndNameAndIdNot(
+            Long companyId,
+            String name,
+            Long id
+    );
+
+    /* 직책 부여 인원수 */
+    @Query("""
+            select new com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryListDto(
+                pc.id, pc.name, oc.id, oc.name, parent.id, parent.name, 
+                pc.isHead, pc.isActive, count(e.id), pc.orderIndex
+                )
+            from PositionCategory pc
+            join pc.orgCategory oc
+            left join pc.parent parent
+            left join Employee e
+                on e.positionCategory.id = pc.id
+               and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
+            where pc.company.id = :companyId
+              and (:includeInactive = true or pc.isActive = true)
+            group by
+                pc.id,
+                pc.name,
+                oc.id,
+                oc.name,
+                parent.id,
+                parent.name,
+                pc.isHead,
+                pc.isActive,
+                pc.orderIndex
+            order by pc.orderIndex asc
+                """)
+    List<PositionCategoryListDto> findAllWithAssignedCount(
+            @Param("companyId") Long companyId,
+            @Param("includeInactive") boolean includeInactive
+    );
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
@@ -9,6 +9,7 @@ import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryListDto;
 import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryOrderUpdateReqDto;
 import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryReqDto;
 import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryResDto;
@@ -44,8 +45,11 @@ public class PositionCategoryService {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new NotFoundException("회사를 찾을 수 없습니다."));
 
-        if (positionCategoryRepository.existsByCompanyIdAndName(companyId, request.getName())) {
-            throw new InvalidStateException("이미 존재하는 직책 카테고리명입니다.");
+        String name = normalizeName(request.getName());
+
+        if (positionCategoryRepository
+                .existsByCompanyIdAndName(companyId, name)) {
+            throw new InvalidStateException("이미 존재하는 직책 카테고리입니다.");
         }
 
         OrgCategory orgCategory = orgCategoryRepository.findById(request.getOrgCategoryId())
@@ -55,34 +59,36 @@ public class PositionCategoryService {
             throw new ForbiddenException("해당 회사의 조직 카테고리가 아닙니다.");
         }
 
-        Integer maxOrder =
-                positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
+        // HEAD 중복 금지 로직 --> 제한 두지 않는 방향으로 결정
+//        if (request.getIsHead()
+//                && positionCategoryRepository.existsByCompanyIdAndOrgCategoryIdAndIsHeadTrue(
+//                companyId, orgCategory.getId())) {
+//            throw new InvalidStateException("해당 조직 유형에는 이미 HEAD 직책이 존재합니다.");
+//        }
 
-        int nextOrder = maxOrder == null ? 1 : maxOrder + 1;
 
+        PositionCategory parent = null;
+        if (request.getParentPositionId() != null) {
+            parent = positionCategoryRepository.findById(request.getParentPositionId())
+                    .orElseThrow(() -> new NotFoundException("상위 직책을 찾을 수 없습니다."));
 
-        String name = normalizeNameOrThrow(request.getName());
-
-        boolean isHead = request.getIsHead();
-
-        if (isHead) {
-            boolean exists =
-                    positionCategoryRepository
-                            .existsByCompanyIdAndOrgCategoryIdAndIsHeadTrue(
-                                    companyId,
-                                    orgCategory.getId()
-                            );
-
-            if (exists) {
-                throw new InvalidStateException(
-                        "해당 조직 유형에는 이미 HEAD 직책이 존재합니다."
-                );
+            if (!parent.getCompany().getId().equals(companyId)) {
+                throw new ForbiddenException("해당 회사의 직책이 아닙니다.");
             }
         }
 
 
-        PositionCategory category =
-                PositionCategory.create(company, orgCategory, name, nextOrder, isHead);
+        Integer max = positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
+        int nextOrder = max == null ? 1 : max + 1;
+
+        PositionCategory category = PositionCategory.create(
+                company,
+                orgCategory,
+                parent,
+                name,
+                nextOrder,
+                request.getIsHead()
+        );
 
         return positionCategoryRepository.save(category).getId();
     }
@@ -95,56 +101,60 @@ public class PositionCategoryService {
     ) {
         List<PositionCategory> list =
                 includeInactive
-                        ? positionCategoryRepository.findByCompanyId(companyId)
-                        : positionCategoryRepository.findByCompanyIdAndIsActiveTrue(companyId);
+                        ? positionCategoryRepository.findByCompanyIdOrderByIsActiveDescOrderIndexAscCreatedAtDesc(companyId)
+                        : positionCategoryRepository.findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(companyId);
 
         return list.stream()
                 .map(PositionCategoryResDto::from)
                 .toList();
     }
 
-    /* ================= 수정 ================= */
-    public void update(
+    @Transactional(readOnly = true)
+    public List<PositionCategoryListDto> findAllWithAssignedCount(
             Long companyId,
-            Long categoryId,
-            PositionCategoryReqDto request
+            boolean includeInactive
     ) {
-        PositionCategory category = getCategoryInCompany(companyId, categoryId);
+        return positionCategoryRepository.findAllWithAssignedCount(
+                companyId,
+                includeInactive
+        );
+    }
 
-        // orgCategory 변경 불가
-        if (request.getOrgCategoryId() != null &&
-                !request.getOrgCategoryId().equals(category.getOrgCategory().getId())) {
-            throw new InvalidStateException("직책의 조직 유형은 변경할 수 없습니다.");
-        } // --> 아직 상태 변경 전 (name / isActive 처리 전에 정책적 금지 사항을 먼저 차단)
+
+    /* ================= 수정 ================= */
+    public void update(Long companyId, Long id, PositionCategoryReqDto request) {
+
+        PositionCategory category = get(companyId, id);
+
+        String name = normalizeName(request.getName());
+
+        if (positionCategoryRepository.existsByCompanyIdAndNameAndIdNot(
+                companyId,
+                name,
+                id
+        )) {
+            throw new InvalidStateException("이미 존재하는 직책 카테고리입니다.");
+        }
 
         boolean wasInactive = !category.getIsActive();
         boolean willActivate = Boolean.TRUE.equals(request.getIsActive());
+        boolean willDeactivate = Boolean.FALSE.equals(request.getIsActive());
 
         if (wasInactive && willActivate) {
-            // 재활성화 -> 맨 뒤로 이동
-            Integer maxOrder =
-                    positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
-            category.updateOrderIndex(maxOrder == null ? 1 : maxOrder + 1);
+            Integer max = positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
+            category.activate(max == null ? 1 : max + 1);
         }
 
-        // 비활성화 검증 (조직에서 사용 중인지)
-        if (Boolean.FALSE.equals(request.getIsActive())) {
-            boolean used =
-                    orgPositionUsageRepository
-                            .existsByCompany_IdAndPositionCategory_Id(companyId, categoryId);
-
-
-            if (used) {
+        if (willDeactivate) {
+            if (orgPositionUsageRepository.existsByCompany_IdAndPositionCategory_Id(companyId, id)) {
                 throw new InvalidStateException(
-                        "해당 직책 카테고리를 사용하는 조직이 존재하여 비활성화할 수 없습니다."
+                        "해당 직책을 사용하는 조직이 존재하여 비활성화할 수 없습니다."
                 );
             }
-
-            category.updateOrderIndex(null);
+            category.deactivate();
         }
 
-        String name = normalizeNameOrThrow(request.getName());
-        category.update(name, request.getIsActive());
+        category.updateName(name);
     }
 
     /* ================= 정렬 ================= */
@@ -156,28 +166,20 @@ public class PositionCategoryService {
             throw new InvalidRequestException("순서 정보가 비어 있습니다.");
         }
 
-        long activeCount =
-                positionCategoryRepository.countByCompanyIdAndIsActiveTrue(companyId);
-
+        long activeCount = positionCategoryRepository.countByCompanyIdAndIsActiveTrue(companyId);
         if (activeCount != orders.size()) {
             throw new InvalidStateException("정렬 대상 개수가 일치하지 않습니다.");
         }
 
         int temp = -1;
         for (var item : orders) {
-            PositionCategory category = getCategoryInCompany(companyId, item.getId());
-            if (!category.getIsActive()) {
-                throw new InvalidStateException("비활성 카테고리는 정렬할 수 없습니다.");
-            }
-            category.updateOrderIndex(temp--);
+            get(companyId, item.getId()).updateOrderIndex(temp--);
         }
-
         positionCategoryRepository.flush();
 
-        int orderIndex = 1;
+        int index = 1;
         for (var item : orders) {
-            PositionCategory category = getCategoryInCompany(companyId, item.getId());
-            category.updateOrderIndex(orderIndex++);
+            get(companyId, item.getId()).updateOrderIndex(index++);
         }
     }
 
@@ -185,30 +187,23 @@ public class PositionCategoryService {
 
 
     /* ================= 내부 메서드 ================= */
-    private PositionCategory getCategoryInCompany(Long companyId, Long categoryId) {
-        PositionCategory category =
-                positionCategoryRepository.findById(categoryId)
-                        .orElseThrow(() -> new NotFoundException("직책 카테고리를 찾을 수 없습니다."));
-
-        if (!category.getCompany().getId().equals(companyId)) {
+    private PositionCategory get(Long companyId, Long id) {
+        PositionCategory pc = positionCategoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("직책 카테고리를 찾을 수 없습니다."));
+        if (!pc.getCompany().getId().equals(companyId)) {
             throw new ForbiddenException("해당 회사의 직책 카테고리가 아닙니다.");
         }
-
-        return category;
+        return pc;
     }
 
-    private String normalizeNameOrThrow(String raw) {
-        if (raw == null) {
+    private String normalizeName(String raw) {
+        if (raw == null || raw.trim().isBlank()) {
             throw new InvalidRequestException("직책명은 필수입니다.");
         }
         String name = raw.trim();
-        if (name.isBlank()) {
-            throw new InvalidRequestException("직책명은 필수입니다.");
-        }
         if (name.length() > 50) {
             throw new InvalidRequestException("직책명은 50자 이하여야 합니다.");
         }
         return name;
     }
-
 }

--- a/src/main/resources/static/css/admin-organization.css
+++ b/src/main/resources/static/css/admin-organization.css
@@ -164,3 +164,81 @@
     border-radius: 3px;
     padding: 0 2px;
 }
+
+/* ==================================================
+   조직 생성/수정 - 직책 정책 패널
+================================================== */
+
+.org-modal-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 24px;
+}
+
+.org-policy-panel {
+    padding: 16px;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    background: #fafbff;
+    display: flex;
+    flex-direction: column;
+}
+
+.org-policy-panel h3 {
+    font-size: 14px;
+    font-weight: 800;
+    margin-bottom: 4px;
+}
+
+.org-policy-panel p {
+    font-size: 12px;
+    color: #667085;
+    margin-bottom: 12px;
+}
+
+.policy-toolbar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.policy-toolbar input,
+.policy-toolbar select {
+    height: 34px;
+    font-size: 12.5px;
+}
+
+.policy-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12.5px;
+}
+
+.policy-table th {
+    text-align: left;
+    color: #667085;
+    font-weight: 700;
+    padding-bottom: 6px;
+}
+
+.policy-table td {
+    padding: 8px 4px;
+    vertical-align: middle;
+}
+
+.policy-empty {
+    text-align: center;
+    color: #98a2b3;
+    padding: 16px 0;
+}
+
+.badge-head {
+    display: inline-block;
+    margin-right: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 800;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: #3730a3;
+}

--- a/src/main/resources/static/css/admin-position-category.css
+++ b/src/main/resources/static/css/admin-position-category.css
@@ -1,0 +1,503 @@
+/* ==================================================
+   admin-org-category.css
+   - 조직 카테고리 관리 (목록 + 모달)
+================================================== */
+
+:root {
+    --bg: #f5f7fb;
+    --card: #ffffff;
+    --line: #eef1f6;
+    --text: #111827;
+    --muted: #6b7280;
+    --primary: #2f6af6;
+    --primary-weak: rgba(47, 106, 246, .12);
+
+    --success-bg: #dff7e7;
+    --success-text: #137a3a;
+
+    --danger-bg: #fde2e2;
+    --danger-text: #b42318;
+
+    --shadow: 0 12px 36px rgba(16, 24, 40, 0.08);
+}
+
+
+/* 타이틀 */
+.orgcat-title-row {
+    margin-bottom: 18px;
+}
+
+.orgcat-title {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+    color: var(--text);
+    margin: 0;
+}
+
+/* 카드 */
+.orgcat-card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    box-shadow: var(--shadow);
+    padding: 18px 18px 14px;
+}
+
+/* 툴바 */
+.orgcat-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px; /* 테이블이랑 거리 */
+}
+.toolbar-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+/* 검색 */
+.orgcat-search {
+    flex: 1;
+    max-width: 320px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0 14px;
+    background: #fbfcff;
+}
+
+.orgcat-search i {
+    color: #9aa3b2;
+    font-size: 14px;
+}
+
+.orgcat-search input {
+    width: 220px;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 13.5px;
+    color: var(--text);
+}
+
+.orgcat-search input::placeholder {
+    color: #9aa3b2;
+}
+
+/* 버튼 공통 */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 42px;
+    padding: 0 16px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-size: 13.5px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform .06s ease, background .15s ease, border-color .15s ease;
+    user-select: none;
+}
+
+.btn:active {
+    transform: translateY(1px);
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 10px 24px rgba(47, 106, 246, .22);
+}
+
+.btn-primary:hover {
+    filter: brightness(0.98);
+}
+
+.btn-outline {
+    background: #fff;
+    color: var(--primary);
+    border-color: rgba(47, 106, 246, .35);
+}
+
+.btn-outline:hover {
+    background: var(--primary-weak);
+}
+
+.btn-outline:disabled {
+    cursor: not-allowed;
+    opacity: .45;
+    background: #fff;
+}
+
+.btn-ghost {
+    background: #fff;
+    color: #374151;
+    border-color: #e5e7eb;
+}
+
+.btn-ghost:hover {
+    background: #f3f4f6;
+}
+
+/* 테이블 */
+.orgcat-table-wrap {
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.orgcat-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13.5px;
+}
+
+.orgcat-table thead th {
+    background: #f6f7fb;
+    color: #667085;
+    text-align: left;
+    padding: 14px 16px;
+    font-weight: 800;
+    border-bottom: 1px solid var(--line);
+}
+
+.orgcat-table tbody td {
+    padding: 16px 16px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: middle;
+    color: var(--text);
+}
+
+.orgcat-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.col-order {
+    width: 90px;
+}
+
+.col-status {
+    width: 140px;
+}
+
+.col-action {
+    width: 140px;
+}
+
+/* 드래그 핸들(점 6개 느낌) */
+.drag-handle {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    cursor: grab;
+    color: #98a2b3;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-dots {
+    width: 14px;
+    height: 18px;
+    display: grid;
+    grid-template-columns: repeat(2, 4px);
+    grid-template-rows: repeat(3, 4px);
+    gap: 3px;
+}
+
+.drag-dots span {
+    width: 4px;
+    height: 4px;
+    background: #a9b1c3;
+    border-radius: 50%;
+}
+
+/* 상태 배지 */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 64px;
+    height: 30px;
+    padding: 0 12px;
+    border-radius: 999px;
+    font-size: 12.5px;
+    font-weight: 800;
+}
+
+.status-active {
+    background: var(--success-bg);
+    color: var(--success-text);
+}
+
+.status-inactive {
+    background: var(--danger-bg);
+    color: var(--danger-text);
+}
+
+/* 수정 버튼(테이블 내) */
+.table-btn {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #d0d5dd;
+    background: #fff;
+    font-weight: 800;
+    font-size: 13px;
+    color: #344054;
+    cursor: pointer;
+}
+
+.table-btn:hover {
+    background: #f3f4f6;
+}
+
+/* 하단 */
+.orgcat-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 6px 0;
+}
+
+.orgcat-hint {
+    font-size: 12.5px;
+    color: #98a2b3;
+}
+
+/* =========================
+   모달
+========================= */
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    padding: 18px;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-panel {
+    width: 720px;
+    max-width: 92vw;
+    background: #fff;
+    border-radius: 18px;
+    box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
+    overflow: hidden;
+}
+
+.modal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 22px 24px 10px;
+}
+
+.modal-head h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 900;
+    color: var(--text);
+}
+
+.modal-sub {
+    margin: 8px 0 0;
+    font-size: 12.5px;
+    color: #98a2b3;
+}
+
+.icon-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid #eef2f7;
+    background: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #667085;
+}
+
+.icon-btn:hover {
+    background: #f3f4f6;
+}
+
+.modal-body {
+    padding: 8px 24px 18px;
+}
+
+.form-group {
+    margin-top: 14px;
+}
+
+.form-label {
+    display: block;
+    font-size: 12.5px;
+    font-weight: 900;
+    color: #667085;
+    margin-bottom: 8px;
+}
+
+.form-input {
+    width: 100%;
+    height: 46px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid #e6eaf2;
+    background: #fbfcff;
+    outline: none;
+    font-size: 13.5px;
+    color: var(--text);
+}
+
+.form-input:focus {
+    border-color: rgba(47, 106, 246, .55);
+    box-shadow: 0 0 0 4px rgba(47, 106, 246, .12);
+}
+
+.form-help {
+    margin: 8px 2px 0;
+    font-size: 12.5px;
+    color: #ef4444;
+    min-height: 16px;
+}
+
+/* 토글 */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding-top: 6px;
+}
+
+.toggle-text {
+    font-weight: 900;
+    font-size: 13.5px;
+    color: #344054;
+}
+
+/* switch */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 54px;
+    height: 30px;
+}
+
+.switch input {
+    display: none;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: #d0d5dd;
+    border-radius: 999px;
+    transition: .2s;
+}
+
+.slider:before {
+    content: "";
+    position: absolute;
+    height: 24px;
+    width: 24px;
+    left: 3px;
+    top: 3px;
+    background: white;
+    border-radius: 50%;
+    transition: .2s;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, .12);
+}
+
+.switch input:checked + .slider {
+    background: var(--primary);
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(24px);
+}
+
+/* 모달 하단 버튼 */
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 24px 22px;
+    border-top: 1px solid #eef2f7;
+}
+
+/* Sortable dragging */
+.sortable-chosen {
+    background: #f7f9ff;
+}
+
+.sortable-ghost {
+    opacity: .6;
+}
+
+.inactive-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #475467;
+}
+
+
+/* 반응형 */
+@media (max-width: 720px) {
+    .orgcat-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .orgcat-search {
+        max-width: 100%;
+    }
+
+    .orgcat-footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .orgcat-footer .btn {
+        width: 100%;
+    }
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    font-size: 11.5px;
+    font-weight: 800;
+    border-radius: 999px;
+}
+
+.badge-head {
+    background: #eef2ff;
+    color: #3730a3;
+    border: 1px solid #c7d2fe;
+}

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -19,6 +19,13 @@ let orgCategories = [];
 const expandedSet = new Set();
 
 /* ======================
+   직책 정책 상태
+====================== */
+let positionCategories = [];
+let selectedPositionIds = new Set();
+let currentOrgCategoryId = null;
+
+/* ======================
    Elements
 ====================== */
 const els = {
@@ -250,14 +257,14 @@ async function saveOrder() {
     nodes.forEach(n => {
         const pid = n.dataset.parentId ?? 'root';
         groups[pid] ??= [];
-        groups[pid].push({ id: Number(n.dataset.id) });
+        groups[pid].push({id: Number(n.dataset.id)});
     });
 
     for (const orders of Object.values(groups)) {
         await apiFetch(`${API_BASE}/order`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ orders })
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({orders})
         });
     }
 
@@ -295,6 +302,10 @@ function openCreate() {
     buildCategorySelect(null);
     buildParentSelect(null);
 
+    currentOrgCategoryId = orgCategories[0]?.id;
+    loadPositionPolicies(null, currentOrgCategoryId);
+
+
     // 생성 시: 카테고리 / 부모조직 활성화
     document.getElementById('categorySelect').disabled = false;
     els.parentSelect().disabled = false;
@@ -316,6 +327,7 @@ async function openEdit(id) {
     if (!org) return;
 
     selectedOrgId = id;
+    currentOrgCategoryId = org.categoryId;
 
     els.modalTitle().textContent = '조직 수정';
     els.orgName().value = org.name ?? '';
@@ -347,6 +359,8 @@ async function openEdit(id) {
         }
     }
 
+    await loadPositionPolicies(id, currentOrgCategoryId);
+
     openModal();
 }
 
@@ -356,16 +370,34 @@ async function saveOrg() {
 
     const payload = {
         name,
-        isActive: isEditMode ? document.getElementById('activeToggle').checked : true
+        categoryId: Number(document.getElementById('categorySelect').value),
+        parentOrgId: els.parentSelect().value
+            ? Number(els.parentSelect().value)
+            : null,
+        isActive: isEditMode
+            ? document.getElementById('activeToggle').checked
+            : true
     };
 
     const url = selectedOrgId ? `${API_BASE}/${selectedOrgId}` : API_BASE;
     const method = selectedOrgId ? 'PUT' : 'POST';
 
-    await apiFetch(url, {
+    const res = await apiFetch(url, {
         method,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(payload)
+    });
+
+    const json = await res.json();
+    const savedOrgId = selectedOrgId ?? json.data;
+
+    await apiFetch('/api/admin/org-position-policies', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            orgId: savedOrgId,
+            positionCategoryIds: Array.from(selectedPositionIds)
+        })
     });
 
     closeModal();
@@ -392,6 +424,7 @@ function buildParentSelect(selected) {
 function openModal() {
     els.modal().classList.remove('hidden');
 }
+
 function closeModal() {
     els.modal().classList.add('hidden');
 }
@@ -400,6 +433,7 @@ function markOrderChanged() {
     isOrderChanged = true;
     els.btnSaveOrder().disabled = false;
 }
+
 function resetOrderChanged() {
     isOrderChanged = false;
     els.btnSaveOrder().disabled = true;
@@ -408,9 +442,11 @@ function resetOrderChanged() {
 function normalizeActive(o) {
     return o.isActive === true || o.isActive === 1;
 }
+
 function escapeHtml(str) {
     return String(str).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
+
 function dragHandleHtml() {
     return `<span class="drag-handle"><span class="drag-dots">
         <span></span><span></span><span></span><span></span><span></span><span></span>
@@ -547,3 +583,103 @@ function collectDescendants(parentId, set) {
             collectDescendants(child.id, set);
         });
 }
+
+async function loadPositionPolicies(orgId, orgCategoryId) {
+
+    // 1. 활성 직책 전체
+    const res1 = await apiFetch(
+        '/api/admin/position-categories?includeInactive=false'
+    );
+    const json1 = await res1.json();
+    positionCategories = json1.data || [];
+
+    selectedPositionIds.clear();
+
+    // 2. 수정 시: 기존 정책
+    if (orgId) {
+        const res2 = await apiFetch(
+            `/api/admin/org-position-policies/${orgId}`
+        );
+        const json2 = await res2.json();
+        (json2.data || []).forEach(v =>
+            selectedPositionIds.add(v.positionCategoryId)
+        );
+    }
+
+    renderPolicyTable(orgCategoryId);
+}
+
+function renderPolicyTable(orgCategoryId) {
+
+    const keyword =
+        document.getElementById('policyKeyword').value.trim().toLowerCase();
+    const headFilter =
+        document.getElementById('policyHeadFilter').value;
+
+    const tbody = document.getElementById('policyTableBody');
+    tbody.innerHTML = '';
+
+    const filtered = positionCategories
+        .filter(p => p.isActive)
+        .filter(p => !keyword || p.name.toLowerCase().includes(keyword))
+        .filter(p => {
+            if (headFilter === 'HEAD') return p.isHead;
+            if (headFilter === 'NORMAL') return !p.isHead;
+            return true;
+        });
+
+    if (!filtered.length) {
+        tbody.innerHTML = `
+            <tr>
+                <td colspan="3" class="policy-empty">
+                    선택 가능한 직책이 없습니다.
+                </td>
+            </tr>
+        `;
+        return;
+    }
+
+    filtered.forEach(p => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>
+                ${p.isHead ? `<span class="badge-head">HEAD</span>` : ''}
+                ${escapeHtml(p.name)}
+            </td>
+            <td>${p.assignedCount ?? 0}</td>
+            <td>
+                <label class="switch">
+                    <input type="checkbox"
+                        ${selectedPositionIds.has(p.id) ? 'checked' : ''}
+                        onchange="togglePolicy(${p.id}, this.checked)">
+                    <span class="slider"></span>
+                </label>
+            </td>
+        `;
+        tbody.appendChild(tr);
+    });
+}
+
+function togglePolicy(id, checked) {
+    if (checked) selectedPositionIds.add(id);
+    else selectedPositionIds.delete(id);
+}
+
+
+document.getElementById('categorySelect')
+    .addEventListener('change', e => {
+        currentOrgCategoryId = Number(e.target.value);
+        selectedPositionIds.clear();
+        renderPolicyTable(currentOrgCategoryId);
+    });
+
+
+document.getElementById('policyKeyword')
+    .addEventListener('input', () =>
+        renderPolicyTable(currentOrgCategoryId)
+    );
+
+document.getElementById('policyHeadFilter')
+    .addEventListener('change', () =>
+        renderPolicyTable(currentOrgCategoryId)
+    );

--- a/src/main/resources/static/js/admin-position-category.js
+++ b/src/main/resources/static/js/admin-position-category.js
@@ -1,0 +1,288 @@
+const API = '/api/admin/position-categories';
+const ORG_CAT_API = '/api/admin/org-categories';
+
+let list = [];
+let sortable = null;
+let orderChanged = false;
+let selectedId = null;
+let parentPositionId = null;
+let orgCategories = [];
+
+async function loadOrgCategories() {
+    const res = await apiFetch(ORG_CAT_API);
+    const json = await res.json();
+    orgCategories = json.data || [];
+
+    const select = $('#orgCategorySelect');
+    select.innerHTML = orgCategories.map(c =>
+        `<option value="${c.id}">${c.name}</option>`
+    ).join('');
+}
+
+
+/* ================= Init ================= */
+document.addEventListener('DOMContentLoaded', () => {
+    bind();
+    load();
+});
+
+/* ================= Load ================= */
+async function load() {
+    const includeInactive = $('#includeInactive').checked;
+    const res = await apiFetch(`${API}?includeInactive=${includeInactive}`);
+    const json = await res.json();
+    list = json.data || [];
+    render();
+}
+
+/* ================= Render ================= */
+function render() {
+    const tbody = $('#tableBody');
+    tbody.innerHTML = '';
+
+    const keyword = $('#searchKeyword').value.trim().toLowerCase();
+    const filtered = list.filter(v =>
+        v.name.toLowerCase().includes(keyword)
+    );
+
+    const active = filtered.filter(v => v.isActive);
+    const inactive = filtered.filter(v => !v.isActive);
+
+    active.forEach(v => tbody.appendChild(row(v)));
+
+    if (inactive.length) {
+        tbody.insertAdjacentHTML('beforeend',
+            `<tr><td colspan="6" style="background:#f9fafb;font-weight:800">비활성 직책</td></tr>`
+        );
+        inactive.forEach(v => tbody.appendChild(row(v)));
+    }
+
+    initSortable(active.length);
+}
+
+/* ================= Row ================= */
+function row(v) {
+    const tr = document.createElement('tr');
+    tr.dataset.id = v.id;
+    tr.innerHTML = `
+    <td>${v.isActive ? drag() : ''}</td>
+    <td>${v.name}</td>
+    <td>${v.parentPositionName ?? '-'}</td>
+    <td>${v.isHead ? `<span class="badge badge-head">HEAD</span>` : ''}</td>
+    <td>${v.isActive ? '활성' : '비활성'}</td>
+    <td><button data-edit>수정</button></td>
+  `;
+    tr.querySelector('[data-edit]').onclick = () => openEdit(v.id);
+    return tr;
+}
+
+/* ================= Sortable ================= */
+function initSortable(count) {
+    destroySortable();
+    if (count < 2 || isSearch()) return;
+
+    sortable = Sortable.create($('#tableBody'), {
+        handle: '.drag-handle',
+        onEnd: () => {
+            orderChanged = true;
+            $('#btnSaveOrder').disabled = false;
+        }
+    });
+}
+
+function destroySortable() {
+    if (sortable) sortable.destroy();
+    sortable = null;
+}
+
+/* ================= Modal ================= */
+async function openCreate() {
+    await loadOrgCategories();
+
+    selectedId = null;
+    parentPositionId = null;
+
+    const orgCategorySelect = $('#orgCategorySelect');
+    orgCategorySelect.disabled = false;
+    orgCategorySelect.value = orgCategories[0]?.id ?? '';
+
+    $('#modalTitle').textContent = '직책 생성';
+    $('#positionName').value = '';
+    $('#isHead').checked = false;
+    $('#isHead').disabled = false;
+
+    $('#isActive').checked = true;
+    $('#isActive').disabled = true;
+
+    buildParentPositionSelect(null, false);
+    showModal();
+}
+
+
+
+async function openEdit(id) {
+    await loadOrgCategories();
+
+    const v = list.find(x => x.id === id);
+    if (!v) return;
+
+    selectedId = id;
+    parentPositionId = v.parentPositionId ?? null;
+
+    $('#modalTitle').textContent = '직책 수정';
+    $('#positionName').value = v.name;
+
+    // 조직 유형 기준: 값만 세팅 + 수정 불가
+    const orgCategorySelect = $('#orgCategorySelect');
+    orgCategorySelect.value = v.orgCategoryId;
+    orgCategorySelect.disabled = true;
+
+    // HEAD 여부: 조회만
+    $('#isHead').checked = v.isHead;
+    $('#isHead').disabled = true;
+
+    // 사용 여부만 수정 가능
+    $('#isActive').checked = v.isActive;
+    $('#isActive').disabled = false;
+
+    // 상위 직책: 조회만
+    buildParentPositionSelect(parentPositionId, true);
+
+    showModal();
+}
+
+
+
+/* ================= Save ================= */
+async function save() {
+    const parentValue = $('#parentPositionSelect').value;
+
+
+    const payload = {
+        name: $('#positionName').value.trim(),
+        orgCategoryId: Number($('#orgCategorySelect').value),
+        parentPositionId: $('#parentPositionSelect').value
+            ? Number($('#parentPositionSelect').value)
+            : null,
+        isHead: $('#isHead').checked,
+        isActive: $('#isActive').checked
+    };
+
+
+    const method = selectedId ? 'PUT' : 'POST';
+    const url = selectedId ? `${API}/${selectedId}` : API;
+
+    await apiFetch(url, {
+        method,
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+
+    hideModal();
+    load();
+}
+
+/* ================= Bind ================= */
+function bind() {
+    $('#btnOpenCreate').onclick = openCreate;
+    $('#btnCancel').onclick = hideModal;
+    $('#btnCloseModal').onclick = hideModal;
+    $('#btnSave').onclick = save;
+    $('#btnSearch').onclick = render;
+    $('#includeInactive').onchange = load;
+    $('#btnSaveOrder').onclick = saveOrder;
+}
+
+/* ================= Utils ================= */
+const $ = s => document.querySelector(s);
+const drag = () => `<span class="drag-handle">⋮⋮</span>`;
+const isSearch = () => $('#searchKeyword').value.trim().length > 0;
+
+function showModal() {
+    $('#modal').classList.remove('hidden');
+}
+
+function hideModal() {
+    $('#modal').classList.add('hidden');
+}
+
+/* ================= 상위 직책 셀렉트 빌드 함수 ================= */
+function buildParentPositionSelect(selectedId, disabled = false) {
+    const select = $('#parentPositionSelect');
+
+    const currentOrgCategoryId =
+        Number($('#orgCategorySelect').value);
+
+    const allowedOrgCategoryIds =
+        collectAllowedOrgCategoryIds(currentOrgCategoryId);
+
+    const candidates = list.filter(v =>
+        v.isActive &&
+        v.id !== selectedId &&
+        allowedOrgCategoryIds.has(v.orgCategoryId)
+    );
+
+    select.innerHTML = `
+  ${candidates.map(v =>
+        `<option value="${v.id}" ${v.id === selectedId ? 'selected' : ''}>
+        ${v.name} (${v.orgCategoryName})${v.isHead ? ' · HEAD' : ''}
+    </option>`
+    ).join('')}
+`;
+// --> 부모 직책을 반드시 하나 선택해야 함 (“최상위 직책”이라는 개념이 사라짐, 모든 직책은 명시적 트리 안에 존재)
+
+    select.disabled = disabled;
+}
+
+/* ================= 정렬 저장 ================= */
+async function saveOrder() {
+    if (!orderChanged) return;
+
+    const ids = [...$('#tableBody').children]
+        .filter(tr => tr.dataset.id)
+        .map((tr, idx) => ({
+            id: Number(tr.dataset.id),
+            orderIndex: idx + 1
+        }));
+
+    await apiFetch(`${API}/order`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({orders: ids})
+    });
+
+    orderChanged = false;
+    $('#btnSaveOrder').disabled = true;
+    load();
+}
+
+document
+    .getElementById('orgCategorySelect')
+    .addEventListener('change', () => {
+        buildParentPositionSelect(parentPositionId, false);
+    });
+
+
+// function collectAllowedOrgCategoryIds(orgCategoryId) {
+//     const allowed = new Set();
+//     let currentId = orgCategoryId;
+//
+//     while (currentId) {
+//         allowed.add(currentId);
+//         const current = orgCategories.find(c => c.id === currentId);
+//         currentId = current?.parentId ?? null;
+//     }
+//
+//     return allowed;
+// }
+
+function collectAllowedOrgCategoryIds(orgCategoryId) {
+    const current = orgCategories.find(c => c.id === orgCategoryId);
+    if (!current) return new Set();
+
+    return new Set(
+        orgCategories
+            .filter(c => c.orderIndex <= current.orderIndex)
+            .map(c => c.id)
+    );
+}

--- a/src/main/resources/templates/admin/hr/organization/list.html
+++ b/src/main/resources/templates/admin/hr/organization/list.html
@@ -68,36 +68,72 @@
                 </button>
             </div>
 
-            <div class="modal-body">
+            <div class="modal-body org-modal-grid">
+                <!-- ================= 좌측: 조직 정보 (기존 코드 그대로) ================= -->
+                <div class="org-form-panel">
+                    <div class="form-group">
+                        <label class="form-label">조직 카테고리</label>
+                        <select id="categorySelect" class="form-input"></select>
+                    </div>
 
-                <div class="form-group">
-                    <label class="form-label">조직 카테고리</label>
-                    <select id="categorySelect" class="form-input"></select>
+                    <div class="form-group">
+                        <label class="form-label">조직명</label>
+                        <input id="orgName" class="form-input" type="text" placeholder="예: 인사팀">
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label">상위 조직</label>
+                        <select id="parentOrgSelect" class="form-input"></select>
+                    </div>
+
+                    <div class="form-group toggle-row">
+                        <span class="toggle-text">사용 여부</span>
+                        <label class="switch">
+                            <input type="checkbox" id="activeToggle">
+                            <span class="slider"></span>
+                        </label>
+                        <span id="activeLabel">사용</span>
+                    </div>
+
+                    <div class="form-help" id="inactiveHelp" style="display:none;">
+                        비활성화하려면 해당 조직에 소속된 사원이 없어야 합니다.
+                    </div>
+
                 </div>
 
-                <div class="form-group">
-                    <label class="form-label">조직명</label>
-                    <input id="orgName" class="form-input" type="text" placeholder="예: 인사팀">
-                </div>
+                <!-- ================= 우측: 직책 정책 ================= -->
+                <section class="org-policy-panel">
 
-                <div class="form-group">
-                    <label class="form-label">상위 조직</label>
-                    <select id="parentOrgSelect" class="form-input"></select>
-                </div>
+                    <h3>직책 사용 정책</h3>
+                    <p>이 조직에서 사용할 직책을 선택하세요.</p>
 
-                <div class="form-group toggle-row">
-                    <span class="toggle-text">사용 여부</span>
-                    <label class="switch">
-                        <input type="checkbox" id="activeToggle">
-                        <span class="slider"></span>
-                    </label>
-                    <span id="activeLabel">사용</span>
-                </div>
+                    <div class="policy-toolbar">
+                        <input id="policyKeyword" placeholder="직책명 검색">
+                        <select id="policyHeadFilter">
+                            <option value="">전체</option>
+                            <option value="HEAD">HEAD</option>
+                            <option value="NORMAL">일반</option>
+                        </select>
+                    </div>
 
-                <div class="form-help" id="inactiveHelp" style="display:none;">
-                    비활성화하려면 해당 조직에 소속된 사원이 없어야 합니다.
-                </div>
+                    <table class="policy-table">
+                        <thead>
+                        <tr>
+                            <th>직책명</th>
+                            <th>부여 인원</th>
+                            <th>사용</th>
+                        </tr>
+                        </thead>
+                        <tbody id="policyTableBody">
+                        <!-- JS 렌더링 -->
+                        </tbody>
+                    </table>
 
+                    <div class="form-help">
+                        비활성 직책은 선택할 수 없습니다.
+                    </div>
+
+                </section>
             </div>
 
             <div class="modal-actions">

--- a/src/main/resources/templates/admin/hr/position-category/list.html
+++ b/src/main/resources/templates/admin/hr/position-category/list.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-admin :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{sidebar/admin-sidebar :: menu},
+        ~{::pageCss},
+        ~{::pageScript}
+      )}">
+
+<th:block th:fragment="pageCss">
+  <link rel="stylesheet" th:href="@{/css/admin-position-category.css}">
+</th:block>
+
+<th:block th:fragment="content">
+
+  <div class="orgcat-title-row">
+    <h1 class="orgcat-title">직책 관리</h1>
+  </div>
+
+  <section class="orgcat-card">
+
+    <!-- 툴바 -->
+    <div class="orgcat-toolbar">
+      <div class="toolbar-left">
+
+        <div class="orgcat-search">
+          <i class="fa-solid fa-magnifying-glass"></i>
+          <input id="searchKeyword" placeholder="직책명 검색">
+        </div>
+
+        <button class="btn btn-outline" id="btnSearch">검색</button>
+
+        <label class="inactive-toggle">
+          <input type="checkbox" id="includeInactive">
+          <span>비활성 포함</span>
+        </label>
+
+      </div>
+
+      <div class="toolbar-right">
+        <button class="btn btn-primary" id="btnOpenCreate">
+          직책 추가
+        </button>
+      </div>
+    </div>
+
+    <!-- 테이블 -->
+    <div class="orgcat-table-wrap">
+      <table class="orgcat-table">
+        <thead>
+        <tr>
+          <th style="width:80px">순서</th>
+          <th>직책명</th>
+          <th>상위 직책</th>
+          <th>결재처리자</th>
+          <th>상태</th>
+          <th>관리</th>
+        </tr>
+        </thead>
+        <tbody id="tableBody"></tbody>
+      </table>
+    </div>
+
+    <!-- 하단 -->
+    <div class="orgcat-footer">
+      <div class="orgcat-hint" id="orderHint">
+        드래그앤드롭으로 순서를 변경할 수 있습니다.
+      </div>
+      <button class="btn btn-outline" id="btnSaveOrder" disabled>
+        변경사항저장
+      </button>
+    </div>
+
+  </section>
+
+  <!-- 모달 -->
+  <div id="modal" class="modal hidden">
+    <div class="modal-panel">
+
+      <div class="modal-head">
+        <h2 id="modalTitle">직책 생성</h2>
+        <button class="icon-btn" id="btnCloseModal">
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+
+      <div class="modal-body">
+
+        <input type="hidden" id="positionId">
+
+        <div class="form-group">
+          <label class="form-label">조직 유형 기준</label>
+          <select id="orgCategorySelect" class="form-input"></select>
+          <p class="form-help">
+            결재선 및 직책 사용 정책의 기준이 되는 조직 유형입니다.
+          </p>
+        </div>
+
+        <div class="form-group">
+          <label>상위 직책</label>
+          <select id="parentPositionSelect" class="form-input"></select>
+          <p class="form-help">최상위 직책은 선택하지 않아도 됩니다.</p>
+        </div>
+
+        <div class="form-group">
+          <label>직책명</label>
+          <input id="positionName" class="form-input">
+          <p class="form-help" id="nameHelp"></p>
+        </div>
+
+        <div class="form-group">
+          <label>
+            <input type="checkbox" id="isHead">
+            결재처리자
+          </label>
+        </div>
+
+        <div class="form-group">
+          <label>사용 여부</label>
+          <label class="switch">
+            <input type="checkbox" id="isActive" checked>
+            <span class="slider"></span>
+          </label>
+        </div>
+
+      </div>
+
+      <div class="modal-actions">
+        <button class="btn btn-ghost" id="btnCancel">취소</button>
+        <button class="btn btn-primary" id="btnSave">저장</button>
+      </div>
+
+    </div>
+  </div>
+
+</th:block>
+
+<th:block th:fragment="pageScript">
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+  <script th:src="@{/js/admin-position-category.js}"></script>
+</th:block>
+
+</html>

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -87,7 +87,10 @@
                 <a th:href="@{/view/admin/organizations}">조직 관리</a>
             </li>
             <li th:classappend="${currentMenu == 'rank'} ? 'selected' : ''">
-                <a th:href="@{/view/admin/ranks}">조직 관리</a>
+                <a th:href="@{/view/admin/ranks}">직급 관리</a>
+            </li>
+            <li th:classappend="${currentMenu == 'position-category'} ? 'selected' : ''">
+                <a th:href="@{/view/admin/position-categories}">직책 관리</a>
             </li>
         </ul>
     </li>


### PR DESCRIPTION
…정책 구현

## #️⃣ 연관된 이슈

> #284

## 📝 작업 내용
### 직책 카테고리 구조 개선
- position_category에 self join(parent_position_id) 구조 도입
- 모든 직책이 명시적인 트리 구조를 갖도록 설계
- 활성 상태에서만 정렬 유니크 보장 (active_order_index 가상 컬럼)
### 조직 유형 기준 직책 설계
- 직책은 반드시 조직 카테고리(org_category) 에 귀속
- 상위 직책 선택 시:
  - 동일 조직 유형
  - 또는 상위 조직 유형의 직책만 선택 가능
  - 프론트에서 조직 유형 기준으로 상위 직책 후보 필터링
### HEAD 직책 정책 결정
- 조직당 HEAD 1명 제한 적용하지 않음
- 결재선 설계 유연성을 위해 중복 HEAD 허용
- 관련 제약 로직 주석 처리 및 명시적 설계 결정
### 조직별 직책 사용 정책 (화이트리스트)
- org_position_usage 테이블 신규 도입
- 조직 단위로 사용 가능한 직책을 명시적으로 관리
- 정책 저장 시 덮어쓰기 방식 적용
- 비활성 직책은 정책에 포함 불가
### 조직 생성/수정 화면 UX 개선
- 조직 생성/수정 모달에 직책 정책 패널 통합
- 직책 검색 / HEAD 필터 / 사용 여부 토글 제공
- 조직 카테고리 변경 시 직책 정책 자동 초기화
### 직책 관리 화면 개선
- 상위 직책 컬럼에 부모 직책명 표시
- 상위 직책 선택 드롭다운에:
  - 직책명 (조직유형)
  - HEAD 여부 힌트 표시
- 활성/비활성 분리 렌더링
- 활성 직책만 Drag & Drop 정렬 가능

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- 조직 카테고리는 현재 orderIndex 기반 계층 판단
  - 추후 필요 시 org_category self join 제거/확장 가능
- 직책 계층은 position_category self join으로 유지