### PR TITLE
refactor(AttendanceRule, Employee): 근태 예외 규칙 사원 검색 API를 employee 도메인으…

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/attendance/default_rule/controller/AttendanceRuleController.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/default_rule/controller/AttendanceRuleController.java
@@ -2,11 +2,10 @@ package com.finalproj.orbitflow.attendance.default_rule.controller;
 
 import com.finalproj.orbitflow.attendance.default_rule.dto.AttRuleResDto;
 import com.finalproj.orbitflow.attendance.default_rule.dto.AttRuleUpdateReqDto;
-import com.finalproj.orbitflow.attendance.default_rule.dto.EmployeeSearchDto;
+import com.finalproj.orbitflow.attendance.default_rule.service.AttendanceRuleService;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleCreateReqDto;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleResDto;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleUpdateReqDto;
-import com.finalproj.orbitflow.attendance.default_rule.service.AttendanceRuleService;
 import com.finalproj.orbitflow.global.security.SecurityUser;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -80,20 +79,5 @@ public class AttendanceRuleController {
             @PathVariable Long ruleId) {
         attendanceRuleService.deleteExceptionRule(admin, ruleId);
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/employees/search")
-    public ResponseEntity<List<EmployeeSearchDto>> searchEmployees(
-            @AuthenticationPrincipal SecurityUser admin,
-            @RequestParam String keyword) {
-        // Validation: 최소 2자, 최대 30자, trim 처리
-        String trimmedKeyword = keyword != null ? keyword.trim() : "";
-        if (trimmedKeyword.length() < 2) {
-            throw new IllegalArgumentException("검색어는 최소 2자 이상이어야 합니다.");
-        }
-        if (trimmedKeyword.length() > 30) {
-            throw new IllegalArgumentException("검색어는 30자 이하여야 합니다.");
-        }
-        return ResponseEntity.ok(attendanceRuleService.searchEmployees(admin.getCompanyId(), trimmedKeyword));
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/attendance/default_rule/service/AttendanceRuleService.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/default_rule/service/AttendanceRuleService.java
@@ -2,18 +2,16 @@ package com.finalproj.orbitflow.attendance.default_rule.service;
 
 import com.finalproj.orbitflow.attendance.default_rule.dto.AttRuleResDto;
 import com.finalproj.orbitflow.attendance.default_rule.dto.AttRuleUpdateReqDto;
-import com.finalproj.orbitflow.attendance.default_rule.dto.EmployeeSearchDto;
+import com.finalproj.orbitflow.attendance.default_rule.entity.AttendanceRule;
+import com.finalproj.orbitflow.attendance.default_rule.repository.AttendanceRuleRepository;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleCreateReqDto;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleResDto;
 import com.finalproj.orbitflow.attendance.exception_rule.dto.EmpAttRuleUpdateReqDto;
-import com.finalproj.orbitflow.attendance.default_rule.entity.AttendanceRule;
 import com.finalproj.orbitflow.attendance.exception_rule.entity.EmployeeAttRule;
-import com.finalproj.orbitflow.attendance.default_rule.repository.AttendanceRuleRepository;
 import com.finalproj.orbitflow.attendance.exception_rule.repository.EmployeeAttRuleRepository;
 import com.finalproj.orbitflow.global.security.SecurityUser;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -134,12 +132,6 @@ public class AttendanceRuleService {
         validateCompanyAccess(admin.getCompanyId(), rule.getCompanyId());
 
         employeeRuleRepository.delete(rule);
-    }
-
-    public List<EmployeeSearchDto> searchEmployees(Long companyId, String keyword) {
-        return employeeRepository.searchByCompanyIdAndKeyword(companyId, keyword).stream()
-                .map(EmployeeSearchDto::from)
-                .collect(Collectors.toList());
     }
 
     // =======================================================

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/controller/EmployeeUserController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/controller/EmployeeUserController.java
@@ -1,0 +1,48 @@
+package com.finalproj.orbitflow.hr.employee.controller;
+
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.employee.dto.EmployeeSearchDto;
+import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : EmployeeUserController
+ * @since : 2025-12-30 화요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/employees")
+public class EmployeeUserController {
+
+    private final EmployeeService employeeService;
+
+    @GetMapping("/search")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<EmployeeSearchDto>> searchEmployees(@RequestParam String keyword) {
+        // Validation: 최소 2자, 최대 30자, trim 처리
+        String trimmedKeyword = keyword != null ? keyword.trim() : "";
+        if (trimmedKeyword.length() < 2) {
+            throw new IllegalArgumentException("검색어는 최소 2자 이상이어야 합니다.");
+        }
+        if (trimmedKeyword.length() > 30) {
+            throw new IllegalArgumentException("검색어는 30자 이하여야 합니다.");
+        }
+        return ResponseEntity.ok(
+                employeeService.searchEmployees(
+                        SecurityUtils.getCompanyId(),
+                        keyword.trim()
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/dto/EmployeeSearchDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/dto/EmployeeSearchDto.java
@@ -1,15 +1,14 @@
-package com.finalproj.orbitflow.attendance.default_rule.dto;
+package com.finalproj.orbitflow.hr.employee.dto;
 
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 
 /**
  * Please explain the class!!!
  *
- * @author : rlagkdus
+ * @author : seunga03
  * @filename : EmployeeSearchDto
- * @since : 2025. 12. 22. 월요일
+ * @since : 2025-12-30 화요일
  */
-
 public record EmployeeSearchDto(
         Long id,
         String name,

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -368,4 +368,11 @@ public class EmployeeService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<EmployeeSearchDto> searchEmployees(Long companyId, String keyword) {
+        return employeeRepository.searchByCompanyIdAndKeyword(companyId, keyword).stream()
+                .map(EmployeeSearchDto::from)
+                .toList();
+    }
+
 }

--- a/src/main/resources/static/js/admin-attendance/rule.js
+++ b/src/main/resources/static/js/admin-attendance/rule.js
@@ -16,12 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // ============================================
     async function loadDefaultRule() {
         try {
-            const token = sessionStorage.getItem('accessToken');
-            const res = await fetch('/api/admin/rules/default', {
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
-            });
+            const res = await apiFetch('/api/admin/rules/default');
+
             if (res.ok) {
                 const rule = await res.json();
                 if (rule.defaultStartTime) {
@@ -41,18 +37,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('saveDefaultRuleBtn').addEventListener('click', async () => {
         try {
-            const token = sessionStorage.getItem('accessToken');
             const data = {
                 defaultStartTime: document.getElementById('defaultStartTime').value + ":00",
                 defaultEndTime: document.getElementById('defaultEndTime').value + ":00",
                 lateThresholdMin: parseInt(document.getElementById('tardinessMinutes').value)
             };
 
-            const res = await fetch('/api/admin/rules/default', {
+            const res = await apiFetch('/api/admin/rules/default', {
                 method: 'PUT',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
+                    'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(data)
             });
@@ -75,12 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ============================================
     async function loadExceptionRules() {
         try {
-            const token = sessionStorage.getItem('accessToken');
-            const res = await fetch('/api/admin/rules/exception', {
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
-            });
+            const res = await apiFetch('/api/admin/rules/exception');
 
             if (res.ok) {
                 const rules = await res.json();
@@ -374,12 +363,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
-            const token = sessionStorage.getItem('accessToken');
-            const res = await fetch(`/api/admin/rules/employees/search?keyword=${encodeURIComponent(keyword)}`, {
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
-            });
+            const res = await apiFetch(
+                `/api/employees/search?keyword=${encodeURIComponent(keyword)}`
+            );
 
             if (res.ok) {
                 const employees = await res.json();
@@ -588,7 +574,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const validTo = document.getElementById('validTo').value || null;
 
         try {
-            const token = sessionStorage.getItem('accessToken');
             const data = {
                 employeeId: parseInt(employeeId),
                 startTime: startTime ? startTime + ":00" : null,
@@ -599,11 +584,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 validTo: validTo
             };
 
-            const res = await fetch('/api/admin/rules/exception', {
+            const res = await apiFetch('/api/admin/rules/exception', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
+                    'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(data)
             });
@@ -646,12 +630,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // ============================================
     async function openEditModal(ruleId) {
         try {
-            const token = sessionStorage.getItem('accessToken');
-            const res = await fetch(`/api/admin/rules/exception/${ruleId}`, {
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
-            });
+            const res = await apiFetch(`/api/admin/rules/exception/${ruleId}`);
 
             if (res.ok) {
                 const rule = await res.json();
@@ -879,7 +858,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
-            const token = sessionStorage.getItem('accessToken');
             const ruleId = document.getElementById('editRuleId').value;
             const startTime = document.getElementById('editExceptionStartTime').value;
             const endTime = document.getElementById('editExceptionEndTime').value;
@@ -898,11 +876,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 isActive: true
             };
 
-            const res = await fetch(`/api/admin/rules/exception/${ruleId}`, {
+            const res = await apiFetch(`/api/admin/rules/exception/${ruleId}`, {
                 method: 'PUT',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
+                    'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(data)
             });
@@ -942,12 +919,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
-            const token = sessionStorage.getItem('accessToken');
-            const res = await fetch(`/api/admin/rules/exception/${ruleId}`, {
-                method: 'DELETE',
-                headers: {
-                    'Authorization': `Bearer ${token}`
-                }
+            const res = await apiFetch(`/api/admin/rules/exception/${ruleId}`, {
+                method: 'DELETE'
             });
 
             if (res.ok) {


### PR DESCRIPTION
…로 이동

## #️⃣ 연관된 이슈

> #313

## 📝 작업 내용
- 근태 예외 규칙에서 사용하던 사원 검색 API를 Employee 도메인으로 이동
- 사원 검색 책임을 근태 규칙 도메인에서 분리하여 구조 정리
- 예외 규칙 화면에서 사원 검색 시 Employee API 직접 호출하도록 수정
### 변경 배경
- 근태 규칙 도메인은 **규칙 관리**에 집중해야 하며
- 사원 검색은 Employee 도메인의 책임이므로 API 책임 분리를 통해 구조를 명확히 하기 위함
### 변경 사항
- 사원 검색 API 경로 변경  
  - (Before) `/api/admin/rules/**`
  - (After) `/api/employees/search`
- 프론트엔드 사원 검색 로직 수정
- 기존 규칙 관련 로직에는 영향 없음

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
