### PR TITLE
feat(audit): 인사 감사 로그 목록 조회 및 모달 상세 보기 구현

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
@@ -1,0 +1,63 @@
+package com.finalproj.orbitflow.hr.logAudit.controller;
+
+import com.finalproj.orbitflow.global.common.ResponseDto;
+import com.finalproj.orbitflow.hr.logAudit.dto.AuditLogResDto;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditLogAdminController
+ * @since : 2026-01-06 화요일
+ */
+@RestController
+@RequestMapping("/api/admin/audit-logs")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('COMPANY_ADMIN', 'ADMIN')")
+public class AuditLogController {
+
+    private final AuditLogService auditLogService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<Page<AuditLogResDto>>> search(
+            Pageable pageable
+    ) {
+        Page<AuditLogResDto> result =
+                auditLogService.search(null, null, null, pageable);
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "감사 로그 목록 조회 성공",
+                        result
+                )
+        );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseDto<AuditLogResDto>> detail(
+            @PathVariable Long id
+    ) {
+        AuditLogResDto result =
+                AuditLogResDto.from(auditLogService.findById(id));
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "감사 로그 상세 조회 성공",
+                        result
+                )
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogViewController.java
@@ -1,0 +1,29 @@
+package com.finalproj.orbitflow.hr.logAudit.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditLogViewController
+ * @since : 2026-01-06 화요일
+ */
+@Controller
+@RequestMapping("/view/admin/audit-logs")
+@RequiredArgsConstructor
+public class AuditLogViewController {
+
+    @GetMapping
+    public String listPage() {
+        return "admin/audit-log/list";
+    }
+
+    @GetMapping("/detail")
+    public String detailPage() {
+        return "admin/audit-log/detail";
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/dto/AuditLogResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/dto/AuditLogResDto.java
@@ -18,16 +18,28 @@ import java.util.Map;
 @AllArgsConstructor
 public class AuditLogResDto {
     private Long id;
+
+    private String entityType;   // 대상
+    private Long entityId;       // 대상 ID
+
+    private String entityDisplay; // 화면 표시용
+
+
     private String eventType;
     private String actorName;
     private String actorEmail;
+
     private Map<String, Object> beforeData;
     private Map<String, Object> afterData;
+
     private Instant createdAt;
 
     public static AuditLogResDto from(AuditLog log) {
         return new AuditLogResDto(
                 log.getId(),
+                log.getEntityType().name(),
+                log.getEntityId(),
+                log.getEntityType().getDisplayName(),
                 log.getEventType().name(),
                 log.getActor().getName(),
                 log.getActor().getEmail(),

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
@@ -8,10 +8,21 @@ package com.finalproj.orbitflow.hr.logAudit.enums;
  * @since : 2025-12-16 화요일
  */
 public enum AuditEntityType {
-    COMPANY,            // 회사
-    ORGANIZATION,       // 조직
-    EMPLOYEE,           // 사원
-    HR_RANK,               // 직급
-    POSITION,           // 직책
-    ORG_POSITION_USAGE  // 조직-직책 정책
+
+    COMPANY("회사"),
+    ORGANIZATION("조직"),
+    EMPLOYEE("사원"),
+    HR_RANK("직급"),
+    POSITION("직책"),
+    ORG_POSITION_USAGE("조직-직책 정책");
+
+    private final String displayName;
+
+    AuditEntityType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
@@ -2,7 +2,12 @@ package com.finalproj.orbitflow.hr.logAudit.repository;
 
 import com.finalproj.orbitflow.hr.logAudit.entity.AuditLog;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -18,6 +23,20 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
     List<AuditLog> findByEntityTypeAndEntityIdOrderByCreatedAtDesc(
             AuditEntityType entityType,
             Long entityId
+    );
+
+    @Query("""
+                SELECT a FROM AuditLog a
+                JOIN a.actor act
+                WHERE (:entityType IS NULL OR a.entityType = :entityType)
+                  AND (:eventType IS NULL OR a.eventType = :eventType)
+                  AND (:actorName IS NULL OR act.name LIKE %:actorName%)
+            """)
+    Page<AuditLog> search(
+            @Param("entityType") AuditEntityType entityType,
+            @Param("eventType") AuditEventType eventType,
+            @Param("actorName") String actorName,
+            Pageable pageable
     );
 
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditEntityNameResolver.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditEntityNameResolver.java
@@ -1,0 +1,54 @@
+package com.finalproj.orbitflow.hr.logAudit.service;
+
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
+import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRepository;
+import com.finalproj.orbitflow.hr.rank.repository.RankRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AuditEntityNameResolver
+ * @since : 2026-01-06 화요일
+ */
+@Component
+@RequiredArgsConstructor
+public class AuditEntityNameResolver {
+
+    private final EmployeeRepository employeeRepository;
+    private final OrgRepository organizationRepository;
+    private final RankRepository rankRepository;
+    private final PositionCategoryRepository positionRepository;
+    private final CompanyRepository companyRepository;
+
+    public String resolve(AuditEntityType type, Long entityId) {
+        return switch (type) {
+            case EMPLOYEE ->
+                    employeeRepository.findById(entityId)
+                            .map(e -> e.getName())
+                            .orElse("알 수 없음");
+            case ORGANIZATION ->
+                    organizationRepository.findById(entityId)
+                            .map(o -> o.getName())
+                            .orElse("알 수 없음");
+            case HR_RANK ->
+                    rankRepository.findById(entityId)
+                            .map(r -> r.getName())
+                            .orElse("알 수 없음");
+            case POSITION ->
+                    positionRepository.findById(entityId)
+                            .map(p -> p.getName())
+                            .orElse("알 수 없음");
+            case COMPANY ->
+                    companyRepository.findById(entityId)
+                            .map(c -> c.getName())
+                            .orElse("알 수 없음");
+            default -> "알 수 없음";
+        };
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
@@ -2,11 +2,14 @@ package com.finalproj.orbitflow.hr.logAudit.service;
 
 import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.logAudit.dto.AuditLogResDto;
 import com.finalproj.orbitflow.hr.logAudit.entity.AuditLog;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
 import com.finalproj.orbitflow.hr.logAudit.repository.AuditLogRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,7 @@ import java.util.Map;
 public class AuditLogService {
 
     private final AuditLogRepository auditLogRepository;
+    private final AuditEntityNameResolver entityNameResolver;
 
     public void log(
             Company company,
@@ -54,6 +58,44 @@ public class AuditLogService {
                 AuditEntityType.EMPLOYEE,
                 employeeId
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AuditLogResDto> search(
+            AuditEntityType entityType,
+            AuditEventType eventType,
+            String actorName,
+            Pageable pageable
+    ) {
+        return auditLogRepository.search(entityType, eventType, actorName, pageable)
+                .map(log -> {
+
+                    String entityName =
+                            entityNameResolver.resolve(log.getEntityType(), log.getEntityId());
+
+                    String display =
+                            log.getEntityType().getDisplayName() + " · " + entityName;
+
+                    return new AuditLogResDto(
+                            log.getId(),
+                            log.getEntityType().name(),
+                            log.getEntityId(),
+                            display,
+                            log.getEventType().name(),
+                            log.getActor().getName(),
+                            log.getActor().getEmail(),
+                            log.getBeforeData(),
+                            log.getAfterData(),
+                            log.getCreatedAt()
+                    );
+                });
+    }
+
+
+    @Transactional(readOnly = true)
+    public AuditLog findById(Long id) {
+        return auditLogRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("AuditLog not found"));
     }
 
 }

--- a/src/main/resources/static/css/admin-audit/admin-audit-logs.css
+++ b/src/main/resources/static/css/admin-audit/admin-audit-logs.css
@@ -1,0 +1,354 @@
+/* =========================
+   Board Container
+========================= */
+.board-container {
+    background-color: #fff;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 24px;
+    max-width: 1400px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 200px);
+}
+
+/* =========================
+   Page Header
+========================= */
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.page-title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #222;
+    letter-spacing: -1px;
+}
+
+/* =========================
+   Table Container
+========================= */
+.board-table-container {
+    margin-bottom: 24px;
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e5e7eb;
+
+    min-height: 600px;
+    max-height: 600px;
+
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+/* =========================
+   Resource Table
+========================= */
+.resource-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    table-layout: fixed;
+}
+
+.resource-table thead {
+    background: #f8f9fa;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.resource-table th,
+.resource-table td {
+    padding: 14px 16px;
+    font-size: 14px;
+    text-align: left;
+    border-bottom: 1px solid #f0f0f0;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    box-sizing: border-box;
+}
+
+.resource-table th {
+    font-weight: 600;
+    color: #495057;
+}
+
+.resource-table td {
+    color: #555;
+}
+
+/* 번호 컬럼 */
+.resource-table th:first-child,
+.resource-table td:first-child {
+    text-align: center;
+    font-weight: 600;
+    color: #6c757d;
+}
+
+/* 상세 버튼 컬럼 */
+.resource-table th:last-child,
+.resource-table td:last-child {
+    text-align: center;
+    vertical-align: middle;
+}
+
+.resource-table tbody tr {
+    transition: background 0.2s;
+}
+
+.resource-table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+.resource-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* =========================
+   Action Button (보기)
+========================= */
+.btn-edit {
+    padding: 6px 14px;
+    border-radius: 12px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+
+    background: #e3f2fd;
+    border: 1.2px solid #6d8cdc;
+    color: #1976d2;
+}
+
+.btn-edit:hover {
+    background: #bbdefb;
+}
+
+/* =========================
+   Empty State
+========================= */
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #999;
+}
+
+.empty-state i {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.3;
+}
+
+.empty-state p {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+/* =========================
+   Pagination
+========================= */
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    margin-top: 24px;
+}
+
+.pagination button {
+    min-width: 32px;
+    height: 36px;
+    padding: 0 8px;
+    border: 1px solid #ddd;
+    background: #fff;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    color: #555;
+    font-weight: 500;
+    transition: all 0.2s;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.pagination button:hover:not(:disabled) {
+    background: #f8f9fa;
+    border-color: #4a69bd;
+    color: #4a69bd;
+}
+
+.pagination button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.pagination button.active {
+    background: #4a69bd;
+    color: #fff;
+    border-color: #4a69bd;
+    font-weight: 600;
+}
+
+/* =========================
+   Warning Hint (Audit Notice)
+========================= */
+.hint.warning {
+    margin-top: 16px;
+    padding: 12px 16px;
+    font-size: 13px;
+    color: #856404;
+    background: #fff3cd;
+    border: 1px solid #ffeeba;
+    border-radius: 8px;
+    text-align: center;
+}
+
+/* =========================
+   Modal Overlay
+========================= */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+/* =========================
+   Modal
+========================= */
+.modal {
+    background: #fff;
+    width: 100%;
+    max-width: 1100px;
+    max-height: 90vh;
+    border-radius: 12px;
+    overflow-y: auto;
+}
+
+/* =========================
+   Modal Header
+========================= */
+.modal-header {
+    padding: 16px 24px;
+    border-bottom: 1px solid #e9ecef;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h2 {
+    font-size: 18px;
+    font-weight: 700;
+    color: #333;
+}
+
+.btn-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #555;
+}
+
+.btn-close:hover {
+    color: #000;
+}
+
+/* =========================
+   Modal Body
+========================= */
+.modal-body {
+    padding: 24px;
+}
+
+/* =========================
+   Info Grid (Modal)
+========================= */
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.info-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+}
+
+.info-text {
+    padding: 12px 14px;
+    font-size: 14px;
+    color: #333;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e9ecef;
+    font-weight: 500;
+}
+
+/* =========================
+   Diff (Before / After)
+========================= */
+.diff-container {
+    display: flex;
+    gap: 16px;
+}
+
+.diff-box {
+    flex: 1;
+    padding: 16px;
+    border-radius: 8px;
+    background: #f8f9fa;
+    border: 1px solid #e5e7eb;
+}
+
+.diff-box h3 {
+    font-size: 14px;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.diff-box.before {
+    border-left: 4px solid #adb5bd;
+}
+
+.diff-box.after {
+    border-left: 4px solid #4a69bd;
+}
+
+.diff-box pre {
+    font-size: 13px;
+    white-space: pre-wrap;
+    line-height: 1.5;
+    margin: 0;
+}

--- a/src/main/resources/static/js/admin-audit/admin-audit-logs.js
+++ b/src/main/resources/static/js/admin-audit/admin-audit-logs.js
@@ -1,0 +1,189 @@
+/**
+ * 관리자 - 인사 감사 로그 목록
+ */
+
+/* ==========================
+   Pagination State
+========================== */
+let currentPage = 0;
+let pageSize = 10;
+
+/* ==========================
+   Init
+========================== */
+document.addEventListener('DOMContentLoaded', () => {
+    loadAuditLogs();
+});
+
+/* ==========================
+   Data Load
+========================== */
+async function loadAuditLogs(page = 0) {
+    try {
+        const res = await apiFetch(
+            `/api/admin/audit-logs?page=${page}&size=${pageSize}&sort=createdAt,desc`,
+            { method: 'GET' }
+        );
+
+        if (!res.ok) throw new Error();
+
+        const result = await res.json();
+        const pageData = result.data;
+
+        const tbody = document.querySelector('.resource-table tbody');
+        tbody.innerHTML = '';
+
+        currentPage = pageData.number;
+        const content = pageData.content;
+
+        if (!content || content.length === 0) {
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="6">
+                        <div class="empty-state">
+                            <i class="fas fa-clipboard-list"></i>
+                            <p>감사 로그가 없습니다.</p>
+                        </div>
+                    </td>
+                </tr>
+            `;
+            document.getElementById('pagination-container').style.display = 'none';
+            return;
+        }
+
+        document.getElementById('pagination-container').style.display = 'flex';
+
+        // 번호 계산 (페이지 기준, 연속 번호)
+        const startNumber = currentPage * pageSize;
+
+        content.forEach((log, index) => {
+            const tr = document.createElement('tr');
+
+            tr.append(
+                createCell(startNumber + index + 1),
+                createCell(formatDateTime(log.createdAt)),
+                createCell(log.actorName),
+                createCell(log.entityDisplay),
+                createCell(log.eventType),
+                createDetailButton(log.id)
+            );
+
+            tbody.appendChild(tr);
+        });
+
+        renderPagination(pageData);
+
+    } catch (e) {
+        console.error(e);
+        alert('인사 감사 로그 목록을 불러오지 못했습니다.');
+    }
+}
+
+/* ==========================
+   Cell Helpers
+========================== */
+function createCell(value = '') {
+    const td = document.createElement('td');
+    td.textContent = value ?? '-';
+    return td;
+}
+
+function createDetailButton(id) {
+    const td = document.createElement('td');
+
+    const btn = document.createElement('button');
+    btn.className = 'btn-edit'; // 디자인 통일 (보기 버튼)
+    btn.textContent = '보기';
+    btn.onclick = () => openAuditLogModal(id);
+
+    td.appendChild(btn);
+    return td;
+}
+
+/* ==========================
+   Pagination Render
+========================== */
+function renderPagination(pageData) {
+    const container = document.querySelector('.pagination');
+    container.innerHTML = '';
+
+    const { number, totalPages, first, last } = pageData;
+
+    // 이전 버튼
+    const prevBtn = document.createElement('button');
+    prevBtn.innerHTML = '<i class="fas fa-chevron-left"></i>';
+    prevBtn.disabled = first;
+    prevBtn.onclick = () => loadAuditLogs(number - 1);
+    container.appendChild(prevBtn);
+
+    // 페이지 번호 (5개 단위)
+    const startPage = Math.floor(number / 5) * 5;
+    const endPage = Math.min(startPage + 5, totalPages);
+
+    for (let i = startPage; i < endPage; i++) {
+        const pageBtn = document.createElement('button');
+        pageBtn.textContent = i + 1;
+        pageBtn.className = i === number ? 'active' : '';
+        pageBtn.onclick = () => loadAuditLogs(i);
+        container.appendChild(pageBtn);
+    }
+
+    // 다음 버튼
+    const nextBtn = document.createElement('button');
+    nextBtn.innerHTML = '<i class="fas fa-chevron-right"></i>';
+    nextBtn.disabled = last;
+    nextBtn.onclick = () => loadAuditLogs(number + 1);
+    container.appendChild(nextBtn);
+}
+
+/* ==========================
+   Modal (Detail)
+========================== */
+async function openAuditLogModal(id) {
+    try {
+        const res = await apiFetch(`/api/admin/audit-logs/${id}`);
+        if (!res.ok) throw new Error();
+
+        const { data: log } = await res.json();
+
+        // 기본 정보
+        setText('modal-created-at', formatDateTime(log.createdAt));
+        setText('modal-actor', `${log.actorName} (${log.actorEmail})`);
+        setText('modal-entity', log.entityDisplay);
+        setText('modal-event', log.eventType);
+
+        // BEFORE / AFTER
+        document.getElementById('modal-before').textContent =
+            formatJson(log.beforeData);
+        document.getElementById('modal-after').textContent =
+            formatJson(log.afterData);
+
+        document.getElementById('audit-log-modal').style.display = 'flex';
+
+    } catch (e) {
+        console.error(e);
+        alert('감사 로그 상세를 불러오지 못했습니다.');
+    }
+}
+
+function closeAuditLogModal() {
+    document.getElementById('audit-log-modal').style.display = 'none';
+}
+
+/* ==========================
+   Utils
+========================== */
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value ?? '-';
+}
+
+function formatJson(obj) {
+    if (!obj || Object.keys(obj).length === 0) return '';
+    return JSON.stringify(obj, null, 2);
+}
+
+function formatDateTime(isoString) {
+    if (!isoString) return '-';
+    return isoString.replace('T', ' ').substring(0, 19);
+}

--- a/src/main/resources/templates/admin/audit-log/list.html
+++ b/src/main/resources/templates/admin/audit-log/list.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/layout-admin :: layout(
+        ~{::content},
+        ~{fragments/header :: header},
+        ~{sidebar/admin-sidebar :: menu},
+        ~{::pageCss},
+        ~{::pageScript}
+      )}">
+
+<head>
+  <meta charset="UTF-8">
+  <title>인사 감사 로그</title>
+
+  <th:block th:fragment="pageCss">
+    <link rel="stylesheet" th:href="@{/css/admin-audit/admin-audit-logs.css}">
+  </th:block>
+
+  <th:block th:fragment="pageScript">
+    <script th:src="@{/js/admin-audit/admin-audit-logs.js}"></script>
+  </th:block>
+</head>
+
+<body>
+<div th:fragment="content">
+
+  <div class="board-container">
+
+    <!-- Header -->
+    <div class="page-header">
+      <h1 class="page-title">인사 감사 로그</h1>
+    </div>
+
+    <!-- Table -->
+    <div class="board-table-container">
+      <table class="resource-table">
+        <colgroup>
+          <col style="width:5%">
+          <col style="width:20%">
+          <col style="width:15%">
+          <col style="width:15%">
+          <col style="width:15%">
+          <col style="width:10%">
+        </colgroup>
+        <thead>
+        <tr>
+          <th>No</th>
+          <th>일시</th>
+          <th>수행자</th>
+          <th>대상</th>
+          <th>이벤트</th>
+          <th>상세</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div class="pagination-container" id="pagination-container">
+      <div class="pagination"></div>
+    </div>
+
+    <!-- 안내 문구 -->
+    <div class="hint warning">
+      ※ 인사 감사 로그는 법적 보관 데이터로 수정 및 삭제가 불가합니다.
+    </div>
+  </div>
+
+  <!-- Audit Log Detail Modal (반드시 content 안) -->
+  <div class="modal-overlay" id="audit-log-modal" style="display:none;">
+    <div class="modal">
+
+      <div class="modal-header">
+        <h2>인사 감사 로그 상세</h2>
+        <button class="btn-close" onclick="closeAuditLogModal()">×</button>
+      </div>
+
+      <div class="modal-body">
+
+        <div class="info-grid">
+          <div class="info-item">
+            <label class="info-label">발생 일시</label>
+            <div class="info-text" id="modal-created-at">-</div>
+          </div>
+
+          <div class="info-item">
+            <label class="info-label">수행자</label>
+            <div class="info-text" id="modal-actor">-</div>
+          </div>
+
+          <div class="info-item">
+            <label class="info-label">대상</label>
+            <div class="info-text" id="modal-entity">-</div>
+          </div>
+
+          <div class="info-item">
+            <label class="info-label">이벤트</label>
+            <div class="info-text" id="modal-event">-</div>
+          </div>
+        </div>
+
+        <div class="diff-container">
+          <div class="diff-box before">
+            <h3>BEFORE</h3>
+            <pre id="modal-before"></pre>
+          </div>
+
+          <div class="diff-box after">
+            <h3>AFTER</h3>
+            <pre id="modal-after"></pre>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/sidebar/admin-sidebar.html
+++ b/src/main/resources/templates/sidebar/admin-sidebar.html
@@ -18,6 +18,12 @@
         </a>
     </li>
 
+    <li class="menu-item">
+        <a th:href="@{/view/admin/audit-logs}" class="menu-title" style="text-decoration:none;">
+            <span>감사 로그</span>
+        </a>
+    </li>
+
     <li class="menu-item no-sub">
         <a th:href="@{/view/admin/approval}" class="menu-title" style="text-decoration:none;">
             <span>결재 관리</span>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #411

## 📝 작업 내용
### 1. 인사 감사 로그 조회 기능 구현
- 관리자 권한으로 감사 로그 목록 조회 API 추가
- 최신 로그 기준(createdAt desc) 페이징 처리
- 로그가 없는 경우 Empty State UI 제공

### 2. 감사 로그 상세 모달 구현
- 감사 로그 상세를 페이지 이동이 아닌 **모달 방식**으로 제공
- BEFORE / AFTER 데이터 JSON pretty 출력

### 3. 감사 대상 정보 가독성 개선
- `AuditEntityType`에 한글 표시명(displayName) 추가
- entityId 기반으로 실제 대상 이름 조회
- 화면에는 `사원 · 김오빗`, `조직 · 인사팀` 형태로 표시

### 4. 아키텍처 정리
- REST Controller / View Controller 분리 유지
- 감사 로그 도메인 내부에 `AuditEntityNameResolver` 추가하여 엔티티 이름 해석 책임 분리
- DTO는 화면 표시용 데이터만 전달하도록 단순화

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
