### PR TITLE
feat: add password reset flow and find-password page

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/PasswordFindViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/PasswordFindViewController.java
@@ -1,0 +1,20 @@
+package com.finalproj.orbitflow.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PasswordFindViewController
+ * @since : 2026-01-05 월요일
+ */
+@Controller
+public class PasswordFindViewController {
+
+    @GetMapping("/find-password")
+    public String findPasswordPage() {
+        return "auth/find-password";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/auth/service/AuthService.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/service/AuthService.java
@@ -64,8 +64,8 @@ public class AuthService {
         refreshTokenRepository.deleteByToken(token);
     }
 
-    // 동시 로그인 차단 // TODO: 사용할지는 나중에 결정하기
-//    public void invalidateAll(Long employeeId) { // 특정 사원의 모든 Refresh Token을 DB에서 삭제
-//        refreshTokenRepository.deleteAllByEmployeeId(employeeId);
-//    }
+    // 비밀번호 변경 시 Refresh Token 전체 무효화
+    public void invalidateAll(Long employeeId) { // 특정 사원의 모든 Refresh Token을 DB에서 삭제
+        refreshTokenRepository.deleteAllByEmployeeId(employeeId);
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
@@ -1,5 +1,6 @@
 package com.finalproj.orbitflow.email.controller;
 
+import com.finalproj.orbitflow.auth.service.AuthService;
 import com.finalproj.orbitflow.email.dto.PasswordResetReqDto;
 import com.finalproj.orbitflow.email.entity.EmailVerificationToken;
 import com.finalproj.orbitflow.email.enums.EmailTokenType;
@@ -32,6 +33,7 @@ public class PasswordResetController {
     private final EmployeeService employeeService;
     private final EmailVerificationService emailService;
     private final AuditLogService auditLogService;
+    private final AuthService authService;
 
     @PostMapping("/password/reset-request")
     public ResponseEntity<?> request(@RequestParam String email) {
@@ -49,11 +51,14 @@ public class PasswordResetController {
             @RequestBody @Valid PasswordResetReqDto dto
     ) {
         EmailVerificationToken verificationToken =
-                emailService.verify(token, EmailTokenType.ACTIVATE_ACCOUNT);
+                emailService.verify(token, EmailTokenType.RESET_PASSWORD);
 
         Employee employee = verificationToken.getEmployee();
 
         employeeService.resetPassword(employee, dto.getPassword());
+
+        // 모든 세션 무효화 --> 비밀번호 변경 즉시 모든 기기 로그아웃
+        authService.invalidateAll(employee.getId());
 
         // 여기서 토큰 사용 처리
         emailService.markTokenUsed(verificationToken);

--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                 "/favicon.ico",
                                 "/activate",
                                 "/reset-password",
+                                "/find-password",
                                 "/api/email/**"
                         ).permitAll()
 

--- a/src/main/resources/templates/auth/find-password.html
+++ b/src/main/resources/templates/auth/find-password.html
@@ -1,0 +1,43 @@
+<form onsubmit="requestReset(event)">
+  <h2>비밀번호 재설정</h2>
+
+  <input id="email"
+         type="email"
+         placeholder="이메일 입력"
+         required />
+
+  <button id="submitBtn" type="submit">
+    재설정 메일 보내기
+  </button>
+
+  <p id="msg" style="margin-top:12px; font-size:13px;"></p>
+</form>
+
+<script>
+  async function requestReset(e) {
+    e.preventDefault();
+
+    const emailInput = document.getElementById('email');
+    const msg = document.getElementById('msg');
+    const btn = document.getElementById('submitBtn');
+
+    btn.disabled = true;
+    msg.textContent = '처리 중입니다…';
+
+    try {
+      await fetch(
+              `/api/email/password/reset-request?email=${encodeURIComponent(emailInput.value)}`,
+              { method: 'POST' }
+      );
+
+      // 보안상 항상 동일 메시지
+      msg.textContent =
+              '메일이 전송되었습니다. (계정이 존재할 경우)';
+    } catch (err) {
+      msg.textContent =
+              '요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.';
+    } finally {
+      btn.disabled = false;
+    }
+  }
+</script>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -121,6 +121,14 @@
   </div>
 
   <button class="login-btn" type="submit">로그인</button>
+
+  <div style="margin-top:16px; text-align:center;">
+    <a href="/find-password"
+       style="font-size:13px; color:#4f7cff; text-decoration:none;">
+      비밀번호를 잊으셨나요?
+    </a>
+  </div>
+
 </form>
 
 

--- a/src/main/resources/templates/email/reset-password.html
+++ b/src/main/resources/templates/email/reset-password.html
@@ -90,6 +90,7 @@
     const pw = document.getElementById('password').value;
     const confirm = document.getElementById('passwordConfirm').value;
     const error = document.getElementById('error');
+    const btn = document.querySelector('.btn');
 
     error.innerText = '';
 
@@ -102,7 +103,9 @@
       return;
     }
 
-    fetch(`/api/email/password/reset?token=${token}`, {
+    btn.disabled = true;
+
+    fetch(`/api/email/password/reset?token=${encodeURIComponent(token)}`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ password: pw })
@@ -114,6 +117,7 @@
             })
             .catch(() => {
               error.innerText = '링크가 만료되었거나 이미 사용되었습니다.';
+              btn.disabled = false;
             });
   }
 </script>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #364

## 📝 작업 내용
### 비밀번호 재설정 기능
- 이메일 기반 비밀번호 재설정 요청 API 구현
- 토큰 만료/재사용 방지 처리
- 비밀번호 변경 성공 시 기존 Refresh Token 전체 무효화 (보안 강화)

### UI / UX
- 로그인 화면에 **“비밀번호를 잊으셨나요?”** 링크 추가
- 비밀번호 재설정 요청 페이지 (`/find-password`) 신규 추가
- 비밀번호 재설정 페이지 UX 개선 (비밀번호 확인, 검증 메시지)

### 보안 설정
- 인증 없이 접근 가능한 경로에 `/find-password`, `/reset-password` 허용
- 토큰 타입 검증(RESET_PASSWORD) 및 만료 처리 강화


## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="755" height="295" alt="image" src="https://github.com/user-attachments/assets/e580d71e-bc12-492f-bc56-8a51b7654a5c" />

## 💬 리뷰 요구사항(선택)
