### PR TITLE
feat(org): 조직 관리 검색 기능 서버 검색 방식으로 전환

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
@@ -47,17 +47,31 @@ public class OrgController {
                 ));
     }
 
-    @GetMapping()
-    public ResponseEntity<ResponseDto<List<OrgResDto>>> list(
-            @RequestParam(defaultValue = "false") boolean includeInactive
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<OrgResDto>>> listOrSearch(
+            @RequestParam(defaultValue = "false") boolean includeInactive,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean includeDescendants
     ) {
         Long companyId = SecurityUtils.getCompanyId();
 
+        // 검색어 없으면 기존 목록
+        if (keyword == null || keyword.isBlank()) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            HttpStatus.OK,
+                            "조직 목록 조회",
+                            orgService.findAll(companyId, includeInactive)
+                    )
+            );
+        }
+
+        // 검색어 있으면 검색
         return ResponseEntity.ok(
                 new ResponseDto<>(
                         HttpStatus.OK,
-                        "조직 목록 조회",
-                        orgService.findAll(companyId, includeInactive)
+                        "조직 검색 결과 조회",
+                        orgService.search(companyId, keyword, includeInactive, includeDescendants)
                 )
         );
     }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -92,6 +92,79 @@ public class OrgService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<OrgResDto> search(
+            Long companyId,
+            String keyword,
+            boolean includeInactive,
+            boolean includeDescendants
+    ) {
+        String normalized = keyword.trim().toLowerCase();
+
+        // 기준 데이터 로딩
+        List<Organization> baseList = includeInactive
+                ? orgRepository.findByCompanyIdOrderByIsActiveDescParentOrgIdAscOrderIndexAsc(companyId)
+                : orgRepository.findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(companyId);
+
+        // 빠른 탐색용 Map
+        var orgMap = baseList.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Organization::getId,
+                        o -> o
+                ));
+
+        // 검색 히트 조직
+        var matched = baseList.stream()
+                .filter(o -> o.getName().toLowerCase().contains(normalized))
+                .toList();
+
+        java.util.Set<Long> resultIds = new java.util.HashSet<>();
+
+        for (Organization org : matched) {
+
+            // 2-1) 자기 자신
+            resultIds.add(org.getId());
+
+            // 2-2) 부모 체인 포함
+            Long cursor = org.getParentOrgId();
+            while (cursor != null) {
+                Organization parent = orgMap.get(cursor);
+                if (parent == null) break;
+                resultIds.add(parent.getId());
+                cursor = parent.getParentOrgId();
+            }
+
+            // 2-3) 하위 조직 포함 (옵션)
+            if (includeDescendants) {
+                collectDescendants(org.getId(), orgMap, resultIds);
+            }
+        }
+
+        // 결과 DTO 변환
+        return baseList.stream()
+                .filter(o -> resultIds.contains(o.getId()))
+                .map(OrgResDto::from)
+                .toList();
+    }
+
+    /**
+     * 하위 조직 재귀 수집
+     */
+    private void collectDescendants(
+            Long parentId,
+            java.util.Map<Long, Organization> orgMap,
+            java.util.Set<Long> result
+    ) {
+        orgMap.values().stream()
+                .filter(o -> parentId.equals(o.getParentOrgId()))
+                .forEach(child -> {
+                    if (result.add(child.getId())) {
+                        collectDescendants(child.getId(), orgMap, result);
+                    }
+                });
+    }
+
+
     /* ================= 수정 ================= */
     public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
 

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -67,7 +67,11 @@ async function loadOrganizations() {
 
     const json = await res.json();
     allOrgList = json.data || [];
-    applyFilterAndRender();
+    filteredOrgList = allOrgList;
+
+    expandedSet.clear();
+    renderTree();
+    initSortable();
     resetOrderChanged();
 }
 
@@ -76,49 +80,6 @@ async function loadOrgCategories() {
     const json = await res.json();
     orgCategories = (json.data || []).filter(c => c.isActive === true);
 }
-
-/* ======================
-   Filter + Render
-====================== */
-function applyFilterAndRender() {
-    const keyword = els.search().value.trim().toLowerCase();
-    const includeInactive = els.includeInactive().checked;
-
-    // 검색어 없을 때 → 기존 전체 트리
-    if (!keyword) {
-        filteredOrgList = allOrgList.filter(o =>
-            includeInactive || normalizeActive(o)
-        );
-
-        renderTree();
-        initSortable();
-        return;
-    }
-
-    // 검색어 있을 때
-    const includeDescendants = els.includeDescendants().checked;
-    const visibleIds = collectMatchedOrgIds(keyword, includeDescendants);
-
-    filteredOrgList = allOrgList.filter(o => {
-        // 회사(최상위 parent=null)는 제외
-        if (o.parentOrgId === null) return false;
-
-        if (!includeInactive && !normalizeActive(o)) return false;
-
-        return visibleIds.has(o.id);
-    });
-
-    // 부모 자동 펼침
-    filteredOrgList.forEach(o => expandParents(o));
-
-    renderTree();
-
-    // 검색 중 정렬 비활성화
-    destroySortable();
-    els.btnSaveOrder().disabled = true;
-    isOrderChanged = false;
-}
-
 
 /* ======================
    Render Tree
@@ -276,17 +237,16 @@ async function saveOrder() {
    Events
 ====================== */
 function bindEvents() {
-    els.search().addEventListener('input', applyFilterAndRender);
-    els.includeInactive().addEventListener('change', loadOrganizations);
-    els.btnSearch().addEventListener('click', applyFilterAndRender);
+    els.search().addEventListener('input', loadOrganizationsWithSearch);
+    els.btnSearch().addEventListener('click', loadOrganizationsWithSearch);
+    els.includeDescendants().addEventListener('change', loadOrganizationsWithSearch);
+    els.includeInactive().addEventListener('change', loadOrganizationsWithSearch);
 
     els.btnCreate().addEventListener('click', openCreate);
     els.btnSaveOrder().addEventListener('click', saveOrder);
     els.btnCloseIcon().addEventListener('click', closeModal);
     els.btnCancel().addEventListener('click', closeModal);
     els.btnSave().addEventListener('click', saveOrg);
-
-    els.includeDescendants().addEventListener('change', applyFilterAndRender);
 }
 
 /* ======================
@@ -515,74 +475,6 @@ function focusFirstMatch(keyword) {
     setTimeout(() => el.classList.remove('org-focus'), 1500);
 }
 
-function groupHasKeyword(root, keyword) {
-    const stack = [root];
-
-    while (stack.length) {
-        const cur = stack.pop();
-
-        if (cur.name.toLowerCase().includes(keyword)) {
-            return true;
-        }
-
-        const children = allOrgList.filter(o => o.parentOrgId === cur.id);
-        stack.push(...children);
-    }
-
-    return false;
-}
-
-function expandParentsByKeyword(root, keyword) {
-    const stack = [root];
-
-    while (stack.length) {
-        const cur = stack.pop();
-
-        if (cur.name.toLowerCase().includes(keyword)) {
-            expandParents(cur);
-        }
-
-        const children = allOrgList.filter(o => o.parentOrgId === cur.id);
-        stack.push(...children);
-    }
-}
-
-function collectMatchedOrgIds(keyword, includeDescendants) {
-    const result = new Set();
-
-    allOrgList.forEach(org => {
-        if (!org.name.toLowerCase().includes(keyword)) return;
-
-        // 1. 자기 자신
-        result.add(org.id);
-
-        // 2. 부모 체인
-        let cur = org;
-        while (cur.parentOrgId) {
-            const parent = allOrgList.find(o => o.id === cur.parentOrgId);
-            if (!parent) break;
-            result.add(parent.id);
-            cur = parent;
-        }
-
-        // 3. 하위 조직 (옵션 ON일 때만)
-        if (includeDescendants) {
-            collectDescendants(org.id, result);
-        }
-    });
-
-    return result;
-}
-
-function collectDescendants(parentId, set) {
-    allOrgList
-        .filter(o => o.parentOrgId === parentId)
-        .forEach(child => {
-            if (set.has(child.id)) return;
-            set.add(child.id);
-            collectDescendants(child.id, set);
-        });
-}
 
 async function loadPositionPolicies(orgId, orgCategoryId) {
 
@@ -683,3 +575,33 @@ document.getElementById('policyHeadFilter')
     .addEventListener('change', () =>
         renderPolicyTable(currentOrgCategoryId)
     );
+
+
+
+async function loadOrganizationsWithSearch() {
+    const keyword = els.search().value.trim();
+    const includeInactive = els.includeInactive().checked;
+    const includeDescendants = els.includeDescendants().checked;
+
+    const params = new URLSearchParams({
+        includeInactive,
+        includeDescendants
+    });
+
+    if (keyword) {
+        params.append('keyword', keyword);
+    }
+
+    const res = await apiFetch(`${API_BASE}?${params.toString()}`);
+    const json = await res.json();
+
+    allOrgList = json.data || [];
+    filteredOrgList = allOrgList;
+
+    expandedSet.clear();
+    allOrgList.forEach(o => expandParents(o));
+
+    renderTree();
+    destroySortable();
+    resetOrderChanged();
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #315

## 📝 작업 내용
- 조직 관리 화면의 검색 기능을 프론트 필터링 방식에서 서버 검색 방식으로 전환
- 검색 시 서버에서:
  - 조직명 기준 매칭
  - 부모 조직 체인 자동 포함
  - 옵션에 따른 하위 조직 포함 검색 처리
- 프론트에서는 검색 결과를 그대로 렌더링하도록 구조 단순화
- 검색 중에는 조직 정렬(Drag & Drop) 기능 비활성화 처리
- 기존 트리 UI / 확장 UX / 하이라이트 효과 유지
### 주요 변경 사항
- OrgController: 목록 조회 API를 검색 API와 통합 (keyword, includeDescendants 파라미터 추가)
- OrgService
  - 조직 검색 로직 서버 처리
  - 부모/하위 조직 포함 검색 로직 구현
- admin-organization.js
  - 프론트 필터링 로직 제거
  - 서버 검색 결과 기반 렌더링 구조로 리팩터링

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
