### PR TITLE
feat(Organization): 조직 검색 시 사용자 화면에서 회사(최상위 조직) 노출 제거

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserController.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -54,4 +55,43 @@ public class OrgUserController {
                 )
         );
     }
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<OrgResDto>>> listOrSearch(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean includeDescendants
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        // 검색어 없으면 → 사용자 기준 전체 조직 (회사 제외)
+        if (keyword == null || keyword.isBlank()) {
+            List<OrgResDto> orgs = orgService.findAll(companyId, false)
+                    .stream()
+                    .filter(o -> o.getParentOrgId() != null)
+                    .toList();
+
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            HttpStatus.OK,
+                            "조직 목록 조회",
+                            orgs
+                    )
+            );
+        }
+
+        // 검색
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "조직 검색 결과 조회",
+                        orgService.searchForUser(
+                                companyId,
+                                keyword,
+                                false,
+                                includeDescendants
+                        )
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -410,4 +410,22 @@ public class OrgService {
         return new OrgDeactivateCheckResDto(true, null);
     }
 
+
+    // 사용자용 검색 메서드
+    @Transactional(readOnly = true)
+    public List<OrgResDto> searchForUser(
+            Long companyId,
+            String keyword,
+            boolean includeInactive,
+            boolean includeDescendants
+    ) {
+        List<OrgResDto> result =
+                search(companyId, keyword, includeInactive, includeDescendants);
+
+        // 최상위 조직(회사명) 제외
+        return result.stream()
+                .filter(o -> o.getParentOrgId() != null)
+                .toList();
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
### 1. 사용자용 조직 검색 API 추가
- `/api/organizations` 엔드포인트에 **조직 검색 기능**을 추가함
- `keyword`, `includeDescendants` 파라미터를 통해 조직 검색 가능
### 2. 사용자 검색 시 최상위 조직(회사명) 제외 정책 적용
- 사용자 화면에서는 **회사(최상위 조직, parentOrgId = null)** 를 노출하지 않도록 처리
- 기존 관리자용 조직 검색(`/api/admin/organizations`) 로직은 변경 없이 유지
### 3. Service 레벨에서 사용자/관리자 정책 분리
- 기존 `OrgService.search(...)` 로직을 재사용
- 사용자 전용 검색 메서드 `searchForUser(...)`를 추가하여 사용자 정책(회사 제외)을 Service 레벨에서 명확히 분리    
- Repository는 공통으로 사용하여 **데이터 접근 책임과 정책 책임을 분리**


## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
