### PR TITLE
feat(auth): 로그인 시 기존 refresh token 정리 로직 추가

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
+++ b/src/main/java/com/finalproj/orbitflow/auth/controller/AuthController.java
@@ -48,8 +48,11 @@ public class AuthController {
      * 로그인
      */
     @PostMapping("/login")
-    public ResponseEntity<ResponseDto> login(@RequestBody LoginReqDto request,
-                                             HttpServletResponse response) {
+    public ResponseEntity<ResponseDto> login(
+            @RequestBody LoginReqDto request,
+            @CookieValue(value = "refreshToken", required = false) String oldRefreshToken,
+            HttpServletResponse response
+    ) {
 
         SecurityUser user;
         try {
@@ -66,9 +69,10 @@ public class AuthController {
             throw new ForbiddenException("계정이 활성 상태가 아닙니다.");
         }
 
-        // 동시 로그인 차단하려면 주석 풀기
-//        authService.invalidateAll(user.getEmployeeId());
-
+        // 추가) 기존 refresh token 정리
+        if (oldRefreshToken != null) {
+            authService.invalidateRefreshToken(oldRefreshToken);
+        }
 
         String accessToken = jwtProvider.createToken(user);
         RefreshToken refreshToken = authService.issueRefreshToken(user);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #402

## 📝 작업 내용
- 로그인 요청에 refresh token 쿠키가 포함된 경우 새 토큰 발급 전에 기존 refresh token을 DB에서 삭제
- 쿠키 덮어쓰기 상황에서 발생할 수 있는 유휴 토큰 문제 개선

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
