### PR TITLE
feat(Organization): 조직도 페이지 + 내선번호 목록 1차 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/jwt/JwtAuthenticationFilter.java
@@ -40,6 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean isPublicPath(String path) {
         return path.startsWith("/api/auth/login")
                 || path.startsWith("/api/auth/refresh")
+                || path.startsWith("/view/**")
                 || path.startsWith("/css/")
                 || path.startsWith("/js/")
                 || path.startsWith("/images/")

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/controller/EmployeeUserController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/controller/EmployeeUserController.java
@@ -1,15 +1,15 @@
 package com.finalproj.orbitflow.hr.employee.controller;
 
+import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.employee.dto.EmployeeDetailResDto;
 import com.finalproj.orbitflow.hr.employee.dto.EmployeeSearchDto;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -45,4 +45,21 @@ public class EmployeeUserController {
                 )
         );
     }
+
+    @GetMapping("/{employeeId}")
+    public ResponseEntity<ResponseDto<EmployeeDetailResDto>> detail(
+            @PathVariable Long employeeId
+    ) {
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "사원 상세 조회 성공",
+                        employeeService.getDetail(
+                                SecurityUtils.getCompanyId(),
+                                employeeId
+                        )
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -47,13 +47,13 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
             Long organizationId,
             EmployeeStatus status
     );
-  
+
     /**
      * 회사 ID + 이름, 사번 또는 이메일로 사원 검색
      */
     @Query("SELECT e FROM Employee e WHERE e.company.id = :companyId " +
-           "AND (e.name LIKE CONCAT('%', :keyword, '%') OR e.employeeNo LIKE CONCAT('%', :keyword, '%') OR e.email LIKE CONCAT('%', :keyword, '%')) " +
-           "AND e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE")
+            "AND (e.name LIKE CONCAT('%', :keyword, '%') OR e.employeeNo LIKE CONCAT('%', :keyword, '%') OR e.email LIKE CONCAT('%', :keyword, '%')) " +
+            "AND e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE")
     List<Employee> searchByCompanyIdAndKeyword(
             @Param("companyId") Long companyId,
             @Param("keyword") String keyword
@@ -81,32 +81,32 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
 
     @Query("""
-        select e
-        from Employee e
-        join e.positionCategory pc
-        join e.organization o
-        where o.id = :organizationId
-          and pc.orgCategory.id = :orgCategoryId
-          and pc.isHead = true
-          and pc.isActive = true
-          and e.status = "ACTIVE"
-    """)
+                select e
+                from Employee e
+                join e.positionCategory pc
+                join e.organization o
+                where o.id = :organizationId
+                  and pc.orgCategory.id = :orgCategoryId
+                  and pc.isHead = true
+                  and pc.isActive = true
+                  and e.status = "ACTIVE"
+            """)
     Optional<Employee> findHeadByOrganizationAndOrgCategory(
             @Param("organizationId") Long organizationId,
             @Param("orgCategoryId") Long orgCategoryId
     );
 
     @Query("""
-        select case when count(e) > 0 then true else false end
-        from Employee e
-        join e.organization o
-        join e.positionCategory pc
-        where e.id = :employeeId
-          and o.id = :organizationId
-          and pc.id = :positionCategoryId
-          and e.status = "ACTIVE"
-          and pc.isActive = true
-    """)
+                select case when count(e) > 0 then true else false end
+                from Employee e
+                join e.organization o
+                join e.positionCategory pc
+                where e.id = :employeeId
+                  and o.id = :organizationId
+                  and pc.id = :positionCategoryId
+                  and e.status = "ACTIVE"
+                  and pc.isActive = true
+            """)
     boolean existsInOrgAndPositionCategory(
             @Param("employeeId") Long employeeId,
             @Param("organizationId") Long organizationId,
@@ -115,17 +115,17 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
 
     @Query("""
-        select e
-        from Employee e
-        join e.organization o
-        join e.positionCategory pc
-        where o.id = :orgId
-          and pc.isHead = true
-          and pc.isActive = true
-          and pc.orgCategory.id = o.categoryId
-          and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
-        order by e.id asc
-    """)
+                select e
+                from Employee e
+                join e.organization o
+                join e.positionCategory pc
+                where o.id = :orgId
+                  and pc.isHead = true
+                  and pc.isActive = true
+                  and pc.orgCategory.id = o.categoryId
+                  and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
+                order by e.id asc
+            """)
     List<Employee> findHeadsByOrgId(@Param("orgId") Long orgId);
 
     default Optional<Employee> findHeadByOrgId(Long orgId) {
@@ -134,14 +134,14 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     }
 
     @Query("""
-    select e
-    from Employee e
-    join e.organization o
-    join e.positionCategory pc
-    where o.id = :orgId
-      and pc.id = :positionCategoryId
-      and e.status = :status
-    """)
+            select e
+            from Employee e
+            join e.organization o
+            join e.positionCategory pc
+            where o.id = :orgId
+              and pc.id = :positionCategoryId
+              and e.status = :status
+            """)
     Optional<Employee> findHeadByOrgIdAndPositionCategoryIdAndStatus(
             @Param("orgId") Long orgId,
             @Param("positionCategoryId") Long positionCategoryId,
@@ -149,15 +149,15 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     );
 
     @Query("""
-    select e
-    from Employee e
-    join e.organization o
-    join e.positionCategory pc
-    where e.id = :employeeId
-      and o.id = :orgId
-      and pc.id = :positionCategoryId
-      and e.status = :status
-    """)
+            select e
+            from Employee e
+            join e.organization o
+            join e.positionCategory pc
+            where e.id = :employeeId
+              and o.id = :orgId
+              and pc.id = :positionCategoryId
+              and e.status = :status
+            """)
     Optional<Employee> findByIdAndOrgIdAndPositionCategoryIdAndStatus(
             @Param("employeeId") Long employeeId,
             @Param("orgId") Long orgId,
@@ -168,17 +168,17 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     List<Employee> findByStatus(EmployeeStatus employeeStatus);
 
     @Query("""
-    select e
-    from Employee e
-    join e.organization o
-    where e.company.id = :companyId
-      and (:status is null or e.status = :status)
-      and (
-        :keyword is null
-        or e.name like concat('%', :keyword, '%')
-        or e.email like concat('%', :keyword, '%')
-      )
-""")
+                select e
+                from Employee e
+                join e.organization o
+                where e.company.id = :companyId
+                  and (:status is null or e.status = :status)
+                  and (
+                    :keyword is null
+                    or e.name like concat('%', :keyword, '%')
+                    or e.email like concat('%', :keyword, '%')
+                  )
+            """)
     Page<Employee> searchAdmin(
             @Param("companyId") Long companyId,
             @Param("keyword") String keyword,
@@ -188,4 +188,15 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
 
     List<Employee> findByCompanyIdAndStatus(Long companyId, EmployeeStatus employeeStatus);
+
+    @Query("""
+                select e
+                from Employee e
+                join fetch e.organization o
+                where e.company.id = :companyId
+                  and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
+                  and e.internalPhone is not null
+            """)
+    List<Employee> findActiveWithExtension(Long companyId);
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgSidebarController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgSidebarController.java
@@ -1,0 +1,42 @@
+package com.finalproj.orbitflow.hr.organization.controller;
+
+import com.finalproj.orbitflow.global.common.ResponseDto;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.organization.dto.sidebar.OrgSidebarDto;
+import com.finalproj.orbitflow.hr.organization.service.OrgSidebarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgSidebarController
+ * @since : 2026-01-05 월요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sidebar")
+@PreAuthorize("isAuthenticated()")
+public class OrgSidebarController {
+
+    private final OrgSidebarService orgSidebarService;
+
+    @GetMapping("/extensions")
+    public ResponseEntity<ResponseDto<List<OrgSidebarDto>>> sidebarExtensions() {
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "사이드바 내선 조직도 조회",
+                        orgSidebarService.getSidebarTree(SecurityUtils.getCompanyId())
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserTreeController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserTreeController.java
@@ -1,0 +1,42 @@
+package com.finalproj.orbitflow.hr.organization.controller;
+
+import com.finalproj.orbitflow.global.common.ResponseDto;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.organization.dto.sidebar.OrgSidebarDto;
+import com.finalproj.orbitflow.hr.organization.service.OrgSidebarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgUserTreeController
+ * @since : 2026-01-05 월요일
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/organizations")
+@PreAuthorize("isAuthenticated()")
+public class OrgUserTreeController {
+
+    private final OrgSidebarService orgSidebarService;
+
+    @GetMapping("/tree")
+    public ResponseEntity<ResponseDto<List<OrgSidebarDto>>> getUserOrgTree() {
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "사용자 조직도 조회",
+                        orgSidebarService.getSidebarTree(SecurityUtils.getCompanyId())
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserViewController.java
@@ -1,0 +1,31 @@
+package com.finalproj.orbitflow.hr.organization.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgUserViewController
+ * @since : 2026-01-05 월요일
+ */
+
+@Controller
+@RequestMapping("/view/organizations")
+public class OrgUserViewController {
+    @GetMapping
+    public String orgTree(
+            @RequestParam(required = false) Long employeeId,
+            Model model
+    ) {
+        model.addAttribute("employeeId", employeeId);
+        model.addAttribute("pageTitle", "조직도");
+        model.addAttribute("sidebarFragment", "user-sidebar");
+        return "organization/tree";
+    }
+
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarDto.java
@@ -1,0 +1,24 @@
+package com.finalproj.orbitflow.hr.organization.dto.sidebar;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgSidebarDto
+ * @since : 2026-01-05 월요일
+ */
+@Getter
+@AllArgsConstructor
+public class OrgSidebarDto {
+
+    private Long orgId;
+    private String orgName;
+
+    private List<OrgSidebarEmployeeDto> employees;   // 이 조직 소속 사원
+    private List<OrgSidebarDto> children;             // 하위 조직
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarEmployeeDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarEmployeeDto.java
@@ -1,0 +1,20 @@
+package com.finalproj.orbitflow.hr.organization.dto.sidebar;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgSidebarEmployeeDto
+ * @since : 2026-01-05 월요일
+ */
+@Getter
+@AllArgsConstructor
+public class OrgSidebarEmployeeDto {
+
+    private Long employeeId;
+    private String name;
+    private String internalPhone;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgSidebarService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgSidebarService.java
@@ -1,0 +1,93 @@
+package com.finalproj.orbitflow.hr.organization.service;
+
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.organization.dto.sidebar.OrgSidebarDto;
+import com.finalproj.orbitflow.hr.organization.dto.sidebar.OrgSidebarEmployeeDto;
+import com.finalproj.orbitflow.hr.organization.entity.Organization;
+import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgSidebarService
+ * @since : 2026-01-05 월요일
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrgSidebarService {
+
+    private final OrgRepository orgRepository;
+    private final EmployeeRepository employeeRepository;
+
+    public List<OrgSidebarDto> getSidebarTree(Long companyId) {
+        // 조직 전체 조회 (ACTIVE)
+        List<Organization> orgs =
+                orgRepository.findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(companyId);
+
+        // 내선 있는 사원 조회
+        List<Employee> employees =
+                employeeRepository.findActiveWithExtension(companyId);
+
+        // orgId 기준 사원 그룹핑
+        Map<Long, List<OrgSidebarEmployeeDto>> employeeMap =
+                employees.stream()
+                        .collect(Collectors.groupingBy(
+                                e -> e.getOrganization().getId(),
+                                Collectors.mapping(
+                                        e -> new OrgSidebarEmployeeDto(
+                                                e.getId(),
+                                                e.getName(),
+                                                e.getInternalPhone()
+                                        ),
+                                        Collectors.toList()
+                                )
+                        ));
+
+        // orgId -> OrgSidebarDto Map 생성
+        Map<Long, OrgSidebarDto> orgDtoMap = new HashMap<>();
+
+        for (Organization org : orgs) {
+            orgDtoMap.put(
+                    org.getId(),
+                    new OrgSidebarDto(
+                            org.getId(),
+                            org.getName(),
+                            employeeMap.getOrDefault(org.getId(), List.of()),
+                            new ArrayList<>()
+                    )
+            );
+        }
+
+        // 트리 구성 (부모 -> 자식)
+        List<OrgSidebarDto> roots = new ArrayList<>();
+
+        for (Organization org : orgs) {
+            OrgSidebarDto current = orgDtoMap.get(org.getId());
+
+            if (org.getParentOrgId() == null) {
+                roots.add(current);
+            } else {
+                OrgSidebarDto parent = orgDtoMap.get(org.getParentOrgId());
+                if (parent != null) {
+                    parent.getChildren().add(current);
+                }
+            }
+        }
+
+
+        return roots;
+
+    }
+}

--- a/src/main/resources/static/css/organization/org-tree.css
+++ b/src/main/resources/static/css/organization/org-tree.css
@@ -1,0 +1,145 @@
+/* =========================
+   Layout
+========================= */
+.org-page {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    height: 100%;
+}
+
+/* =========================
+   Org Tree (보조)
+========================= */
+.org-tree {
+    background: #fff;
+    border-radius: 14px;
+    padding: 12px 10px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.05);
+    overflow-y: auto;
+}
+
+.org-node {
+    font-size: 14px;
+    font-weight: 800;
+    margin: 6px 0;
+    color: #1f2937;
+}
+
+.org-emp {
+    font-size: 13px;
+    padding: 4px 8px;
+    margin: 2px 0;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #374151;
+}
+
+.org-emp:hover,
+.org-emp.active {
+    background: #eef4ff;
+    color: #2563eb;
+}
+
+/* =========================
+   Employee Panel (메인)
+========================= */
+.employee-panel {
+    background: #fff;
+    border-radius: 18px;
+    padding: 22px;
+    box-shadow: 0 10px 32px rgba(0,0,0,.08);
+}
+
+.employee-panel.hidden {
+    display: none;
+}
+
+/* Hero */
+.emp-hero {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.emp-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: #f3f4f6;
+}
+
+.emp-name {
+    font-size: 20px;
+    font-weight: 900;
+}
+
+.emp-summary {
+    margin-top: 4px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #6b7280;
+}
+
+.emp-meta {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #6b7280;
+}
+
+.emp-meta .dot {
+    margin: 0 6px;
+    color: #d1d5db;
+}
+
+.emp-status {
+    margin-top: 6px;
+    font-size: 12px;
+    font-weight: 900;
+}
+
+.emp-status.active { color: #15803d; }
+.emp-status.suspended { color: #b45309; }
+.emp-status.resigned { color: #b91c1c; }
+
+/* Info Card */
+.emp-info-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 14px;
+    padding: 16px;
+}
+
+.kv {
+    display: grid;
+    grid-template-columns: 90px 1fr;
+    gap: 10px 14px;
+    font-size: 14px;
+}
+
+.kv .k {
+    font-weight: 800;
+    color: #6b7280;
+}
+
+.kv .v {
+    font-weight: 800;
+}
+
+/* =========================
+   Responsive
+========================= */
+@media (max-width: 900px) {
+    .org-page {
+        grid-template-columns: 1fr;
+    }
+
+    .org-tree {
+        order: 2;
+    }
+
+    .employee-panel {
+        order: 1;
+    }
+}

--- a/src/main/resources/static/css/user-sidebar/user-sidebar.css
+++ b/src/main/resources/static/css/user-sidebar/user-sidebar.css
@@ -163,3 +163,53 @@
     display: none; /* 더 이상 사용하지 않음 */
 }
 
+/* ===== 내선번호 영역 ===== */
+
+.extension-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    padding: 12px 14px;
+    font-size: 13px;
+    font-weight: 600;
+
+    cursor: pointer;
+    border-top: 1px solid rgba(255,255,255,0.1);
+}
+
+.extension-tree {
+    max-height: 260px;
+    overflow-y: auto;
+    font-size: 12px;
+}
+
+.extension-tree.hidden {
+    display: none;
+}
+
+.extension-org {
+    padding: 6px 14px;
+    font-weight: 600;
+    color: #ddd;
+}
+
+.extension-emp {
+    padding: 4px 28px;
+    cursor: pointer;
+    color: #ccc;
+}
+
+.extension-emp:hover {
+    background: rgba(255,255,255,0.08);
+}
+
+.extension-emp .phone {
+    color: #9ecbff;
+    margin-left: 6px;
+}
+
+.extension-emp.active {
+    background: rgba(255,255,255,0.15);
+    color: #fff;
+}

--- a/src/main/resources/static/js/org-tree.js
+++ b/src/main/resources/static/js/org-tree.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+    apiFetch('/api/user/organizations/tree')
+        .then(res => res.json())
+        .then(res => renderOrgTree(res.data))
+        .catch(console.error);
+
+    if (targetEmployeeId) {
+        loadEmployeeDetail(targetEmployeeId);
+    }
+});
+
+/* =========================
+   Org Tree
+========================= */
+function renderOrgTree(nodes) {
+    const container = document.getElementById('org-tree-container');
+    container.innerHTML = '';
+    nodes.forEach(n => renderNode(n, container, 0));
+}
+
+function renderNode(node, parent, depth) {
+    const org = document.createElement('div');
+    org.className = 'org-node';
+    org.style.paddingLeft = `${8 + depth * 14}px`;
+    org.textContent = node.orgName;
+    parent.appendChild(org);
+
+    node.employees.forEach(emp => {
+        const el = document.createElement('div');
+        el.className = 'org-emp';
+        el.style.paddingLeft = `${24 + depth * 14}px`;
+        el.textContent = emp.name;
+        el.onclick = () => {
+            document.querySelectorAll('.org-emp')
+                .forEach(e => e.classList.remove('active'));
+            el.classList.add('active');
+            loadEmployeeDetail(emp.employeeId);
+        };
+        parent.appendChild(el);
+    });
+
+    node.children.forEach(c => renderNode(c, parent, depth + 1));
+}
+
+/* =========================
+   Employee Detail
+========================= */
+window.loadEmployeeDetail = async function (id) {
+    const panel = document.getElementById('employee-panel');
+    panel.classList.remove('hidden');
+
+    const res = await apiFetch(`/api/employees/${id}`);
+    const { data: e } = await res.json();
+
+    document.getElementById('empAvatar').src =
+        e.gender === 'FEMALE' ? '/images/female.png' : '/images/male.png';
+
+    document.getElementById('empName').textContent = e.name;
+    document.getElementById('empSummary').textContent =
+        [e.orgPath, e.positionName, e.rankName].filter(Boolean).join(' · ');
+
+    document.getElementById('empEmail').textContent = e.email ?? '-';
+    document.getElementById('empInternalPhone').textContent = e.internalPhone ?? '-';
+
+    document.getElementById('empOrg').textContent = e.orgPath ?? '-';
+    document.getElementById('empRank').textContent = e.rankName ?? '-';
+    document.getElementById('empPosition').textContent = e.positionName ?? '-';
+
+    const status = document.getElementById('empStatus');
+    status.textContent = e.status === 'ACTIVE' ? '근무중' : e.status;
+    status.className = `emp-status ${e.status.toLowerCase()}`;
+};

--- a/src/main/resources/static/js/sidebar-extension.js
+++ b/src/main/resources/static/js/sidebar-extension.js
@@ -1,0 +1,86 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+    const toggle = document.getElementById('extension-toggle');
+    const treeEl = document.getElementById('extension-tree');
+
+    // 사이드바가 없는 페이지에서는 실행 안 함
+    if (!toggle || !treeEl) return;
+
+    /* =========================
+       내선번호 토글
+    ========================= */
+    toggle.addEventListener('click', () => {
+        treeEl.classList.toggle('hidden');
+
+        const icon = toggle.querySelector('i');
+        if (!icon) return;
+
+        icon.classList.toggle('fa-chevron-up');
+        icon.classList.toggle('fa-chevron-down');
+    });
+
+
+    /* =========================
+       내선번호 트리 로딩
+    ========================= */
+    apiFetch('/api/sidebar/extensions')
+        .then(res => {
+            if (!res.ok) throw new Error('내선번호 API 실패');
+            return res.json();
+        })
+        .then(res => {
+            treeEl.innerHTML = ''; // 재렌더링 대비
+            renderTree(res.data);
+        })
+        .catch(err => console.error('내선번호 조회 실패', err));
+
+
+    /* =========================
+       트리 렌더링
+    ========================= */
+    function renderTree(nodes, depth = 0) {
+        nodes.forEach(org => {
+
+            /* ---- 조직 ---- */
+            const orgDiv = document.createElement('div');
+            orgDiv.className = 'extension-org';
+            orgDiv.style.paddingLeft = `${14 + depth * 12}px`;
+            orgDiv.textContent = org.orgName;
+            treeEl.appendChild(orgDiv);
+
+            /* ---- 사원 ---- */
+            (org.employees || []).forEach(emp => {
+                const empDiv = document.createElement('div');
+                empDiv.className = 'extension-emp';
+                empDiv.style.paddingLeft = `${28 + depth * 12}px`;
+                empDiv.innerHTML = `
+                    <span class="name">${emp.name}</span>
+                    <span class="phone">${emp.internalPhone ?? '-'}</span>
+                `;
+
+                empDiv.addEventListener('click', () => {
+                    // 선택 강조
+                    document.querySelectorAll('.extension-emp')
+                        .forEach(el => el.classList.remove('active'));
+                    empDiv.classList.add('active');
+
+                    // 조직도 페이지면 → 우측 패널만 갱신
+                    if (typeof window.loadEmployeeDetail === 'function') {
+                        window.loadEmployeeDetail(emp.employeeId);
+                    }
+                    // 그 외 페이지면 → 조직도 페이지로 이동
+                    else {
+                        location.href = `/view/organizations?employeeId=${emp.employeeId}`;
+                    }
+                });
+
+                treeEl.appendChild(empDiv);
+            });
+
+            /* ---- 하위 조직 ---- */
+            if (org.children && org.children.length > 0) {
+                renderTree(org.children, depth + 1);
+            }
+        });
+    }
+});

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -14,6 +14,16 @@
         </div>
 
         <div class="sidebar-footer">
+
+            <div id="extension-toggle" class="extension-title">
+                <span>내선번호</span>
+                <i class="fas fa-chevron-up"></i>
+            </div>
+
+            <div id="extension-tree" class="extension-tree hidden">
+                <!-- JS 렌더링 영역 -->
+            </div>
+
         </div>
     </div>
 </nav>

--- a/src/main/resources/templates/layout/layout-user.html
+++ b/src/main/resources/templates/layout/layout-user.html
@@ -45,6 +45,7 @@
 <script th:src="@{/js/common.js}"></script>
 <script th:src="@{/js/notification/notification.js}"></script>
 <script th:src="@{/js/chatbot/chatbot.js}"></script>
+<script th:src="@{/js/sidebar-extension.js}"></script>
 
 <!-- 페이지별 JS 삽입 위치 -->
 <th:block th:if="${pageScript}" th:replace="${pageScript}"></th:block>

--- a/src/main/resources/templates/organization/tree.html
+++ b/src/main/resources/templates/organization/tree.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-user :: layout(
+         ~{::content},
+         ~{fragments/header :: header},
+         ~{::user-sidebar-menu},
+         ~{::pageCss},
+         ~{::pageScript}
+     )}">
+
+<!-- =========================
+     페이지 전용 CSS
+========================= -->
+<th:block th:fragment="pageCss">
+    <link rel="stylesheet" th:href="@{/css/organization/org-tree.css}">
+</th:block>
+
+<!-- =========================
+     메인 콘텐츠
+========================= -->
+<th:block th:fragment="content">
+    <div class="org-page">
+
+        <!-- 좌측: 조직 트리 -->
+        <aside id="org-tree-container" class="org-tree"></aside>
+
+        <!-- 우측: 사원 상세 (메인) -->
+        <section id="employee-panel" class="employee-panel hidden">
+
+            <!-- Hero -->
+            <div class="emp-hero">
+                <img id="empAvatar"
+                     class="emp-avatar"
+                     src="/images/male.png"
+                     alt="profile"/>
+
+                <div class="emp-main">
+                    <div class="emp-name" id="empName">-</div>
+                    <div class="emp-summary" id="empSummary">-</div>
+
+                    <div id="empStatus" class="emp-status"></div>
+
+                    <div class="emp-meta">
+                        <span id="empEmail">-</span>
+                        <span class="dot">•</span>
+                        <span>내선 <b id="empInternalPhone">-</b></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Info -->
+            <div class="emp-info-card">
+                <div class="kv">
+                    <div class="k">조직</div>
+                    <div class="v" id="empOrg">-</div>
+
+                    <div class="k">직급</div>
+                    <div class="v" id="empRank">-</div>
+
+                    <div class="k">직책</div>
+                    <div class="v" id="empPosition">-</div>
+                </div>
+            </div>
+
+        </section>
+    </div>
+</th:block>
+
+<!-- =========================
+     페이지 전용 JS
+========================= -->
+<th:block th:fragment="pageScript">
+    <script th:inline="javascript">
+        const targetEmployeeId = [[${employeeId}]];
+    </script>
+    <script th:src="@{/js/org-tree.js}"></script>
+</th:block>
+
+<!-- =========================
+     사용자 사이드바 메뉴
+========================= -->
+<ul th:fragment="user-sidebar-menu" class="sidebar-menu">
+    <li class="selected">
+        <a th:href="@{/view/organizations}" class="sidebar-link">
+            조직도
+        </a>
+    </li>
+</ul>
+
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #381

## 📝 작업 내용
- **사용자 조직도 페이지 구조 개편**
    - 좌측에 조직 트리, 우측에 사원 상세 정보가 함께 노출되는 **Split View UI**로 재구성
    - 조직 트리는 보조 영역, 사원 상세 조회를 메인 콘텐츠로 배치
- **사용자 조직 트리 API 연동**
    - `/api/user/organizations/tree` API를 사용해 조직 + 하위 조직 + 소속 사원 정보를 트리 구조로 렌더링
    - 기존 관리자 조직 트리 로직을 재사용하여 사용자용으로 확장
- **사원 상세 조회 패널 구현**
    - 조직 트리 또는 URL 파라미터(`?employeeId=`)를 통해 사원 선택 시 우측 패널에서 상세 정보 조회
    - 표시 정보:
        - 프로필 이미지(성별 기준 기본 이미지)
        - 이름 / 근무 상태
        - 이메일 / 사내 내선
        - 조직 경로 / 직급 / 직책
- **반응형 레이아웃 적용**
    - 데스크톱: 좌측 조직 트리 + 우측 사원 상세 고정 레이아웃
    - 태블릿/모바일: 세로 스택 구조로 전환, 가독성 유지
- **JS 책임 분리 및 구조 정리**
    - `org-tree.js`
        - 조직 트리 렌더링
        - 사원 클릭 시 상세 패널 갱신
    - HTML은 구조만 담당, 데이터 바인딩은 JS에서 처리하도록 정리
  
## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/95efa9ef-8c06-4094-bc5b-b22fb9cc6779" />

## 💬 리뷰 요구사항(선택)
