### PR TITLE
Feat/#418

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -25,12 +25,12 @@ CREATE TABLE org_category
     is_active          BOOLEAN     NOT NULL DEFAULT TRUE,
 
     active_order_index INT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN is_active = TRUE THEN order_index
-                ELSE NULL
-                END
-            ) STORED,
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN is_active = TRUE THEN order_index
+                               ELSE NULL
+                               END
+                           ) STORED,
 
     created_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -59,12 +59,12 @@ CREATE TABLE organization
 
     -- 활성 조직만 정렬 대상
     active_order_index INT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN is_active = TRUE THEN order_index
-                ELSE NULL
-                END
-            ) STORED,
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN is_active = TRUE THEN order_index
+                               ELSE NULL
+                               END
+                           ) STORED,
 
     created_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -115,12 +115,12 @@ CREATE TABLE position_category
     is_active          BOOLEAN     NOT NULL DEFAULT TRUE,
     -- 활성일 때만 정렬 유니크를 적용하기 위한 가상 컬럼
     active_order_index INT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN is_active = TRUE THEN order_index
-                ELSE NULL
-                END
-            ) STORED,
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN is_active = TRUE THEN order_index
+                               ELSE NULL
+                               END
+                           ) STORED,
     created_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
@@ -257,6 +257,24 @@ CREATE TABLE refresh_token
 );
 
 
+CREATE TABLE email_verification_token
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    employee_id BIGINT      NOT NULL,
+    token       VARCHAR(64) NOT NULL,
+    type        VARCHAR(30) NOT NULL,
+    expired_at  DATETIME    NOT NULL,
+    used_at     DATETIME    NULL,
+    created_at  DATETIME    NOT NULL,
+    updated_at  DATETIME    NOT NULL,
+    CONSTRAINT uq_email_verification_token UNIQUE (token),
+    CONSTRAINT fk_email_verification_employee
+        FOREIGN KEY (employee_id)
+            REFERENCES employee (id)
+            ON DELETE CASCADE
+);
+
+
 -- =========================================================
 -- 1. LEAVE TYPE
 -- =========================================================
@@ -362,12 +380,12 @@ CREATE TABLE form_template
         ON UPDATE CURRENT_TIMESTAMP,
 
     active_version     INT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN status = 'ACTIVE' THEN version
-                ELSE NULL
-                END
-            ) STORED,
+                       GENERATED ALWAYS AS (
+                           CASE
+                               WHEN status = 'ACTIVE' THEN version
+                               ELSE NULL
+                               END
+                           ) STORED,
 
     CONSTRAINT fk_ft_company
         FOREIGN KEY (company_id)
@@ -864,12 +882,12 @@ CREATE TABLE employee_signature
 
     -- 활성 서명만 UNIQUE 제약을 걸기 위한 가상 컬럼
     active_flag TINYINT
-        GENERATED ALWAYS AS (
-            CASE
-                WHEN is_active = TRUE THEN 1
-                ELSE NULL
-                END
-            ),
+                GENERATED ALWAYS AS (
+                    CASE
+                        WHEN is_active = TRUE THEN 1
+                        ELSE NULL
+                        END
+                    ),
 
     created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
@@ -1,16 +1,17 @@
 package com.finalproj.orbitflow.email.controller;
 
-import com.finalproj.orbitflow.email.enums.EmailTokenType;
+import com.finalproj.orbitflow.email.dto.PasswordActivateReqDto;
+import com.finalproj.orbitflow.email.entity.EmailVerificationToken;
 import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.finalproj.orbitflow.email.enums.EmailTokenType.ACTIVATE_ACCOUNT;
 
 /**
  * Please explain the class!!!
@@ -28,12 +29,27 @@ public class AccountActivateController {
     private final EmployeeService employeeService;
 
     @PostMapping("/activate")
-    public ResponseEntity<?> activate(@RequestParam String token) {
+    public ResponseEntity<?> activate(
+            @RequestParam String token,
+            @RequestBody @Valid PasswordActivateReqDto dto
+    ) {
+        EmailVerificationToken vt =
+                emailService.verify(token, ACTIVATE_ACCOUNT);
 
-        Employee employee =
-                emailService.verifyAndGetEmployee(token, EmailTokenType.ACTIVATE_ACCOUNT);
+        Employee employee = vt.getEmployee();
 
+        if (employee.getStatus() != EmployeeStatus.TEMP) {
+            throw new IllegalStateException("이미 활성화된 계정입니다.");
+        }
+
+        // 비밀번호 설정
+        employeeService.resetPassword(employee, dto.getPassword());
+
+        // 계정 활성화
         employeeService.activate(employee);
+
+        // 토큰 사용 처리
+        emailService.markTokenUsed(vt);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/finalproj/orbitflow/email/controller/ActivateViewController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/ActivateViewController.java
@@ -1,11 +1,8 @@
 package com.finalproj.orbitflow.email.controller;
 
-import com.finalproj.orbitflow.email.enums.EmailTokenType;
-import com.finalproj.orbitflow.email.service.EmailVerificationService;
-import com.finalproj.orbitflow.hr.employee.entity.Employee;
-import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,18 +19,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 public class ActivateViewController {
 
-    private final EmailVerificationService emailService;
-    private final EmployeeService employeeService;
-
     @GetMapping
-    public String activateAndRedirect(@RequestParam String token) {
-
-        Employee employee =
-                emailService.verifyAndGetEmployee(token, EmailTokenType.ACTIVATE_ACCOUNT);
-
-        employeeService.activate(employee);
-
-        // 활성화 끝 --> 비밀번호 재설정으로 이동
-        return "redirect:/reset-password?token=" + token;
+    public String activate(@RequestParam String token, Model model) {
+        model.addAttribute("token", token);
+        return "email/activate"; // 비밀번호 생성 페이지
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
@@ -6,6 +6,7 @@ import com.finalproj.orbitflow.email.entity.EmailVerificationToken;
 import com.finalproj.orbitflow.email.enums.EmailTokenType;
 import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
@@ -39,6 +40,11 @@ public class PasswordResetController {
     public ResponseEntity<?> request(@RequestParam String email) {
 
         Employee employee = employeeService.findByEmail(email);
+
+        if (employee.getStatus() != EmployeeStatus.ACTIVE) {
+            throw new IllegalStateException("요청을 처리할 수 없습니다."); // 활성화된 계정만 비밀번호 재설정이 가능합니다.
+        }
+
         emailService.requestPasswordReset(employee);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/finalproj/orbitflow/email/dto/PasswordActivateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/email/dto/PasswordActivateReqDto.java
@@ -5,14 +5,14 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 /**
- * Please explain the class!!!
+ * 계정 활성화 시 최초 비밀번호 설정 DTO
  *
  * @author : seunga03
- * @filename : PasswordResetReqDto
+ * @filename : PasswordActivateReqDto
  * @since : 2026-01-02 금요일
  */
 @Getter
-public class PasswordResetReqDto {
+public class PasswordActivateReqDto {
 
     @NotBlank
     @Pattern(

--- a/src/main/java/com/finalproj/orbitflow/email/service/SmtpMailSender.java
+++ b/src/main/java/com/finalproj/orbitflow/email/service/SmtpMailSender.java
@@ -26,7 +26,7 @@ public class SmtpMailSender implements MailSender {
         msg.setTo(to);
         msg.setSubject(subject);
         msg.setText(content);
-        msg.setFrom("OrbitFlow <seungalee220@gmail.com>");
+        msg.setFrom("OrbitFlow");
         mailSender.send(msg);
     }
 }

--- a/src/main/java/com/finalproj/orbitflow/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/finalproj/orbitflow/global/exception/GlobalExceptionHandler.java
@@ -93,4 +93,10 @@ public class GlobalExceptionHandler {
                 .body(new ResponseDto(HttpStatus.CONFLICT, e.getMessage(), null));
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ResponseDto> handleIllegalState(IllegalStateException e) {
+        return ResponseEntity.badRequest()
+                .body(new ResponseDto(HttpStatus.BAD_REQUEST, e.getMessage(), null));
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
+++ b/src/main/java/com/finalproj/orbitflow/global/security/SecurityConfig.java
@@ -52,9 +52,9 @@ public class SecurityConfig {
                                 "/favicon.ico",
                                 "/internal/**",
                                 "/favicon.ico",
-                                "/activate",
-                                "/reset-password",
-                                "/find-password",
+                                "/activate/**",
+                                "/reset-password/**",
+                                "/find-password/**",
                                 "/api/email/**"
                         ).permitAll()
 

--- a/src/main/resources/templates/auth/find-password.html
+++ b/src/main/resources/templates/auth/find-password.html
@@ -1,23 +1,130 @@
-<form onsubmit="requestReset(event)">
-  <h2>비밀번호 재설정</h2>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>비밀번호 재설정 | OrbitFlow</title>
 
-  <input id="email"
-         type="email"
-         placeholder="이메일 입력"
-         required />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap">
 
-  <button id="submitBtn" type="submit">
-    재설정 메일 보내기
-  </button>
+  <style>
+    * {
+      box-sizing: border-box;
+      font-family: 'Noto Sans KR', sans-serif;
+    }
 
-  <p id="msg" style="margin-top:12px; font-size:13px;"></p>
-</form>
+    body {
+      margin: 0;
+      background: #f6f8fb;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .card {
+      width: 420px;
+      background: #fff;
+      border-radius: 16px;
+      padding: 48px 40px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+    }
+
+    .title {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    .title h1 {
+      margin: 0;
+      font-size: 26px;
+      font-weight: 700;
+    }
+
+    .title p {
+      margin-top: 8px;
+      font-size: 14px;
+      color: #666;
+    }
+
+    .form-group {
+      margin-bottom: 20px;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #333;
+    }
+
+    input {
+      width: 100%;
+      height: 44px;
+      padding: 0 14px;
+      border-radius: 8px;
+      border: 1px solid #d1d5db;
+      font-size: 14px;
+      outline: none;
+    }
+
+    input:focus {
+      border-color: #4f7cff;
+      box-shadow: 0 0 0 3px rgba(79,124,255,0.15);
+    }
+
+    .btn {
+      width: 100%;
+      height: 48px;
+      border-radius: 10px;
+      border: none;
+      background: #4f7cff;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 12px;
+    }
+
+    .btn:hover {
+      background: #3f6bf2;
+    }
+
+    .msg {
+      margin-top: 16px;
+      font-size: 13px;
+      text-align: center;
+      color: #374151;
+    }
+  </style>
+</head>
+<body>
+
+<div class="card">
+  <div class="title">
+    <h1>비밀번호 재설정</h1>
+    <p>가입한 이메일을 입력하세요.</p>
+  </div>
+
+  <form onsubmit="requestReset(event)">
+    <div class="form-group">
+      <label>이메일</label>
+      <input id="email" type="email" required>
+    </div>
+
+    <button id="submitBtn" class="btn" type="submit">
+      재설정 메일 보내기
+    </button>
+
+    <div id="msg" class="msg"></div>
+  </form>
+</div>
 
 <script>
   async function requestReset(e) {
     e.preventDefault();
-
-    const emailInput = document.getElementById('email');
+    const email = document.getElementById('email').value;
     const msg = document.getElementById('msg');
     const btn = document.getElementById('submitBtn');
 
@@ -26,14 +133,13 @@
 
     try {
       await fetch(
-              `/api/email/password/reset-request?email=${encodeURIComponent(emailInput.value)}`,
+              `/api/email/password/reset-request?email=${encodeURIComponent(email)}`,
               { method: 'POST' }
       );
 
-      // 보안상 항상 동일 메시지
       msg.textContent =
               '메일이 전송되었습니다. (계정이 존재할 경우)';
-    } catch (err) {
+    } catch {
       msg.textContent =
               '요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.';
     } finally {
@@ -41,3 +147,6 @@
     }
   }
 </script>
+
+</body>
+</html>

--- a/src/main/resources/templates/email/activate.html
+++ b/src/main/resources/templates/email/activate.html
@@ -3,63 +3,77 @@
 <head>
     <meta charset="UTF-8">
     <title>계정 활성화 | OrbitFlow</title>
+
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap">
+
     <style>
-        body {
-            margin: 0;
-            height: 100vh;
-            background: #f6f8fb;
-            display: flex;
-            justify-content: center;
-            align-items: center;
+        * {
+            box-sizing: border-box;
             font-family: 'Noto Sans KR', sans-serif;
         }
+
+        body {
+            margin: 0;
+            background: #f6f8fb;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         .card {
             width: 420px;
             background: #fff;
             border-radius: 16px;
-            padding: 40px;
-            box-shadow: 0 20px 50px rgba(0,0,0,.12);
+            padding: 48px 40px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
         }
+
         h1 {
-            margin-bottom: 18px;
-            font-size: 22px;
-            font-weight: 900;
             text-align: center;
+            font-size: 26px;
+            font-weight: 700;
+            margin-bottom: 32px;
         }
+
         .form-group {
-            margin-bottom: 14px;
+            margin-bottom: 20px;
         }
+
         label {
             display: block;
-            font-size: 13px;
-            font-weight: 700;
             margin-bottom: 6px;
+            font-size: 14px;
+            font-weight: 500;
         }
+
         input {
             width: 100%;
             height: 44px;
-            padding: 0 12px;
-            border-radius: 12px;
-            border: 1px solid #e5e7eb;
+            padding: 0 14px;
+            border-radius: 8px;
+            border: 1px solid #d1d5db;
             font-size: 14px;
         }
+
         .error {
-            margin-top: 10px;
+            margin-top: 8px;
             font-size: 13px;
-            font-weight: 700;
-            color: #b91c1c;
+            color: #ef4444;
         }
+
         .btn {
-            margin-top: 24px;
             width: 100%;
-            height: 46px;
-            border-radius: 12px;
+            height: 48px;
+            border-radius: 10px;
             border: none;
-            background: #2563eb;
+            background: #4f7cff;
             color: #fff;
-            font-size: 14px;
-            font-weight: 800;
+            font-size: 16px;
+            font-weight: 600;
             cursor: pointer;
+            margin-top: 12px;
         }
     </style>
 </head>
@@ -68,40 +82,48 @@
 <div class="card">
     <h1>계정 활성화</h1>
 
-    <div class="form-group">
-        <label>비밀번호</label>
-        <input type="password" id="password">
-    </div>
+    <!-- form 사용 → 엔터키 자동 제출 -->
+    <form onsubmit="activate(event)">
+        <div class="form-group">
+            <label for="password">비밀번호</label>
+            <input type="password" id="password" required>
+        </div>
 
-    <div class="form-group">
-        <label>비밀번호 확인</label>
-        <input type="password" id="confirm">
-    </div>
+        <div class="form-group">
+            <label for="passwordConfirm">비밀번호 확인</label>
+            <input type="password" id="passwordConfirm" required>
+        </div>
 
-    <div id="error" class="error"></div>
+        <div id="error" class="error"></div>
 
-    <button class="btn" onclick="activate()">계정 활성화</button>
+        <button class="btn" type="submit">계정 활성화</button>
+    </form>
 </div>
 
 <script>
     const token = '[[${token}]]';
-    const regex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/;
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/;
 
-    function activate() {
-        const pw = document.getElementById('password').value;
-        const confirm = document.getElementById('confirm').value;
-        const error = document.getElementById('error');
+    function activate(event) {
+        event.preventDefault();
 
-        error.innerText = '';
+        const passwordInput = document.getElementById('password');
+        const confirmInput  = document.getElementById('passwordConfirm');
+        const errorEl = document.getElementById('error');
 
-        if (!regex.test(pw)) {
-            error.innerText =
+        const pw = passwordInput.value;
+        const cf = confirmInput.value;
+
+        errorEl.textContent = '';
+
+        if (!passwordRegex.test(pw)) {
+            errorEl.textContent =
                 '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.';
             return;
         }
 
-        if (pw !== confirm) {
-            error.innerText = '비밀번호가 일치하지 않습니다.';
+        if (pw !== cf) {
+            errorEl.textContent = '비밀번호가 일치하지 않습니다.';
             return;
         }
 
@@ -110,14 +132,19 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ password: pw })
         })
-            .then(res => {
-                if (!res.ok) throw new Error();
+            .then(async res => {
+                const data = await res.json().catch(() => null);
+
+                if (!res.ok) {
+                    throw new Error(data?.message || '요청 처리 중 오류가 발생했습니다.');
+                }
+
                 alert('계정이 활성화되었습니다. 로그인해 주세요.');
                 location.href = '/login';
             })
-            .catch(() => {
-                error.innerText =
-                    '만료되었거나 이미 사용된 링크입니다.';
+            .catch(err => {
+                console.error(err);
+                errorEl.textContent = err.message;
             });
     }
 </script>

--- a/src/main/resources/templates/email/activate.html
+++ b/src/main/resources/templates/email/activate.html
@@ -19,36 +19,40 @@
             border-radius: 16px;
             padding: 40px;
             box-shadow: 0 20px 50px rgba(0,0,0,.12);
-            text-align: center;
         }
         h1 {
-            margin-bottom: 12px;
+            margin-bottom: 18px;
             font-size: 22px;
             font-weight: 900;
+            text-align: center;
         }
-        p {
-            margin: 0;
+        .form-group {
+            margin-bottom: 14px;
+        }
+        label {
+            display: block;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 6px;
+        }
+        input {
+            width: 100%;
+            height: 44px;
+            padding: 0 12px;
+            border-radius: 12px;
+            border: 1px solid #e5e7eb;
             font-size: 14px;
-            font-weight: 600;
-            color: #6b7280;
         }
-        .success { color: #15803d; }
-        .error { color: #b91c1c; }
-        .spinner {
-            margin: 24px auto;
-            width: 36px;
-            height: 36px;
-            border: 4px solid #e5e7eb;
-            border-top-color: #2563eb;
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-        }
-        @keyframes spin {
-            to { transform: rotate(360deg); }
+        .error {
+            margin-top: 10px;
+            font-size: 13px;
+            font-weight: 700;
+            color: #b91c1c;
         }
         .btn {
-            margin-top: 28px;
-            padding: 12px 18px;
+            margin-top: 24px;
+            width: 100%;
+            height: 46px;
             border-radius: 12px;
             border: none;
             background: #2563eb;
@@ -62,37 +66,60 @@
 <body>
 
 <div class="card">
-    <h1 id="title">계정 활성화 중</h1>
-    <div class="spinner" id="spinner"></div>
-    <p id="message">잠시만 기다려 주세요.</p>
+    <h1>계정 활성화</h1>
 
-    <button id="loginBtn" class="btn" style="display:none"
-            onclick="location.href='/login'">
-        로그인 페이지로 이동
-    </button>
+    <div class="form-group">
+        <label>비밀번호</label>
+        <input type="password" id="password">
+    </div>
+
+    <div class="form-group">
+        <label>비밀번호 확인</label>
+        <input type="password" id="confirm">
+    </div>
+
+    <div id="error" class="error"></div>
+
+    <button class="btn" onclick="activate()">계정 활성화</button>
 </div>
 
 <script>
     const token = '[[${token}]]';
+    const regex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/;
 
-    fetch(`/api/email/activate?token=${token}`, { method: 'POST' })
-        .then(res => {
-            if (!res.ok) throw new Error();
-            document.getElementById('title').innerText = '계정 활성화 완료';
-            document.getElementById('title').className = 'success';
-            document.getElementById('message').innerText =
-                '이제 OrbitFlow를 이용하실 수 있습니다.';
+    function activate() {
+        const pw = document.getElementById('password').value;
+        const confirm = document.getElementById('confirm').value;
+        const error = document.getElementById('error');
+
+        error.innerText = '';
+
+        if (!regex.test(pw)) {
+            error.innerText =
+                '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.';
+            return;
+        }
+
+        if (pw !== confirm) {
+            error.innerText = '비밀번호가 일치하지 않습니다.';
+            return;
+        }
+
+        fetch(`/api/email/activate?token=${encodeURIComponent(token)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pw })
         })
-        .catch(() => {
-            document.getElementById('title').innerText = '활성화 실패';
-            document.getElementById('title').className = 'error';
-            document.getElementById('message').innerText =
-                '이미 사용되었거나 만료된 링크입니다.';
-        })
-        .finally(() => {
-            document.getElementById('spinner').style.display = 'none';
-            document.getElementById('loginBtn').style.display = 'inline-block';
-        });
+            .then(res => {
+                if (!res.ok) throw new Error();
+                alert('계정이 활성화되었습니다. 로그인해 주세요.');
+                location.href = '/login';
+            })
+            .catch(() => {
+                error.innerText =
+                    '만료되었거나 이미 사용된 링크입니다.';
+            });
+    }
 </script>
 
 </body>

--- a/src/main/resources/templates/email/reset-password.html
+++ b/src/main/resources/templates/email/reset-password.html
@@ -3,63 +3,64 @@
 <head>
   <meta charset="UTF-8">
   <title>비밀번호 재설정 | OrbitFlow</title>
+
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap">
+
   <style>
+    * { box-sizing: border-box; font-family: 'Noto Sans KR', sans-serif; }
     body {
       margin: 0;
-      height: 100vh;
       background: #f6f8fb;
+      height: 100vh;
       display: flex;
-      justify-content: center;
       align-items: center;
-      font-family: 'Noto Sans KR', sans-serif;
+      justify-content: center;
     }
     .card {
       width: 420px;
       background: #fff;
       border-radius: 16px;
-      padding: 40px;
-      box-shadow: 0 20px 50px rgba(0,0,0,.12);
+      padding: 48px 40px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.08);
     }
     h1 {
-      margin-bottom: 18px;
-      font-size: 22px;
-      font-weight: 900;
       text-align: center;
+      font-size: 26px;
+      font-weight: 700;
+      margin-bottom: 32px;
     }
-    .form-group {
-      margin-bottom: 14px;
-    }
+    .form-group { margin-bottom: 20px; }
     label {
       display: block;
-      font-size: 13px;
-      font-weight: 700;
       margin-bottom: 6px;
+      font-size: 14px;
+      font-weight: 500;
     }
     input {
       width: 100%;
       height: 44px;
-      padding: 0 12px;
-      border-radius: 12px;
-      border: 1px solid #e5e7eb;
+      padding: 0 14px;
+      border-radius: 8px;
+      border: 1px solid #d1d5db;
       font-size: 14px;
     }
     .error {
-      margin-top: 10px;
+      margin-top: 8px;
       font-size: 13px;
-      font-weight: 700;
-      color: #b91c1c;
+      color: #ef4444;
     }
     .btn {
-      margin-top: 24px;
       width: 100%;
-      height: 46px;
-      border-radius: 12px;
+      height: 48px;
+      border-radius: 10px;
       border: none;
-      background: #2563eb;
+      background: #4f7cff;
       color: #fff;
-      font-size: 14px;
-      font-weight: 800;
+      font-size: 16px;
+      font-weight: 600;
       cursor: pointer;
+      margin-top: 12px;
     }
   </style>
 </head>
@@ -68,38 +69,46 @@
 <div class="card">
   <h1>비밀번호 재설정</h1>
 
-  <div class="form-group">
-    <label>새 비밀번호</label>
-    <input type="password" id="password">
-  </div>
+  <form onsubmit="resetPassword(event)">
+    <div class="form-group">
+      <label>새 비밀번호</label>
+      <input type="password" id="password" required>
+    </div>
 
-  <div class="form-group">
-    <label>새 비밀번호 확인</label>
-    <input type="password" id="passwordConfirm">
-  </div>
+    <div class="form-group">
+      <label>새 비밀번호 확인</label>
+      <input type="password" id="passwordConfirm" required>
+    </div>
 
-  <div id="error" class="error"></div>
+    <div id="error" class="error"></div>
 
-  <button class="btn" onclick="resetPassword()">비밀번호 변경</button>
+    <button class="btn" type="submit">비밀번호 변경</button>
+  </form>
+
 </div>
 
 <script>
   const token = '[[${token}]]';
+  const regex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/;
 
-  function resetPassword() {
-    const pw = document.getElementById('password').value;
-    const confirm = document.getElementById('passwordConfirm').value;
+  function resetPassword(event) {
+    event.preventDefault();
+
+    const pw = password.value;
+    const cf = passwordConfirm.value;
     const error = document.getElementById('error');
     const btn = document.querySelector('.btn');
 
-    error.innerText = '';
+    error.textContent = '';
 
-    if (!pw || pw.length < 8) {
-      error.innerText = '비밀번호는 최소 8자 이상이어야 합니다.';
+    if (!regex.test(pw)) {
+      error.textContent =
+              '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.';
       return;
     }
-    if (pw !== confirm) {
-      error.innerText = '비밀번호가 일치하지 않습니다.';
+
+    if (pw !== cf) {
+      error.textContent = '비밀번호가 일치하지 않습니다.';
       return;
     }
 
@@ -107,7 +116,7 @@
 
     fetch(`/api/email/password/reset?token=${encodeURIComponent(token)}`, {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ password: pw })
     })
             .then(res => {
@@ -116,7 +125,8 @@
               location.href = '/login';
             })
             .catch(() => {
-              error.innerText = '링크가 만료되었거나 이미 사용되었습니다.';
+              error.textContent =
+                      '링크가 만료되었거나 이미 사용되었습니다.';
               btn.disabled = false;
             });
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #418

## 📝 작업 내용
### 계정 활성화 플로우 개선
- 이메일 인증 링크 클릭 시 **계정 활성화 + 최초 비밀번호 설정을 하나의 화면에서 처리**
- 기존 `활성화 → 로그인 → 비밀번호 재설정`의 단절된 UX 개선
- `TEMP` 상태 계정만 활성화 가능하도록 서버 검증 강화

### 비밀번호 재설정 플로우 정비
- 비밀번호 재설정 메일 요청 / 재설정 처리 API 분리
- 재설정 성공 시 **모든 세션 무효화** 처리
- 재설정 이력 Audit Log 기록

### 비밀번호 정책 공통 적용
- 영문 + 숫자 + 특수문자 포함, 8자 이상
- 프론트엔드 + 백엔드 DTO 이중 검증

### UI/UX 통합
- 로그인 페이지 스타일 기준으로
  - 계정 활성화 페이지
  - 비밀번호 재설정 페이지
  - 비밀번호 찾기 페이지
  디자인 통일
- `<form onsubmit>` 구조로 **엔터키 제출 지원**

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
