### PR TITLE
feat(Organization): 사용자 조직 검색 정책 분리 (활성 조직만 조회, 회사 조직 제외)

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgUserController.java
@@ -87,7 +87,6 @@ public class OrgUserController {
                         orgService.searchForUser(
                                 companyId,
                                 keyword,
-                                false,
                                 includeDescendants
                         )
                 )

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -416,11 +416,10 @@ public class OrgService {
     public List<OrgResDto> searchForUser(
             Long companyId,
             String keyword,
-            boolean includeInactive,
             boolean includeDescendants
     ) {
         List<OrgResDto> result =
-                search(companyId, keyword, includeInactive, includeDescendants);
+                search(companyId, keyword, false, includeDescendants); // 항상 활성만
 
         // 최상위 조직(회사명) 제외
         return result.stream()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #399

## 📝 작업 내용
### 1. 사용자용 조직 검색 API 추가
- `/api/organizations` 엔드포인트에 사용자 조직 검색 기능 추가
- `keyword`, `includeDescendants` 파라미터를 통해 조직 검색 가능
### 2. 사용자 조직 검색 정책 분리
- 사용자 조직 검색 시 **활성화된 조직만 검색**되도록 Service 레벨에서 정책 고정
- 호출자가 옵션을 잘못 전달해도 비활성 조직이 노출되지 않도록 구조 개선
### 3. 회사(최상위 조직) 검색 결과 제외
- 사용자 화면에서는 최상위 조직(회사명, parentOrgId = null)을 검색 및 목록 결과에서 제외
- 관리자 조직 검색 API(`/api/admin/organizations`)는 기존 동작 유지

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
