### PR TITLE
Design/#424

### DIFF
--- a/src/main/resources/static/css/admin-org-category.css
+++ b/src/main/resources/static/css/admin-org-category.css
@@ -1,6 +1,7 @@
 /* ==================================================
    admin-org-category.css
    - 조직 카테고리 관리 (목록 + 모달)
+   - board.css 디자인 기준 통일 버전
 ================================================== */
 
 :root {
@@ -9,8 +10,9 @@
     --line: #eef1f6;
     --text: #111827;
     --muted: #6b7280;
-    --primary: #2f6af6;
-    --primary-weak: rgba(47, 106, 246, .12);
+    --primary: #3B82F6;
+    --primary-hover: #2563EB;
+    --primary-weak: rgba(59, 130, 246, .12);
 
     --success-bg: #dff7e7;
     --success-text: #137a3a;
@@ -18,39 +20,48 @@
     --danger-bg: #fde2e2;
     --danger-text: #b42318;
 
-    --shadow: 0 12px 36px rgba(16, 24, 40, 0.08);
+    --neutral-700: #374151;
+    --neutral-800: #1F2937;
 }
 
+/* =========================
+   카드 / 레이아웃
+========================= */
 
-/* 타이틀 */
-.orgcat-title-row {
-    margin-bottom: 18px;
-}
-
-.orgcat-title {
-    font-size: 22px;
-    font-weight: 800;
-    letter-spacing: -0.2px;
-    color: var(--text);
-    margin: 0;
-}
-
-/* 카드 */
 .orgcat-card {
     background: var(--card);
     border: 1px solid var(--line);
-    border-radius: 18px;
-    box-shadow: var(--shadow);
-    padding: 18px 18px 14px;
+    border-radius: 12px;
+    padding: 20px;
 }
 
-/* 툴바 */
+/* 카드 헤더 */
+.orgcat-card-head {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--line);
+}
+
+.orgcat-card-head .orgcat-title {
+    font-size: 26px;          /* board h1 기준 */
+    font-weight: 600;
+    color: var(--neutral-800);
+    letter-spacing: -0.02em;
+    margin: 0;
+}
+
+/* =========================
+   상단 툴바
+========================= */
+
 .orgcat-toolbar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 16px; /* 테이블이랑 거리 */
+    margin-bottom: 16px;
+    gap: 12px;
 }
+
 .toolbar-left {
     display: flex;
     align-items: center;
@@ -59,71 +70,67 @@
 
 /* 검색 */
 .orgcat-search {
-    flex: 1;
-    max-width: 320px;
     display: flex;
     align-items: center;
-    gap: 10px;
-    height: 44px;
-    border: 1px solid var(--line);
-    border-radius: 12px;
+    gap: 8px;
+    height: 40px;                 /* board 기준 */
     padding: 0 14px;
-    background: #fbfcff;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: #fff;
 }
 
 .orgcat-search i {
-    color: #9aa3b2;
     font-size: 14px;
+    color: #9ca3af;
 }
 
 .orgcat-search input {
-    width: 220px;
     border: none;
     outline: none;
-    background: transparent;
-    font-size: 13.5px;
+    font-size: 14px;
     color: var(--text);
+    background: transparent;
 }
 
 .orgcat-search input::placeholder {
-    color: #9aa3b2;
+    color: #9ca3af;
 }
 
-/* 버튼 공통 */
+/* =========================
+   버튼 (board 스타일 통일)
+========================= */
+
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    height: 42px;
+    height: 40px;
     padding: 0 16px;
-    border-radius: 12px;
-    border: 1px solid transparent;
-    font-size: 13.5px;
-    font-weight: 700;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
     cursor: pointer;
-    transition: transform .06s ease, background .15s ease, border-color .15s ease;
-    user-select: none;
-}
-
-.btn:active {
-    transform: translateY(1px);
+    border: 1px solid transparent;
+    background: #fff;
+    transition: all .2s ease;
 }
 
 .btn-primary {
     background: var(--primary);
     color: #fff;
-    box-shadow: 0 10px 24px rgba(47, 106, 246, .22);
 }
 
 .btn-primary:hover {
-    filter: brightness(0.98);
+    background: var(--primary-hover);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
 }
 
 .btn-outline {
     background: #fff;
     color: var(--primary);
-    border-color: rgba(47, 106, 246, .35);
+    border-color: var(--primary);
 }
 
 .btn-outline:hover {
@@ -131,25 +138,17 @@
 }
 
 .btn-outline:disabled {
+    opacity: .5;
     cursor: not-allowed;
-    opacity: .45;
-    background: #fff;
 }
 
-.btn-ghost {
-    background: #fff;
-    color: #374151;
-    border-color: #e5e7eb;
-}
+/* =========================
+   테이블
+========================= */
 
-.btn-ghost:hover {
-    background: #f3f4f6;
-}
-
-/* 테이블 */
 .orgcat-table-wrap {
     border: 1px solid var(--line);
-    border-radius: 16px;
+    border-radius: 12px;
     overflow: hidden;
     background: #fff;
 }
@@ -157,51 +156,203 @@
 .orgcat-table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 13.5px;
+    font-size: 14px;
 }
 
 .orgcat-table thead th {
-    background: #f6f7fb;
-    color: #667085;
-    text-align: left;
+    background: #f9fafb;
+    color: var(--neutral-700);
     padding: 14px 16px;
-    font-weight: 800;
+    font-weight: 600;
     border-bottom: 1px solid var(--line);
+    text-align: left;
 }
 
 .orgcat-table tbody td {
-    padding: 16px 16px;
+    padding: 14px 16px;
     border-bottom: 1px solid var(--line);
+    color: var(--neutral-800);
     vertical-align: middle;
-    color: var(--text);
+}
+
+.orgcat-table tbody tr:hover {
+    background: #f9fafb;
 }
 
 .orgcat-table tbody tr:last-child td {
     border-bottom: none;
 }
 
-.col-order {
-    width: 90px;
+/* 컬럼 폭 */
+.col-order { width: 90px; }
+.col-status { width: 140px; text-align: center; }
+.col-action { width: 140px; }
+
+/* =========================
+   상태 배지
+========================= */
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 56px;
+    height: 22px;
+    padding: 0 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
 }
 
-.col-status {
-    width: 140px;
+.status-active {
+    background: var(--success-bg);
+    color: var(--success-text);
 }
 
-.col-action {
-    width: 140px;
+.status-inactive {
+    background: var(--danger-bg);
+    color: var(--danger-text);
 }
 
-/* 드래그 핸들(점 6개 느낌) */
+/* =========================
+   테이블 버튼
+========================= */
+
+.table-btn {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    background: #fff;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.table-btn:hover {
+    background: #f3f4f6;
+}
+
+/* =========================
+   하단 영역
+========================= */
+
+.orgcat-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 16px;
+    gap: 12px;
+}
+
+.orgcat-hint {
+    font-size: 13px;
+    color: #9ca3af;
+}
+
+/* =========================
+   모달
+========================= */
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+.modal-panel {
+    width: 720px;
+    max-width: 92vw;
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.modal-head {
+    padding: 20px 24px 12px;
+}
+
+.modal-head h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--neutral-800);
+    margin: 0;
+}
+
+.modal-sub {
+    margin-top: 6px;
+    font-size: 13px;
+    color: #9ca3af;
+}
+
+.modal-body {
+    padding: 16px 24px;
+}
+
+.form-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--neutral-700);
+    margin-bottom: 6px;
+}
+
+.form-input {
+    width: 100%;
+    height: 40px;
+    padding: 0 14px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    font-size: 14px;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(59,130,246,.1);
+}
+
+/* =========================
+   반응형
+========================= */
+
+@media (max-width: 720px) {
+    .orgcat-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .orgcat-footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .orgcat-footer .btn {
+        width: 100%;
+    }
+}
+
+
+/* =========================
+   드래그 핸들 (점 6개)
+========================= */
+
 .drag-handle {
     width: 34px;
     height: 34px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 10px;
+    border-radius: 8px;
     cursor: grab;
-    color: #98a2b3;
+    color: #9ca3af;
 }
 
 .drag-handle:active {
@@ -220,270 +371,54 @@
 .drag-dots span {
     width: 4px;
     height: 4px;
-    background: #a9b1c3;
+    background: #9ca3af;
     border-radius: 50%;
 }
 
-/* 상태 배지 */
-.status-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 56px;
-    height: 22px;
-    padding: 3px 14px;
-    border-radius: 20px;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1;
-}
 
-.status-active {
-    background: var(--success-bg);
-    color: var(--success-text);
-}
 
-.status-inactive {
-    background: var(--danger-bg);
-    color: var(--danger-text);
-}
-
-/* 수정 버튼(테이블 내) */
-.table-btn {
-    height: 36px;
-    padding: 0 14px;
-    border-radius: 12px;
-    border: 1px solid #d0d5dd;
-    background: #fff;
-    font-weight: 800;
-    font-size: 13px;
-    color: #344054;
-    cursor: pointer;
-}
-
-.table-btn:hover {
-    background: #f3f4f6;
-}
-
-/* 하단 */
-.orgcat-footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 12px 6px 0;
-}
-
-.orgcat-hint {
-    font-size: 12.5px;
-    color: #98a2b3;
+/* 상태 컬럼 중앙 정렬 */
+.orgcat-table th.col-status,
+.orgcat-table td.col-status {
+    text-align: center;
+    vertical-align: middle;
 }
 
 /* =========================
-   모달
+   상태 / 관리 컬럼 완전 중앙 정렬 (FIX)
 ========================= */
-.modal {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.45);
+
+/* 상태 컬럼 */
+.orgcat-table th.col-status,
+.orgcat-table td.col-status {
+    text-align: center;
+}
+
+
+/* 관리 컬럼 */
+.orgcat-table th.col-action,
+.orgcat-table td.col-action {
+    text-align: center;
+}
+
+/* =========================
+   테이블 셀 중앙 정렬
+========================= */
+
+.cell-center {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 2000;
-    padding: 18px;
+    align-items: center;      /* 세로 중앙 */
+    justify-content: center;  /* 가로 중앙 */
+    height: 100%;
 }
 
-.modal.hidden {
-    display: none;
-}
+/* =========================
+   테이블 행 높이 통일 (board 기준)
+========================= */
 
-.modal-panel {
-    width: 720px;
-    max-width: 92vw;
-    background: #fff;
-    border-radius: 18px;
-    box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
-    overflow: hidden;
-}
-
-.modal-head {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    padding: 22px 24px 10px;
-}
-
-.modal-head h2 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 900;
-    color: var(--text);
-}
-
-.modal-sub {
-    margin: 8px 0 0;
-    font-size: 12.5px;
-    color: #98a2b3;
-}
-
-.icon-btn {
-    width: 36px;
-    height: 36px;
-    border-radius: 10px;
-    border: 1px solid #eef2f7;
-    background: #fff;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #667085;
-}
-
-.icon-btn:hover {
-    background: #f3f4f6;
-}
-
-.modal-body {
-    padding: 8px 24px 18px;
-}
-
-.form-group {
-    margin-top: 14px;
-}
-
-.form-label {
-    display: block;
-    font-size: 12.5px;
-    font-weight: 900;
-    color: #667085;
-    margin-bottom: 8px;
-}
-
-.form-input {
-    width: 100%;
-    height: 46px;
-    padding: 0 14px;
-    border-radius: 12px;
-    border: 1px solid #e6eaf2;
-    background: #fbfcff;
-    outline: none;
-    font-size: 13.5px;
-    color: var(--text);
-}
-
-.form-input:focus {
-    border-color: rgba(47, 106, 246, .55);
-    box-shadow: 0 0 0 4px rgba(47, 106, 246, .12);
-}
-
-.form-help {
-    margin: 8px 2px 0;
-    font-size: 12.5px;
-    color: #ef4444;
-    min-height: 16px;
-}
-
-/* 토글 */
-.toggle-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding-top: 6px;
-}
-
-.toggle-text {
-    font-weight: 900;
-    font-size: 13.5px;
-    color: #344054;
-}
-
-/* switch */
-.switch {
-    position: relative;
-    display: inline-block;
-    width: 54px;
-    height: 30px;
-}
-
-.switch input {
-    display: none;
-}
-
-.slider {
-    position: absolute;
-    cursor: pointer;
-    inset: 0;
-    background: #d0d5dd;
-    border-radius: 999px;
-    transition: .2s;
-}
-
-.slider:before {
-    content: "";
-    position: absolute;
-    height: 24px;
-    width: 24px;
-    left: 3px;
-    top: 3px;
-    background: white;
-    border-radius: 50%;
-    transition: .2s;
-    box-shadow: 0 8px 18px rgba(0, 0, 0, .12);
-}
-
-.switch input:checked + .slider {
-    background: var(--primary);
-}
-
-.switch input:checked + .slider:before {
-    transform: translateX(24px);
-}
-
-/* 모달 하단 버튼 */
-.modal-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    padding: 16px 24px 22px;
-    border-top: 1px solid #eef2f7;
-}
-
-/* Sortable dragging */
-.sortable-chosen {
-    background: #f7f9ff;
-}
-
-.sortable-ghost {
-    opacity: .6;
-}
-
-.inactive-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    font-weight: 700;
-    color: #475467;
-}
-
-
-/* 반응형 */
-@media (max-width: 720px) {
-    .orgcat-toolbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .orgcat-search {
-        max-width: 100%;
-    }
-
-    .orgcat-footer {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .orgcat-footer .btn {
-        width: 100%;
-    }
+.orgcat-table tbody td {
+    height: 52px;              /* board-table td와 동일 */
+    padding: 14px 16px;        /* 이미 동일하지만 명시 */
+    vertical-align: middle;
+    box-sizing: border-box;
 }

--- a/src/main/resources/static/css/admin-org-category.css
+++ b/src/main/resources/static/css/admin-org-category.css
@@ -1,7 +1,7 @@
 /* ==================================================
-   admin-org-category.css
+   admin-org-category.css (FINAL)
    - 조직 카테고리 관리 (목록 + 모달)
-   - board.css 디자인 기준 통일 버전
+   - board.css 디자인 기준 완전 통일
 ================================================== */
 
 :root {
@@ -10,6 +10,7 @@
     --line: #eef1f6;
     --text: #111827;
     --muted: #6b7280;
+
     --primary: #3B82F6;
     --primary-hover: #2563EB;
     --primary-weak: rgba(59, 130, 246, .12);
@@ -35,15 +36,13 @@
     padding: 20px;
 }
 
-/* 카드 헤더 */
 .orgcat-card-head {
     margin-bottom: 16px;
     padding-bottom: 12px;
-    border-bottom: 1px solid var(--line);
 }
 
 .orgcat-card-head .orgcat-title {
-    font-size: 26px;          /* board h1 기준 */
+    font-size: 26px; /* board h1 */
     font-weight: 600;
     color: var(--neutral-800);
     letter-spacing: -0.02em;
@@ -73,7 +72,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    height: 40px;                 /* board 기준 */
+    height: 40px;
     padding: 0 14px;
     border: 1px solid var(--line);
     border-radius: 8px;
@@ -98,7 +97,7 @@
 }
 
 /* =========================
-   버튼 (board 스타일 통일)
+   버튼 (board 통일)
 ========================= */
 
 .btn {
@@ -169,10 +168,12 @@
 }
 
 .orgcat-table tbody td {
+    height: 52px;              /* board-table 기준 */
     padding: 14px 16px;
     border-bottom: 1px solid var(--line);
     color: var(--neutral-800);
     vertical-align: middle;
+    box-sizing: border-box;
 }
 
 .orgcat-table tbody tr:hover {
@@ -184,34 +185,58 @@
 }
 
 /* 컬럼 폭 */
-.col-order { width: 90px; }
-.col-status { width: 140px; text-align: center; }
+.col-order  { width: 90px; }
+.col-status { width: 140px; }
 .col-action { width: 140px; }
+
+/* =========================
+   상태 / 관리 컬럼 정렬
+========================= */
+
+.orgcat-table th.col-status,
+.orgcat-table td.col-status,
+.orgcat-table th.col-action,
+.orgcat-table td.col-action {
+    text-align: center;
+    vertical-align: middle;
+}
 
 /* =========================
    상태 배지
 ========================= */
 
+
 .status-badge {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+
     min-width: 56px;
     height: 22px;
-    padding: 0 12px;
-    border-radius: 999px;
+    padding: 3px 14px;
+
+    border-radius: 20px;
     font-size: 12px;
     font-weight: 600;
+    line-height: 1;
+
+    border: 1.2px solid transparent;
+    color: dimgray;
+    background: #f5f5f5;
 }
 
-.status-active {
-    background: var(--success-bg);
-    color: var(--success-text);
+/* 활성 */
+.status-badge.status-active {
+    background: #ecfdf5;          /* 연한 민트 */
+    border-color: #10b981;
+    color: dimgray;
 }
 
-.status-inactive {
-    background: var(--danger-bg);
-    color: var(--danger-text);
+/* 비활성 */
+.status-badge.status-inactive {
+    background: #fef2f2;          /* 연한 레드 */
+    border-color: #f87171;
+    color: dimgray;
 }
 
 /* =========================
@@ -219,18 +244,53 @@
 ========================= */
 
 .table-btn {
-    height: 36px;
-    padding: 0 14px;
-    border-radius: 8px;
-    border: 1px solid var(--line);
-    background: #fff;
-    font-size: 14px;
-    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: 12px;
+    font-size: 13px;
     cursor: pointer;
+    transition: background 0.2s;
+    background: #e3f2fd;
+    border: 1.2px solid #6d8cdc;
+    color: #1976d2;
 }
 
 .table-btn:hover {
     background: #f3f4f6;
+}
+
+/* =========================
+   드래그 핸들 (점 6개)
+========================= */
+
+.drag-handle {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    cursor: grab;
+    color: #9ca3af;
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-dots {
+    width: 14px;
+    height: 18px;
+    display: grid;
+    grid-template-columns: repeat(2, 4px);
+    grid-template-rows: repeat(3, 4px);
+    gap: 3px;
+}
+
+.drag-dots span {
+    width: 4px;
+    height: 4px;
+    background: #9ca3af;
+    border-radius: 50%;
 }
 
 /* =========================
@@ -294,7 +354,13 @@
 }
 
 .modal-body {
-    padding: 16px 24px;
+    padding: 24px 28px;
+}
+
+/* 입력 그룹 최대 폭 제한 */
+.modal-body .form-group {
+    /*width: 100%;*/
+    max-width: 480px;
 }
 
 .form-label {
@@ -324,11 +390,7 @@
 ========================= */
 
 @media (max-width: 720px) {
-    .orgcat-toolbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
+    .orgcat-toolbar,
     .orgcat-footer {
         flex-direction: column;
         align-items: stretch;
@@ -340,85 +402,218 @@
 }
 
 
+/* ==================================================
+   Modal UI Upgrade (FINAL)
+================================================== */
+
+/* 배경 */
+.modal {
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(4px);
+}
+
+/* 패널 */
+.modal-panel {
+    width: 560px;
+    background: #fff;
+    border-radius: 16px;
+    box-shadow:
+            0 20px 40px rgba(0, 0, 0, 0.12),
+            0 8px 16px rgba(0, 0, 0, 0.08);
+    animation: modalFadeUp .18s ease-out;
+}
+
+/* 등장 애니메이션 */
+@keyframes modalFadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
 /* =========================
-   드래그 핸들 (점 6개)
+   헤더
 ========================= */
 
-.drag-handle {
-    width: 34px;
-    height: 34px;
+.modal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 24px 28px 16px;
+    border-bottom: 1px solid var(--line);
+}
+
+.modal-head-text h2 {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--neutral-800);
+    margin: 0;
+}
+
+.modal-sub {
+    margin-top: 6px;
+    font-size: 14px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+/* 닫기 버튼 */
+.icon-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: #6b7280;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 8px;
-    cursor: grab;
+}
+
+.icon-btn:hover {
+    background: #f3f4f6;
+    color: #111827;
+}
+
+/* =========================
+   바디
+========================= */
+
+.modal-body {
+    align-items: flex-start;
+    padding: 24px 28px;
+}
+
+/* 폼 그룹 */
+.form-group {
+    margin-bottom: 24px;
+}
+
+.form-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--neutral-700);
+    margin-bottom: 8px;
+    display: block;
+}
+
+/* 인풋 */
+.form-input {
+    height: 44px;
+    font-size: 14px;
+    padding: 0 14px;
+    border-radius: 10px;
+    border: 1px solid var(--line);
+    transition: all .2s ease;
+}
+
+.form-input::placeholder {
     color: #9ca3af;
 }
 
-.drag-handle:active {
-    cursor: grabbing;
+.form-input:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px rgba(59, 130, 246, .12);
 }
 
-.drag-dots {
-    width: 14px;
-    height: 18px;
-    display: grid;
-    grid-template-columns: repeat(2, 4px);
-    grid-template-rows: repeat(3, 4px);
-    gap: 3px;
-}
-
-.drag-dots span {
-    width: 4px;
-    height: 4px;
-    background: #9ca3af;
-    border-radius: 50%;
-}
-
-
-
-/* 상태 컬럼 중앙 정렬 */
-.orgcat-table th.col-status,
-.orgcat-table td.col-status {
-    text-align: center;
-    vertical-align: middle;
+/* 도움말 / 에러 */
+.form-help {
+    margin-top: 6px;
+    font-size: 13px;
+    color: var(--danger-text);
 }
 
 /* =========================
-   상태 / 관리 컬럼 완전 중앙 정렬 (FIX)
+   토글 (사용여부)
 ========================= */
 
-/* 상태 컬럼 */
-.orgcat-table th.col-status,
-.orgcat-table td.col-status {
-    text-align: center;
-}
-
-
-/* 관리 컬럼 */
-.orgcat-table th.col-action,
-.orgcat-table td.col-action {
-    text-align: center;
-}
-
-/* =========================
-   테이블 셀 중앙 정렬
-========================= */
-
-.cell-center {
+.toggle-row {
     display: flex;
-    align-items: center;      /* 세로 중앙 */
-    justify-content: center;  /* 가로 중앙 */
-    height: 100%;
+    align-items: center;
+    gap: 12px;
+}
+
+/* 스위치 */
+.switch {
+    position: relative;
+    width: 44px;
+    height: 24px;
+}
+
+.switch input {
+    display: none;
+}
+
+.slider {
+    position: absolute;
+    inset: 0;
+    background: #e5e7eb;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: .2s;
+}
+
+.slider::before {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: .2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,.2);
+}
+
+.switch input:checked + .slider {
+    background: var(--primary);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(20px);
+}
+
+.toggle-text {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--neutral-700);
 }
 
 /* =========================
-   테이블 행 높이 통일 (board 기준)
+   하단 액션
 ========================= */
 
-.orgcat-table tbody td {
-    height: 52px;              /* board-table td와 동일 */
-    padding: 14px 16px;        /* 이미 동일하지만 명시 */
-    vertical-align: middle;
-    box-sizing: border-box;
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 28px 24px;
+    border-top: 1px solid var(--line);
+}
+
+/* 취소 버튼 */
+.btn-ghost {
+    background: #fff;
+    border: 1px solid var(--line);
+    color: var(--neutral-700);
+}
+
+.btn-ghost:hover {
+    background: #f9fafb;
+}
+
+/* 입력 하단 메타 정보 */
+.input-meta {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #2563eb;       /* 파란 강조 */
+    text-align: right;
+
 }

--- a/src/main/resources/static/css/admin-org-category.css
+++ b/src/main/resources/static/css/admin-org-category.css
@@ -617,3 +617,74 @@
     text-align: right;
 
 }
+
+/* =========================
+   Inactive Toggle (Checkbox)
+========================= */
+
+.inactive-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 14px;
+    color: var(--neutral-700);
+}
+
+/* 기본 checkbox 숨김 */
+.inactive-toggle input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* 커스텀 박스 */
+.inactive-toggle .checkmark {
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    border: 1.6px solid #cbd5f5;
+    background: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: all .2s ease;
+}
+
+/* 체크 아이콘 */
+.inactive-toggle .checkmark::after {
+    content: '';
+    width: 5px;
+    height: 9px;
+    border: solid #fff;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+    opacity: 0;
+}
+
+/* 체크 상태 */
+.inactive-toggle input:checked + .checkmark {
+    background: var(--primary);
+    border-color: var(--primary);
+}
+
+.inactive-toggle input:checked + .checkmark::after {
+    opacity: 1;
+}
+
+/* hover */
+.inactive-toggle:hover .checkmark {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px var(--primary-weak);
+}
+
+/* 텍스트 */
+.inactive-toggle .label-text {
+    font-weight: 500;
+}
+
+.inactive-toggle small {
+    font-size: 12px;
+    color: #9ca3af;
+}

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -3,7 +3,7 @@
 ================================ */
 body {
     margin: 0;
-    font-family: 'Noto Sans KR', sans-serif;
+    /*font-family: 'Noto Sans KR', sans-serif;*/
     background: #f9fafb;
     color: #111827;
 }

--- a/src/main/resources/static/js/admin-org-category.js
+++ b/src/main/resources/static/js/admin-org-category.js
@@ -192,17 +192,26 @@ function renderRow(category) {
     const isActive = normalizeActive(category);
 
     tr.innerHTML = `
-      <td>
+      <td class="col-order">
         ${isActive && !isSearchMode() ? dragHandleHtml() : ''}
       </td>
-      <td><strong>${escapeHtml(category.name)}</strong></td>
-      <td>
-        <span class="status-badge ${isActive ? 'status-active' : 'status-inactive'}">
-          ${isActive ? '활성' : '비활성'}
-        </span>
+
+      <td class="col-name">
+        <strong>${escapeHtml(category.name)}</strong>
       </td>
-      <td>
-        <button class="table-btn" data-edit="${category.id}">수정</button>
+
+      <td class="col-status">
+        <div class="cell-center">
+          <span class="status-badge ${isActive ? 'status-active' : 'status-inactive'}">
+            ${isActive ? '활성' : '비활성'}
+          </span>
+        </div>
+      </td>
+
+      <td class="col-action">
+        <div class="cell-center">
+          <button class="table-btn" data-edit="${category.id}">수정</button>
+        </div>
       </td>
     `;
 

--- a/src/main/resources/static/js/admin-org-category.js
+++ b/src/main/resources/static/js/admin-org-category.js
@@ -34,7 +34,6 @@ const els = {
     toggleText: () => document.getElementById('toggleText'),
     nameHelp: () => document.getElementById('nameHelp'),
 
-    btnCloseModal: () => document.getElementById('btnCloseModal'),
     btnCancel: () => document.getElementById('btnCancel'),
     btnSaveCategory: () => document.getElementById('btnSaveCategory'),
 };
@@ -44,6 +43,7 @@ const els = {
 ====================== */
 document.addEventListener('DOMContentLoaded', () => {
     bindEvents();
+    bindNameCounter();
     loadCategories();
 });
 
@@ -60,7 +60,10 @@ function filterCategories() {
 
     const hint = document.getElementById('orderHint');
     if (hint) {
-        hint.style.display = activeCount > 1 ? 'block' : 'none';
+        hint.style.display =
+            !isSearchMode() && activeCount > 1
+                ? 'block'
+                : 'none';
     }
 
     const searchMode = isSearchMode();
@@ -93,7 +96,6 @@ function bindEvents() {
             filterCategories();
         }
     });
-    els.btnCloseModal()?.addEventListener('click', closeModal);
     els.btnCancel()?.addEventListener('click', closeModal);
     els.btnSaveCategory()?.addEventListener('click', saveCategory);
 
@@ -340,6 +342,11 @@ async function saveCategory() {
         return;
     }
 
+    if (name.length > 50) {
+        els.nameHelp().textContent = '카테고리명은 최대 50자까지 입력 가능합니다.';
+        return;
+    }
+
     const payload = {name, isActive};
 
     const isEdit = !!selectedCategoryId;
@@ -427,4 +434,27 @@ function toggleSaveOrderButton(show) {
     if (!btn) return;
 
     btn.style.display = show ? 'inline-flex' : 'none';
+}
+const MAX_CATEGORY_NAME_LENGTH = 50;
+
+function bindNameCounter() {
+    const input = els.categoryName();
+    const counter = document.getElementById('nameCount');
+
+    if (!input || !counter) return;
+
+    const update = () => {
+        let value = input.value;
+
+        // 혹시라도 초과되면 강제로 잘라냄
+        if (value.length > MAX_CATEGORY_NAME_LENGTH) {
+            value = value.slice(0, MAX_CATEGORY_NAME_LENGTH);
+            input.value = value;
+        }
+
+        counter.textContent = value.length;
+    };
+
+    input.addEventListener('input', update);
+    update(); // 초기 값 반영
 }

--- a/src/main/resources/templates/admin/hr/org-category/list.html
+++ b/src/main/resources/templates/admin/hr/org-category/list.html
@@ -9,6 +9,8 @@
       )}">
 
 <!-- ================= 페이지별 CSS ================= -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap">
+
 <th:block th:fragment="pageCss">
   <link rel="stylesheet" th:href="@{/css/admin-org-category.css}">
 </th:block>
@@ -16,13 +18,13 @@
 <!-- ================= 메인 컨텐츠 ================= -->
 <th:block th:fragment="content">
 
-  <!-- 상단 타이틀 -->
-  <div class="orgcat-title-row">
-    <h1 class="orgcat-title">조직 카테고리 관리</h1>
-  </div>
-
   <!-- 메인 카드 -->
   <section class="orgcat-card">
+
+    <!-- 카드 헤더 (타이틀 영역) -->
+    <div class="orgcat-card-head">
+      <h1 class="orgcat-title">조직 카테고리 관리</h1>
+    </div>
 
     <!-- ================= 상단 유틸 ================= -->
     <div class="orgcat-toolbar">

--- a/src/main/resources/templates/admin/hr/org-category/list.html
+++ b/src/main/resources/templates/admin/hr/org-category/list.html
@@ -141,15 +141,6 @@
             회사별로 조직 카테고리를 추가하고, 비활성화할 수 있습니다.
           </p>
         </div>
-
-        <button
-                class="icon-btn"
-                id="btnCloseModal"
-                type="button"
-                aria-label="닫기"
-        >
-          <i class="fa-solid fa-xmark"></i>
-        </button>
       </div>
 
       <input type="hidden" id="categoryId">
@@ -166,6 +157,11 @@
                   type="text"
                   placeholder="예: 본부 / 팀 / 센터"
           >
+
+          <div class="input-meta">
+            <span id="nameCount">0</span>/50
+          </div>
+
           <p class="form-help" id="nameHelp"></p>
         </div>
 

--- a/src/main/resources/templates/admin/hr/org-category/list.html
+++ b/src/main/resources/templates/admin/hr/org-category/list.html
@@ -55,7 +55,8 @@
         <!-- 비활성 포함 -->
         <label class="inactive-toggle">
           <input type="checkbox" id="includeInactive">
-          <span>비활성 포함</span>
+          <span class="checkmark"></span>
+          <span class="label-text">비활성 포함</span>
           <small>(정렬 제외)</small>
         </label>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #424

## 📝 작업 내용
- 조직 카테고리 관리 화면 UI를 board 디자인 기준으로 통일
- 활성 카테고리만 드래그 앤 드롭 정렬 가능하도록 로직 개선
- `비활성 포함` 조회 시 정렬 기능 및 안내 문구 비활성화 처리
- 상태 컬럼에 공통 상태 배지 디자인 적용 (활성 / 비활성)
- 카테고리명 입력 필드에 글자 수 카운트 UI 추가 (0/50)
- 카테고리명 최대 50자 초과 입력 차단 (프론트엔드 단에서 즉시 제한)
- 비활성 포함 체크박스를 커스텀 체크박스로 변경하여 색상 및 디자인 통일
- 생성/수정 모달 UI 개선 (여백, 폰트, 토글 스위치, 애니메이션 등)

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/8d5eac2b-fac6-4bca-b606-994bc6aaa37c" />

## 💬 리뷰 요구사항(선택)
