### PR TITLE
feat(sidebar, orgTree): 사이드바 내선번호 목록 UI 개선 및 근무 상태 실시간 반영

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/attendance/commute/controller/CommuteController.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/commute/controller/CommuteController.java
@@ -1,6 +1,7 @@
 package com.finalproj.orbitflow.attendance.commute.controller;
 
 import com.finalproj.orbitflow.attendance.commute.dto.ActiveRuleResDto;
+import com.finalproj.orbitflow.attendance.commute.dto.EmployeeWorkStatusResDto;
 import com.finalproj.orbitflow.attendance.commute.dto.TodayAttResDto;
 import com.finalproj.orbitflow.attendance.commute.service.CommuteService;
 import com.finalproj.orbitflow.global.common.ResponseDto;
@@ -86,4 +87,24 @@ public class CommuteController {
                 result
         ));
     }
+
+    @GetMapping("/work-status/{employeeId}")
+    public ResponseEntity<?> getEmployeeWorkStatus(
+            @PathVariable Long employeeId,
+            @AuthenticationPrincipal SecurityUser user
+    ) {
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "사원 근무 상태 조회 성공",
+                        new EmployeeWorkStatusResDto(
+                                commuteService.getEmployeeWorkStatus(
+                                        user.getCompanyId(),
+                                        employeeId
+                                )
+                        )
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/attendance/commute/dto/EmployeeWorkStatusResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/commute/dto/EmployeeWorkStatusResDto.java
@@ -1,0 +1,19 @@
+package com.finalproj.orbitflow.attendance.commute.dto;
+
+import com.finalproj.orbitflow.hr.employee.enums.WorkStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : EmployeeWorkStatusResDto
+ * @since : 2026-01-06 화요일
+ */
+
+@Getter
+@AllArgsConstructor
+public class EmployeeWorkStatusResDto {
+    private WorkStatus workStatus;
+}

--- a/src/main/java/com/finalproj/orbitflow/attendance/commute/service/CommuteService.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/commute/service/CommuteService.java
@@ -135,4 +135,19 @@ public class CommuteService {
             throw new BusinessException("퇴근 시간(" + endTimeThreshold + ") 이전이라서 퇴근할 수 없습니다.");
         }
     }
+
+    // 조직도 페이지 - 사원 근무 상태 조회
+    @Transactional(readOnly = true)
+    public WorkStatus getEmployeeWorkStatus(Long companyId, Long employeeId) {
+
+        Employee employee = employeeRepository.findById(employeeId)
+                .orElseThrow(() -> new BusinessException("사원 정보를 찾을 수 없습니다."));
+
+        if (!employee.getCompany().getId().equals(companyId)) {
+            throw new BusinessException("다른 회사의 사원입니다.");
+        }
+
+        return employee.getWorkStatus();
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -6,6 +6,7 @@ import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.employee.dto.*;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
+import com.finalproj.orbitflow.hr.employee.enums.WorkStatus;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
 import com.finalproj.orbitflow.hr.logAudit.dto.AuditLogResDto;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
@@ -351,7 +352,10 @@ public class EmployeeService {
 
         switch (newStatus) {
             case ACTIVE -> throw new IllegalStateException("ACTIVE는 이메일 인증 전용");
-            case SUSPENDED -> employee.suspend();
+            case SUSPENDED -> {
+                employee.suspend();
+                employee.updateWorkStatus(WorkStatus.OFF_WORK);
+            }
             case RESIGNED -> processResignation(employee);
         }
 
@@ -368,6 +372,7 @@ public class EmployeeService {
 
     private void processResignation(Employee employee) {
         employee.resign();
+        employee.updateWorkStatus(WorkStatus.OFF_WORK);
         employee.changeEmail("resigned_" + employee.getId() + "@orbitflow.local");
         employee.changePassword(passwordEncoder.encode(UUID.randomUUID().toString()));
         employee.clearContactInfo();

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarEmployeeDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/sidebar/OrgSidebarEmployeeDto.java
@@ -1,5 +1,6 @@
 package com.finalproj.orbitflow.hr.organization.dto.sidebar;
 
+import com.finalproj.orbitflow.hr.employee.enums.WorkStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,4 +18,6 @@ public class OrgSidebarEmployeeDto {
     private Long employeeId;
     private String name;
     private String internalPhone;
+    private WorkStatus workStatus;
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgSidebarService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgSidebarService.java
@@ -49,7 +49,8 @@ public class OrgSidebarService {
                                         e -> new OrgSidebarEmployeeDto(
                                                 e.getId(),
                                                 e.getName(),
-                                                e.getInternalPhone()
+                                                e.getInternalPhone(),
+                                                e.getWorkStatus()
                                         ),
                                         Collectors.toList()
                                 )

--- a/src/main/resources/static/css/user-sidebar/user-sidebar.css
+++ b/src/main/resources/static/css/user-sidebar/user-sidebar.css
@@ -6,10 +6,32 @@
     width: 250px;
     background: #0b1220 !important;
     color: #fff;
+
     display: flex;
     flex-direction: column;
-    z-index: 100;
 }
+
+
+.sidebar-inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+
+/* 메뉴 영역만 스크롤 */
+.sidebar-menu-wrapper {
+    flex: 1;
+    overflow-y: auto;
+}
+
+/* 내선번호는 항상 하단 고정 */
+.sidebar-footer {
+    margin-top: auto;
+    border-top: 1px solid rgba(255,255,255,0.1);
+    background: #0b1220;
+}
+
 
 /* 사이드바 메뉴 오버라이드 */
 .sidebar-menu {
@@ -195,15 +217,26 @@
 }
 
 .extension-emp {
-    padding: 4px 28px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between; /* 좌/우 분리 */
+    padding: 4px 14px;
     cursor: pointer;
     color: #ccc;
+}
+
+/* 왼쪽 묶음 */
+.extension-emp .name {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .extension-emp:hover {
     background: rgba(255,255,255,0.08);
 }
 
+/* 내선번호를 이름 옆으로 */
 .extension-emp .phone {
     color: #9ecbff;
     margin-left: 6px;
@@ -212,4 +245,43 @@
 .extension-emp.active {
     background: rgba(255,255,255,0.15);
     color: #fff;
+}
+
+.work-dot {
+    margin-left: 6px;
+    font-size: 10px;
+    vertical-align: middle;
+}
+
+.work-dot.working { color: #22c55e; }   /* 근무중 */
+.work-dot.away { color: #f59e0b; }      /* 자리비움 */
+.work-dot.off_work { color: #9ca3af; }  /* 퇴근 */
+
+/* 왼쪽 묶음 (이름 + 내선번호) */
+.extension-emp .emp-left {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* 오른쪽 점 */
+.extension-emp .work-dot {
+    font-size: 10px;
+}
+
+.extension-tree {
+    background: #0b1220;
+}
+
+.extension-emp:hover {
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.extension-emp.active {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+/* 조직/사원 영역도 배경 명시 (안정성) */
+.extension-org {
+    background: #0b1220;
 }

--- a/src/main/resources/static/js/org-tree.js
+++ b/src/main/resources/static/js/org-tree.js
@@ -1,3 +1,21 @@
+const STATUS_LABEL = {
+    TEMP: '미활성',
+    ACTIVE: '재직중',
+    SUSPENDED: '정지',
+    RESIGNED: '퇴사'
+};
+
+const WORK_STATUS_LABEL = {
+    WORKING: '근무중',
+    OFF_WORK: '퇴근',
+    AWAY: '자리비움'
+};
+
+
+let currentEmployeeId = null;
+
+
+
 document.addEventListener('DOMContentLoaded', () => {
 
     apiFetch('/api/user/organizations/tree')
@@ -47,6 +65,8 @@ function renderNode(node, parent, depth) {
    Employee Detail
 ========================= */
 window.loadEmployeeDetail = async function (id) {
+    currentEmployeeId = id;
+
     const panel = document.getElementById('employee-panel');
     panel.classList.remove('hidden');
 
@@ -63,11 +83,31 @@ window.loadEmployeeDetail = async function (id) {
     document.getElementById('empEmail').textContent = e.email ?? '-';
     document.getElementById('empInternalPhone').textContent = e.internalPhone ?? '-';
 
+    document.getElementById('empEmployeeNo').textContent = e.employeeNo ?? '-';
+    document.getElementById('empEmploymentType').textContent = e.employmentType ?? '-';
+    document.getElementById('empHireDate').textContent =
+        e.hireDate ? e.hireDate.replaceAll('-', '.') : '-';
+
     document.getElementById('empOrg').textContent = e.orgPath ?? '-';
     document.getElementById('empRank').textContent = e.rankName ?? '-';
     document.getElementById('empPosition').textContent = e.positionName ?? '-';
 
     const status = document.getElementById('empStatus');
-    status.textContent = e.status === 'ACTIVE' ? '근무중' : e.status;
+    status.textContent = STATUS_LABEL[e.status] ?? e.status;
     status.className = `emp-status ${e.status.toLowerCase()}`;
+
+    // 근무 상태 조회 (Attendance 도메인)
+    await loadEmployeeWorkStatus(id);
+
 };
+
+async function loadEmployeeWorkStatus(employeeId) {
+    const res = await apiFetch(`/api/attendance/work-status/${employeeId}`);
+    const { data } = await res.json();
+
+    // 다른 사원으로 바뀌었으면 무시 --> race condition 방지
+    if (employeeId !== currentEmployeeId) return;
+
+    document.getElementById('empWorkStatus').textContent =
+        WORK_STATUS_LABEL[data.workStatus] ?? '-';
+}

--- a/src/main/resources/static/js/sidebar-extension.js
+++ b/src/main/resources/static/js/sidebar-extension.js
@@ -1,10 +1,43 @@
+/* =========================
+   Work Status Dot
+========================= */
+function createWorkStatusDot(workStatus) {
+    const dot = document.createElement('span');
+    dot.className = `work-dot ${workStatus?.toLowerCase() ?? 'unknown'}`;
+    dot.textContent = '●';
+    return dot;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 
     const toggle = document.getElementById('extension-toggle');
     const treeEl = document.getElementById('extension-tree');
 
-    // 사이드바가 없는 페이지에서는 실행 안 함
+    // 사이드바 없는 페이지 보호
     if (!toggle || !treeEl) return;
+
+    /* =========================
+       메인 / 조직도 페이지 기본 OPEN
+    ========================= */
+    const isOrganizationPage =
+        location.pathname.startsWith('/view/organizations');
+
+    const isMainPage =
+        location.pathname === '/';
+
+    if (isOrganizationPage || isMainPage) {
+        openExtensionTree();
+    }
+
+    function openExtensionTree() {
+        treeEl.classList.remove('hidden');
+
+        const icon = toggle.querySelector('i');
+        if (icon) {
+            icon.classList.remove('fa-chevron-down');
+            icon.classList.add('fa-chevron-up');
+        }
+    }
 
     /* =========================
        내선번호 토글
@@ -19,21 +52,33 @@ document.addEventListener('DOMContentLoaded', () => {
         icon.classList.toggle('fa-chevron-down');
     });
 
-
     /* =========================
        내선번호 트리 로딩
     ========================= */
-    apiFetch('/api/sidebar/extensions')
-        .then(res => {
-            if (!res.ok) throw new Error('내선번호 API 실패');
-            return res.json();
-        })
-        .then(res => {
-            treeEl.innerHTML = ''; // 재렌더링 대비
-            renderTree(res.data);
-        })
-        .catch(err => console.error('내선번호 조회 실패', err));
+    function loadExtensionTree() {
+        apiFetch('/api/sidebar/extensions')
+            .then(res => {
+                if (!res.ok) throw new Error('내선번호 API 실패');
+                return res.json();
+            })
+            .then(res => {
+                treeEl.innerHTML = '';
+                renderTree(res.data);
+            })
+            .catch(err => console.error('내선번호 조회 실패', err));
+    }
 
+    // 🔹 외부에서도 호출 가능 (출근/퇴근 직후 즉시 반영용)
+    window.reloadExtensionTree = loadExtensionTree;
+
+    /* =========================
+       Polling (10초)
+    ========================= */
+    loadExtensionTree(); // 최초 1회
+
+    setInterval(() => {
+        loadExtensionTree();
+    }, 10000);
 
     /* =========================
        트리 렌더링
@@ -53,13 +98,29 @@ document.addEventListener('DOMContentLoaded', () => {
                 const empDiv = document.createElement('div');
                 empDiv.className = 'extension-emp';
                 empDiv.style.paddingLeft = `${28 + depth * 12}px`;
-                empDiv.innerHTML = `
-                    <span class="name">${emp.name}</span>
-                    <span class="phone">${emp.internalPhone ?? '-'}</span>
-                `;
+
+                /* 왼쪽: 이름 + 내선번호 */
+                const leftWrap = document.createElement('div');
+                leftWrap.className = 'emp-left';
+
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'name';
+                nameSpan.textContent = emp.name;
+
+                const phoneSpan = document.createElement('span');
+                phoneSpan.className = 'phone';
+                phoneSpan.textContent = emp.internalPhone ?? '-';
+
+                leftWrap.appendChild(nameSpan);
+                leftWrap.appendChild(phoneSpan);
+
+                /* 오른쪽: 근무 상태 점 */
+                const workDot = createWorkStatusDot(emp.workStatus);
+
+                empDiv.appendChild(leftWrap);
+                empDiv.appendChild(workDot);
 
                 empDiv.addEventListener('click', () => {
-                    // 선택 강조
                     document.querySelectorAll('.extension-emp')
                         .forEach(el => el.classList.remove('active'));
                     empDiv.classList.add('active');

--- a/src/main/resources/templates/organization/tree.html
+++ b/src/main/resources/templates/organization/tree.html
@@ -59,6 +59,10 @@
 
                     <div class="k">직책</div>
                     <div class="v" id="empPosition">-</div>
+
+                    <div class="k">근무상태</div>
+                    <div class="v" id="empWorkStatus">-</div>
+
                 </div>
             </div>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #391

## 📝 작업 내용
### 사이드바 내선번호 UI 개선
- 내선번호 목록을 사이드바 하단에 고정
- 메뉴 영역과 분리하여 스크롤 처리
- 사원 이름 옆에 내선번호 표시
- 근무 상태(workStatus)를 점(●)으로 우측 정렬 표시

### 근무 상태 실시간 반영 (Polling)
- 내선번호 목록 조회 로직 분리 (`loadExtensionTree`)
- 10초 주기의 polling 적용으로 출근/퇴근/자리비움 상태 자동 반영
- 조직도 페이지(/view/organizations) 및 메인 페이지(/) 진입 시
  내선번호 목록 기본 OPEN 처리
- 외부에서 즉시 갱신 가능하도록 `window.reloadExtensionTree` 노출

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
