### PR TITLE
feat(admin): 관리자 기본 진입 페이지를 사원 관리로 변경

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/global/main/controller/AdminMainViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/global/main/controller/AdminMainViewController.java
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AdminMainViewController {
 
     /**
-     * 관리자 진입점 → 관리자 메뉴로 리다이렉트
+     * 관리자 진입점 → 사원 관리로 바로 이동
      */
     @GetMapping("/admin")
     public String adminRoot() {
-        return "redirect:/view/admin/menu";
+        return "redirect:/view/admin/employees";
     }
 
     /**

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -4,15 +4,18 @@
 <ul th:fragment="menu" class="sidebar-menu">
 
     <li class="menu-item">
-        <div class="menu-title" role="button" onclick="toggleAdminMenu(this)">
+<!--        <div class="menu-title" role="button" onclick="toggleAdminMenu(this)">-->
+<!--            <span>사원 관리</span>-->
+<!--            <i class="fas fa-chevron-down arrow"></i>-->
+<!--        </div>-->
+<!--        <ul class="sub-menu">-->
+<!--            <li th:classappend="${currentMenu == 'employee'} ? 'selected' : ''">-->
+<!--                <a th:href="@{/view/admin/employees}">사원 관리</a>-->
+<!--            </li>-->
+<!--        </ul>-->
+        <a th:href="@{/view/admin/employees}" class="menu-title" style="text-decoration:none;">
             <span>사원 관리</span>
-            <i class="fas fa-chevron-down arrow"></i>
-        </div>
-        <ul class="sub-menu">
-            <li th:classappend="${currentMenu == 'employee'} ? 'selected' : ''">
-                <a th:href="@{/view/admin/employees}">사원 관리</a>
-            </li>
-        </ul>
+        </a>
     </li>
 
     <li class="menu-item no-sub">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #325

## 📝 작업 내용
- 관리자 `/view/admin` 진입 시 리다이렉트 수정
  - 기존: 관리자 메뉴 페이지
  - 변경: 사원 관리 페이지(`/view/admin/employees`)
- 관리자 홈 개념을 사원 관리 화면으로 통합하여 실제 관리자 사용 흐름에 맞는 진입 UX로 개선
- 관리자 사이드바에서 사원 관리 메뉴를 토글형이 아닌 단일 메뉴로 단순화
- `currentMenu=employee` 기준으로 사이드바 선택 상태 유지


## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
