### PR TITLE
feat(email): 계정 활성화 및 최초 비밀번호 재설정 이메일 인증 플로우 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     // redis 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Gmail SMTP
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
@@ -3,6 +3,7 @@ package com.finalproj.orbitflow.email.controller;
 import com.finalproj.orbitflow.email.enums.EmailTokenType;
 import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,22 @@ public class AccountActivateController {
                 emailService.verifyAndGetEmployee(token, EmailTokenType.ACTIVATE_ACCOUNT);
 
         employeeService.activate(employee);
+
+        return ResponseEntity.ok().build();
+    }
+
+
+    @PostMapping("/activate/resend")
+    public ResponseEntity<?> resendActivateMail(@RequestParam Long employeeId) {
+
+        Employee employee = employeeService.findById(employeeId);
+
+        // 이미 ACTIVE면 재전송 불가
+        if (employee.getStatus() != EmployeeStatus.TEMP) {
+            throw new IllegalStateException("이미 활성화된 계정입니다.");
+        }
+
+        emailService.sendActivateMail(employee);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/finalproj/orbitflow/email/controller/ActivateViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/ActivateViewController.java
@@ -1,0 +1,39 @@
+package com.finalproj.orbitflow.email.controller;
+
+import com.finalproj.orbitflow.email.enums.EmailTokenType;
+import com.finalproj.orbitflow.email.service.EmailVerificationService;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : ActivateViewController
+ * @since : 2026-01-02 금요일
+ */
+@Controller
+@RequestMapping("/activate")
+@RequiredArgsConstructor
+public class ActivateViewController {
+
+    private final EmailVerificationService emailService;
+    private final EmployeeService employeeService;
+
+    @GetMapping
+    public String activateAndRedirect(@RequestParam String token) {
+
+        Employee employee =
+                emailService.verifyAndGetEmployee(token, EmailTokenType.ACTIVATE_ACCOUNT);
+
+        employeeService.activate(employee);
+
+        // 활성화 끝 --> 비밀번호 재설정으로 이동
+        return "redirect:/reset-password?token=" + token;
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
@@ -1,6 +1,7 @@
 package com.finalproj.orbitflow.email.controller;
 
 import com.finalproj.orbitflow.email.dto.PasswordResetReqDto;
+import com.finalproj.orbitflow.email.entity.EmailVerificationToken;
 import com.finalproj.orbitflow.email.enums.EmailTokenType;
 import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
@@ -47,10 +48,15 @@ public class PasswordResetController {
             @RequestParam String token,
             @RequestBody @Valid PasswordResetReqDto dto
     ) {
-        Employee employee =
-                emailService.verifyAndGetEmployee(token, EmailTokenType.RESET_PASSWORD);
+        EmailVerificationToken verificationToken =
+                emailService.verify(token, EmailTokenType.ACTIVATE_ACCOUNT);
+
+        Employee employee = verificationToken.getEmployee();
 
         employeeService.resetPassword(employee, dto.getPassword());
+
+        // 여기서 토큰 사용 처리
+        emailService.markTokenUsed(verificationToken);
 
         auditLogService.log(
                 employee.getCompany(),

--- a/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetViewController.java
@@ -1,0 +1,25 @@
+package com.finalproj.orbitflow.email.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PasswordResetViewController
+ * @since : 2026-01-02 금요일
+ */
+@Controller
+@RequestMapping("/reset-password")
+public class PasswordResetViewController {
+
+    @GetMapping
+    public String resetPage(@RequestParam String token, Model model) {
+        model.addAttribute("token", token);
+        return "email/reset-password";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/email/service/ConsoleMailSender.java
+++ b/src/main/java/com/finalproj/orbitflow/email/service/ConsoleMailSender.java
@@ -1,5 +1,6 @@
 package com.finalproj.orbitflow.email.service;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
  * @filename : ConsoleMailSender
  * @since : 2026-01-01 목요일
  */
+@Profile("dev")
 @Component
 public class ConsoleMailSender implements MailSender {
     public void send(String to, String subject, String content) {

--- a/src/main/java/com/finalproj/orbitflow/email/service/EmailVerificationService.java
+++ b/src/main/java/com/finalproj/orbitflow/email/service/EmailVerificationService.java
@@ -7,6 +7,7 @@ import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * Please explain the class!!!
@@ -23,29 +24,22 @@ public class EmailVerificationService {
     private final EmailVerificationTokenRepository tokenRepository;
     private final MailSender mailSender;
 
+    @Value("${app.base-url}")
+    private String baseUrl;
+
     public void sendActivateMail(Employee employee) {
         EmailVerificationToken token =
                 EmailVerificationToken.create(employee, EmailTokenType.ACTIVATE_ACCOUNT, 30);
 
         tokenRepository.save(token);
 
+        String link = baseUrl + "/activate?token=" + token.getToken();
+
         mailSender.send(
                 employee.getEmail(),
                 "[OrbitFlow] 계정 활성화",
-                "https://orbitflow.local/activate?token=" + token.getToken()
+                link
         );
-    }
-
-    public EmailVerificationToken verify(String tokenValue, EmailTokenType type) {
-        EmailVerificationToken token = tokenRepository.findByToken(tokenValue)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰"));
-
-        if (token.isUsed()) throw new IllegalStateException("이미 사용됨");
-        if (token.isExpired()) throw new IllegalStateException("만료됨");
-        if (token.getType() != type) throw new IllegalStateException("타입 불일치");
-
-        token.markUsed();
-        return token;
     }
 
     public void requestPasswordReset(Employee employee) {
@@ -54,12 +48,31 @@ public class EmailVerificationService {
 
         tokenRepository.save(token);
 
+        String link = baseUrl + "/reset-password?token=" + token.getToken();
+
         mailSender.send(
                 employee.getEmail(),
                 "[OrbitFlow] 비밀번호 재설정",
-                "https://orbitflow.local/reset-password?token=" + token.getToken()
+                link
         );
     }
+
+    public EmailVerificationToken verify(String tokenValue, EmailTokenType type) {
+        EmailVerificationToken token = tokenRepository.findByToken(tokenValue)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰"));
+
+        if (token.isUsed()) throw new IllegalStateException("이미 사용된 토큰입니다.");
+        if (token.isExpired()) throw new IllegalStateException("만료된 토큰입니다.");
+        if (token.getType() != type) throw new IllegalStateException("타입이 올바르지 않습니다.");
+
+        // markUsed() 여기서 하지 않음
+        return token;
+    }
+
+    public void markTokenUsed(EmailVerificationToken token) {
+        token.markUsed();
+    }
+
 
     public Employee verifyAndGetEmployee(String tokenValue, EmailTokenType type) {
         EmailVerificationToken token = verify(tokenValue, type);

--- a/src/main/java/com/finalproj/orbitflow/email/service/SmtpMailSender.java
+++ b/src/main/java/com/finalproj/orbitflow/email/service/SmtpMailSender.java
@@ -1,0 +1,32 @@
+package com.finalproj.orbitflow.email.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : SmtpMailSender
+ * @since : 2026-01-03 토요일
+ */
+@Profile("local")
+@Component
+@RequiredArgsConstructor
+public class SmtpMailSender implements MailSender {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void send(String to, String subject, String content) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(to);
+        msg.setSubject(subject);
+        msg.setText(content);
+        msg.setFrom("OrbitFlow <seungalee220@gmail.com>");
+        mailSender.send(msg);
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
@@ -49,8 +49,11 @@ public class SecurityConfig {
                                 "/css/**",
                                 "/js/**",
                                 "/images/**",
-                                "/favicon.ico"
-                                ).permitAll()
+                                "/favicon.ico",
+                                "/activate",
+                                "/reset-password",
+                                "/api/email/**"
+                        ).permitAll()
 
                         .requestMatchers("/api/admin/**")
                         .hasAnyRole("ADMIN", "COMPANY_ADMIN")

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -468,4 +468,10 @@ public class EmployeeService {
         return EmployeeUpdateResDto.from(e);
     }
 
+    @Transactional(readOnly = true)
+    public Employee findById(Long employeeId) {
+        return employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new IllegalArgumentException("사원을 찾을 수 없습니다."));
+    }
+
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,3 +32,6 @@ external:
 business:
   validation:
     strict: false   # 시연용 (true = 운영)
+
+app:
+  base-url: https://orbitflow.com

--- a/src/main/resources/templates/email/activate.html
+++ b/src/main/resources/templates/email/activate.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>계정 활성화 | OrbitFlow</title>
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background: #f6f8fb;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-family: 'Noto Sans KR', sans-serif;
+        }
+        .card {
+            width: 420px;
+            background: #fff;
+            border-radius: 16px;
+            padding: 40px;
+            box-shadow: 0 20px 50px rgba(0,0,0,.12);
+            text-align: center;
+        }
+        h1 {
+            margin-bottom: 12px;
+            font-size: 22px;
+            font-weight: 900;
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            font-weight: 600;
+            color: #6b7280;
+        }
+        .success { color: #15803d; }
+        .error { color: #b91c1c; }
+        .spinner {
+            margin: 24px auto;
+            width: 36px;
+            height: 36px;
+            border: 4px solid #e5e7eb;
+            border-top-color: #2563eb;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        .btn {
+            margin-top: 28px;
+            padding: 12px 18px;
+            border-radius: 12px;
+            border: none;
+            background: #2563eb;
+            color: #fff;
+            font-size: 14px;
+            font-weight: 800;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+
+<div class="card">
+    <h1 id="title">계정 활성화 중</h1>
+    <div class="spinner" id="spinner"></div>
+    <p id="message">잠시만 기다려 주세요.</p>
+
+    <button id="loginBtn" class="btn" style="display:none"
+            onclick="location.href='/login'">
+        로그인 페이지로 이동
+    </button>
+</div>
+
+<script>
+    const token = '[[${token}]]';
+
+    fetch(`/api/email/activate?token=${token}`, { method: 'POST' })
+        .then(res => {
+            if (!res.ok) throw new Error();
+            document.getElementById('title').innerText = '계정 활성화 완료';
+            document.getElementById('title').className = 'success';
+            document.getElementById('message').innerText =
+                '이제 OrbitFlow를 이용하실 수 있습니다.';
+        })
+        .catch(() => {
+            document.getElementById('title').innerText = '활성화 실패';
+            document.getElementById('title').className = 'error';
+            document.getElementById('message').innerText =
+                '이미 사용되었거나 만료된 링크입니다.';
+        })
+        .finally(() => {
+            document.getElementById('spinner').style.display = 'none';
+            document.getElementById('loginBtn').style.display = 'inline-block';
+        });
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/email/reset-password.html
+++ b/src/main/resources/templates/email/reset-password.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>비밀번호 재설정 | OrbitFlow</title>
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      background: #f6f8fb;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-family: 'Noto Sans KR', sans-serif;
+    }
+    .card {
+      width: 420px;
+      background: #fff;
+      border-radius: 16px;
+      padding: 40px;
+      box-shadow: 0 20px 50px rgba(0,0,0,.12);
+    }
+    h1 {
+      margin-bottom: 18px;
+      font-size: 22px;
+      font-weight: 900;
+      text-align: center;
+    }
+    .form-group {
+      margin-bottom: 14px;
+    }
+    label {
+      display: block;
+      font-size: 13px;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+    input {
+      width: 100%;
+      height: 44px;
+      padding: 0 12px;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+      font-size: 14px;
+    }
+    .error {
+      margin-top: 10px;
+      font-size: 13px;
+      font-weight: 700;
+      color: #b91c1c;
+    }
+    .btn {
+      margin-top: 24px;
+      width: 100%;
+      height: 46px;
+      border-radius: 12px;
+      border: none;
+      background: #2563eb;
+      color: #fff;
+      font-size: 14px;
+      font-weight: 800;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+<div class="card">
+  <h1>비밀번호 재설정</h1>
+
+  <div class="form-group">
+    <label>새 비밀번호</label>
+    <input type="password" id="password">
+  </div>
+
+  <div class="form-group">
+    <label>새 비밀번호 확인</label>
+    <input type="password" id="passwordConfirm">
+  </div>
+
+  <div id="error" class="error"></div>
+
+  <button class="btn" onclick="resetPassword()">비밀번호 변경</button>
+</div>
+
+<script>
+  const token = '[[${token}]]';
+
+  function resetPassword() {
+    const pw = document.getElementById('password').value;
+    const confirm = document.getElementById('passwordConfirm').value;
+    const error = document.getElementById('error');
+
+    error.innerText = '';
+
+    if (!pw || pw.length < 8) {
+      error.innerText = '비밀번호는 최소 8자 이상이어야 합니다.';
+      return;
+    }
+    if (pw !== confirm) {
+      error.innerText = '비밀번호가 일치하지 않습니다.';
+      return;
+    }
+
+    fetch(`/api/email/password/reset?token=${token}`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ password: pw })
+    })
+            .then(res => {
+              if (!res.ok) throw new Error();
+              alert('비밀번호가 변경되었습니다. 다시 로그인해 주세요.');
+              location.href = '/login';
+            })
+            .catch(() => {
+              error.innerText = '링크가 만료되었거나 이미 사용되었습니다.';
+            });
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #352

## 📝 작업 내용
### 이메일 인증 기반 계정 활성화 플로우 구현
- 사원 생성 시 TEMP 상태 계정에 대해 **계정 활성화 메일 발송**
- 활성화 링크 클릭 시:
  - 토큰 검증
  - 사원 상태 TEMP → ACTIVE 전환
  - 최초 비밀번호 재설정 페이지로 자동 이동

### 최초 비밀번호 설정 / 재설정 기능 구현
- 이메일 토큰 기반 비밀번호 재설정 API 구현
- 비밀번호 변경 완료 시 토큰 사용 처리
- 토큰 만료 / 중복 사용 방지 로직 적용

### MailSender 추상화 및 환경별 구현체 분리
- `MailSender` 인터페이스 도입
- dev 환경: ConsoleMailSender (콘솔 출력)
- local 환경: SMTP(Gmail) 기반 실제 메일 발송
- Spring Profile 기반 구현체 자동 선택

### 보안 및 설정 개선
- base URL을 `app.base-url` 설정값으로 분리
- 이메일 링크 환경별 유연 대응 가능
- Spring Security에서 인증 필요 없는 경로 명확히 허용


## 동작 플로우 요약
1. 관리자 → 사원 생성 (TEMP)
2. 활성화 메일 발송
3. 메일 링크 클릭 → 계정 활성화
4. 비밀번호 재설정 페이지 이동
5. 비밀번호 설정 완료 → 토큰 사용 처리
6. 로그인 가능

## 스크린샷 (선택)
<img width="691" height="374" alt="image" src="https://github.com/user-attachments/assets/b5a6013e-a820-4a6e-82c3-958242d4dea2" />

## 💬 리뷰 요구사항(선택)
