### PR TITLE
Design/#432

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -214,4 +214,16 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
                 where e.organization.id = :orgId
             """)
     List<Long> findEmployeeIdsByOrganizationId(@Param("orgId") Long orgId);
+
+    @Query("""
+                SELECT COUNT(e)
+                FROM Employee e
+                WHERE e.company.id = :companyId
+                  AND e.organization.id = :orgId
+                  AND e.status <> com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.RESIGNED
+            """)
+    long countActiveByOrg(
+            @Param("companyId") Long companyId,
+            @Param("orgId") Long orgId
+    );
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/repository/EmployeeRepository.java
@@ -42,11 +42,34 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     List<Employee> findAllByIdIn(List<Long> ids);
 
-    boolean existsByCompanyIdAndOrganizationIdAndStatusNot(
+    /**
+     * 조직 비활성화 가능 여부 판단용
+     * - ACTIVE 사원이 존재하면 true
+     */
+    boolean existsByCompanyIdAndOrganizationIdAndStatus(
             Long companyId,
             Long organizationId,
             EmployeeStatus status
     );
+
+
+    /**
+     * 조직에 실제 근무 중인 사원이 존재하는지 확인
+     * (조직 비활성화 차단 조건)
+     */
+    @Query("""
+            select count(e) > 0
+            from Employee e
+            where e.company.id = :companyId
+            and e.organization.id = :orgId
+            and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
+                    """)
+    boolean existsActiveEmployeeInOrg(
+            @Param("companyId") Long companyId,
+            @Param("orgId") Long orgId
+    );
+
+
 
     /**
      * 회사 ID + 이름, 사번 또는 이메일로 사원 검색
@@ -81,15 +104,15 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
 
     @Query("""
-                select e
-                from Employee e
-                join e.positionCategory pc
-                join e.organization o
-                where o.id = :organizationId
-                  and pc.orgCategory.id = :orgCategoryId
-                  and pc.isHead = true
-                  and pc.isActive = true
-                  and e.status = "ACTIVE"
+                        select e
+                        from Employee e
+                        join e.positionCategory pc
+                        join e.organization o
+                        where o.id = :organizationId
+                          and pc.orgCategory.id = :orgCategoryId
+                          and pc.isHead = true
+                          and pc.isActive = true
+                          and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
             """)
     Optional<Employee> findHeadByOrganizationAndOrgCategory(
             @Param("organizationId") Long organizationId,
@@ -104,7 +127,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
                 where e.id = :employeeId
                   and o.id = :organizationId
                   and pc.id = :positionCategoryId
-                  and e.status = "ACTIVE"
+                  and e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
                   and pc.isActive = true
             """)
     boolean existsInOrgAndPositionCategory(
@@ -220,9 +243,9 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
                 FROM Employee e
                 WHERE e.company.id = :companyId
                   AND e.organization.id = :orgId
-                  AND e.status <> com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.RESIGNED
+                  AND e.status = com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus.ACTIVE
             """)
-    long countActiveByOrg(
+    long countActiveEmployeesByOrg(
             @Param("companyId") Long companyId,
             @Param("orgId") Long orgId
     );

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/repository/OrgPositionUsageRepository.java
@@ -35,4 +35,9 @@ public interface OrgPositionUsageRepository extends JpaRepository<OrgPositionUsa
 """)
     List<OrgPositionUsage> findAllUsagesByOrgId(Long orgId);
 
+    boolean existsByCompanyIdAndOrganizationIdAndPositionCategoryId(Long companyId, Long id, Long positionCategoryId);
+
+    void deleteByCompany_IdAndOrganization_IdAndPositionCategory_IdIn(Long companyId, Long id, List<Long> list);
+
+    List<OrgPositionUsage> findByCompany_IdAndOrganization_Id(Long companyId, Long id);
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgPositionUsage/service/OrgPositionUsageService.java
@@ -18,7 +18,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 조직별 직책 사용 정책 서비스 (화이트리스트)
@@ -54,6 +57,7 @@ public class OrgPositionUsageService {
     }
 
     /* ================= 저장 (덮어쓰기) ================= */
+    @Transactional
     public void updatePolicy(
             Long companyId,
             OrgPositionPolicyUpdateReqDto request
@@ -61,23 +65,41 @@ public class OrgPositionUsageService {
         Company company = getCompany(companyId);
         Organization org = getActiveOrg(companyId, request.getOrgId());
 
-        List<Long> categoryIds = request.getPositionCategoryIds();
+        List<Long> requestedIds = request.getPositionCategoryIds();
 
-        // 중복 ID 검증
-        long distinctCount = categoryIds.stream().distinct().count();
-        if (distinctCount != categoryIds.size()) {
+        // 중복 검증
+        if (requestedIds.size() != requestedIds.stream().distinct().count()) {
             throw new InvalidRequestException("중복된 직책 카테고리가 포함되어 있습니다.");
         }
 
+        // 기존 정책 조회
+        List<OrgPositionUsage> existingUsages =
+                repository.findByCompany_IdAndOrganization_Id(companyId, org.getId());
 
-        // 기존 정책 전부 삭제 (화이트리스트 리셋)
-        repository.deleteByCompany_IdAndOrganization_Id(
-                companyId,
-                org.getId()
-        );
+        Set<Long> existingIds = existingUsages.stream()
+                .map(u -> u.getPositionCategory().getId())
+                .collect(Collectors.toSet());
 
-        // 신규 정책 등록
-        for (Long positionCategoryId : categoryIds) {
+        Set<Long> requestedSet = new HashSet<>(requestedIds);
+
+        // diff 계산
+        Set<Long> toAdd = new HashSet<>(requestedSet);
+        toAdd.removeAll(existingIds);
+
+        Set<Long> toRemove = new HashSet<>(existingIds);
+        toRemove.removeAll(requestedSet);
+
+        // 삭제 (빠진 것만)
+        if (!toRemove.isEmpty()) {
+            repository.deleteByCompany_IdAndOrganization_IdAndPositionCategory_IdIn(
+                    companyId,
+                    org.getId(),
+                    toRemove.stream().toList()
+            );
+        }
+
+        // 추가 (새로 들어온 것만)
+        for (Long positionCategoryId : toAdd) {
 
             PositionCategory category =
                     positionCategoryRepository.findById(positionCategoryId)
@@ -90,23 +112,23 @@ public class OrgPositionUsageService {
                 throw new ForbiddenException("해당 회사의 직책 카테고리가 아닙니다.");
             }
 
-            // 활성 여부 검증
+            // 활성 검증
             if (!Boolean.TRUE.equals(category.getIsActive())) {
                 throw new InvalidStateException("비활성 직책 카테고리는 정책에 포함할 수 없습니다.");
             }
 
-            // 조직 카테고리 일치 검증
-//            if (!category.getOrgCategory().getId().equals(org.getCategoryId())) {
-//                throw new InvalidStateException(
-//                        "해당 조직 유형에서 사용할 수 없는 직책 카테고리입니다."
-//                );
-//            }
+            // 멱등성 보호 (동시 요청 대비)
+            if (repository.existsByCompanyIdAndOrganizationIdAndPositionCategoryId(
+                    companyId, org.getId(), positionCategoryId)) {
+                continue;
+            }
 
             repository.save(
                     OrgPositionUsage.create(company, org, category)
             );
         }
     }
+
 
     /* ================= 내부 ================= */
     private Company getCompany(Long companyId) {

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/controller/OrgController.java
@@ -76,6 +76,35 @@ public class OrgController {
         );
     }
 
+    @GetMapping("/trees")
+    public ResponseEntity<ResponseDto<List<OrgAdminResDto>>> listOrSearchForAdmin(
+            @RequestParam(defaultValue = "false") boolean includeInactive,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean includeDescendants
+    ) {
+        Long companyId = SecurityUtils.getCompanyId();
+
+        // 검색어 없으면 기존 목록
+        if (keyword == null || keyword.isBlank()) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            HttpStatus.OK,
+                            "조직 목록 조회",
+                            orgService.findAllForAdmin(companyId, includeInactive)
+                    )
+            );
+        }
+
+        // 검색어 있으면 검색
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        HttpStatus.OK,
+                        "조직 검색 결과 조회",
+                        orgService.searchForAdmin(companyId, keyword, includeInactive, includeDescendants)
+                )
+        );
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<ResponseDto<Void>> update(
             @PathVariable Long id,

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgAdminResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/dto/OrgAdminResDto.java
@@ -1,0 +1,44 @@
+package com.finalproj.orbitflow.hr.organization.dto;
+
+import com.finalproj.orbitflow.hr.organization.entity.Organization;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : OrgAdminResDto
+ * @since : 2026-01-08 목요일
+ */
+@Getter
+@AllArgsConstructor
+public class OrgAdminResDto {
+
+    private Long id;
+    private Long categoryId;
+    private Long parentOrgId;
+    private String name;
+    private Integer orderIndex;
+    private Boolean isActive;
+
+    private Long employeeCount;     // 소속 사원 수
+    private Long childOrgCount;     // 직계 하위 조직 수
+
+    public static OrgAdminResDto from(
+            Organization o,
+            long employeeCount,
+            long childOrgCount
+    ) {
+        return new OrgAdminResDto(
+                o.getId(),
+                o.getCategoryId(),
+                o.getParentOrgId(),
+                o.getName(),
+                o.getOrderIndex(),
+                o.getIsActive(),
+                employeeCount,
+                childOrgCount
+        );
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -93,6 +93,23 @@ public class OrgService {
     }
 
     @Transactional(readOnly = true)
+    public List<OrgAdminResDto> findAllForAdmin(Long companyId, boolean includeInactive) {
+
+        List<Organization> orgs = includeInactive
+                ? orgRepository.findByCompanyIdOrderByIsActiveDescParentOrgIdAscOrderIndexAsc(companyId)
+                : orgRepository.findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(companyId);
+
+        return orgs.stream()
+                .map(o -> OrgAdminResDto.from(
+                        o,
+                        employeeRepository.countActiveByOrg(companyId, o.getId()),
+                        orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, o.getId())
+                ))
+                .toList();
+    }
+
+
+    @Transactional(readOnly = true)
     public List<OrgResDto> search(
             Long companyId,
             String keyword,
@@ -144,6 +161,65 @@ public class OrgService {
         return baseList.stream()
                 .filter(o -> resultIds.contains(o.getId()))
                 .map(OrgResDto::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrgAdminResDto> searchForAdmin(
+            Long companyId,
+            String keyword,
+            boolean includeInactive,
+            boolean includeDescendants
+    ) {
+        String normalized = keyword.trim().toLowerCase();
+
+        // 기준 데이터 로딩
+        List<Organization> baseList = includeInactive
+                ? orgRepository.findByCompanyIdOrderByIsActiveDescParentOrgIdAscOrderIndexAsc(companyId)
+                : orgRepository.findByCompanyIdAndIsActiveTrueOrderByParentOrgIdAscOrderIndexAsc(companyId);
+
+        // 빠른 탐색용 Map
+        var orgMap = baseList.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Organization::getId,
+                        o -> o
+                ));
+
+        // 검색 히트 조직
+        var matched = baseList.stream()
+                .filter(o -> o.getName().toLowerCase().contains(normalized))
+                .toList();
+
+        java.util.Set<Long> resultIds = new java.util.HashSet<>();
+
+        for (Organization org : matched) {
+
+            // 2-1) 자기 자신
+            resultIds.add(org.getId());
+
+            // 2-2) 부모 체인 포함
+            Long cursor = org.getParentOrgId();
+            while (cursor != null) {
+                Organization parent = orgMap.get(cursor);
+                if (parent == null) break;
+                resultIds.add(parent.getId());
+                cursor = parent.getParentOrgId();
+            }
+
+            // 2-3) 하위 조직 포함 (옵션)
+            if (includeDescendants) {
+                collectDescendants(org.getId(), orgMap, resultIds);
+            }
+        }
+
+        // 결과 DTO 변환 (관리자용: 사원 수 + 하위 조직 수 포함)
+        return baseList.stream()
+                .filter(o -> resultIds.contains(o.getId()))
+                .map(o -> OrgAdminResDto.from(
+                        o,
+                        employeeRepository.countActiveByOrg(companyId, o.getId()),
+                        orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, o.getId())
+                ))
                 .toList();
     }
 

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -5,7 +5,6 @@ import com.finalproj.orbitflow.global.exception.ForbiddenException;
 import com.finalproj.orbitflow.global.exception.InvalidRequestException;
 import com.finalproj.orbitflow.global.exception.InvalidStateException;
 import com.finalproj.orbitflow.global.exception.NotFoundException;
-import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
@@ -102,7 +101,7 @@ public class OrgService {
         return orgs.stream()
                 .map(o -> OrgAdminResDto.from(
                         o,
-                        employeeRepository.countActiveByOrg(companyId, o.getId()),
+                        employeeRepository.countActiveEmployeesByOrg(companyId, o.getId()),
                         orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, o.getId())
                 ))
                 .toList();
@@ -217,7 +216,7 @@ public class OrgService {
                 .filter(o -> resultIds.contains(o.getId()))
                 .map(o -> OrgAdminResDto.from(
                         o,
-                        employeeRepository.countActiveByOrg(companyId, o.getId()),
+                        employeeRepository.countActiveEmployeesByOrg(companyId, o.getId()),
                         orgRepository.countByCompanyIdAndParentOrgIdAndIsActiveTrue(companyId, o.getId())
                 ))
                 .toList();
@@ -244,6 +243,14 @@ public class OrgService {
     /* ================= 수정 ================= */
     public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
 
+        log.info(
+                "[ORG UPDATE] orgId={}, req.isActive={}, req.parentOrgId={}, req.name={}",
+                organizationId,
+                request.getIsActive(),
+                request.getParentOrgId(),
+                request.getName()
+        );
+
         Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
         String oldName = org.getName();
 
@@ -252,7 +259,7 @@ public class OrgService {
         Boolean reqActive = request.getIsActive();
 
         // 비활성화 요청 처리
-        if (Boolean.FALSE.equals(reqActive) && Boolean.TRUE.equals(org.getIsActive())) {
+        if (Boolean.FALSE.equals(reqActive) && !Boolean.FALSE.equals(org.getIsActive())) {
             deactivateInternal(companyId, org);
             return;
         }
@@ -449,17 +456,21 @@ public class OrgService {
             throw new InvalidStateException("하위 조직이 존재하여 비활성화할 수 없습니다.");
         }
 
-        if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
-                companyId, organizationId, EmployeeStatus.RESIGNED)) {
-            throw new InvalidStateException("재직 중인 사원이 존재하여 비활성화할 수 없습니다.");
+        if (employeeRepository.existsActiveEmployeeInOrg(companyId, organizationId)) {
+            throw new InvalidStateException("ACTIVE 사원이 존재하는 조직은 비활성화할 수 없습니다.");
         }
 
         orgPositionUsageRepository
                 .deleteByCompany_IdAndOrganization_Id(companyId, organizationId);
 
+        log.info("[ORG DEACTIVATE] before org.deactivate() id={}", organizationId);
         org.deactivate();
+        log.info("[ORG DEACTIVATE] after org.deactivate() id={}", organizationId);
+
         organizationBoardCategorySyncService.
                 deactivateBoard(companyId, organizationId);
+        log.info("[ORG DEACTIVATE] after deactivateBoard id={}", organizationId);
+
     }
 
 
@@ -475,11 +486,10 @@ public class OrgService {
         }
 
         // 재직 중 사원 존재
-        if (employeeRepository.existsByCompanyIdAndOrganizationIdAndStatusNot(
-                companyId, orgId, EmployeeStatus.RESIGNED)) {
+        if (employeeRepository.existsActiveEmployeeInOrg(companyId, orgId)) {
             return new OrgDeactivateCheckResDto(
                     false,
-                    "재직 중인 사원이 존재하여 비활성화할 수 없습니다."
+                    "재직중인 사원이 존재하여 비활성화할 수 없습니다."
             );
         }
 

--- a/src/main/resources/static/css/admin-organization.css
+++ b/src/main/resources/static/css/admin-organization.css
@@ -315,3 +315,57 @@
     font-size: 13.5px;
     border-radius: 8px;
 }
+
+
+/* ==================================================
+   조직 트리 - 사원 수 / 하위 조직 수 UI (ADD-ON)
+   ※ 기존 admin-organization.css 아래에 그대로 추가
+================================================== */
+
+/* 조직명 + (하위 조직 수) */
+.org-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* (하위 조직 수) */
+.org-label .org-meta-item {
+    font-size: 12px;
+    font-weight: 700;
+    color: #9ca3af;
+}
+
+/* 우측 메타 영역 (사원 수) */
+.org-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 6px;
+    font-size: 12px;
+    color: #6b7280;
+    white-space: nowrap;
+}
+
+/* 메타 pill */
+.org-meta-item {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #f3f4f6;
+    font-weight: 600;
+}
+
+/* 비활성 조직 메타 흐리게 */
+.org-node[data-active="false"] .org-meta-item {
+    background: #f9fafb;
+    color: #9ca3af;
+}
+
+/* 모바일에서는 메타 숨김 */
+@media (max-width: 720px) {
+    .org-meta {
+        display: none;
+    }
+}

--- a/src/main/resources/static/css/admin-organization.css
+++ b/src/main/resources/static/css/admin-organization.css
@@ -1,42 +1,49 @@
 /* ==================================================
-   admin-organization.css (FINAL – PRODUCTION)
-   - admin-org-category.css 위에 덮어쓰는 조직 트리 전용 스타일
-   - DIV 기반 트리 + 토글 + 정렬 모드 대응
+   admin-organization.css (FINAL – SAFE)
 ================================================== */
 
-/* ===== 트리 컨테이너 ===== */
+/* ================= 조직 트리 ================= */
+
 #orgTree {
     display: flex;
     flex-direction: column;
-    gap: 2px;
 }
 
-/* ===== 조직 노드 ===== */
+.org-tree {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: #fff;
+    padding: 6px 0;
+}
+
 .org-node {
+    position: relative;
     user-select: none;
 }
 
+/* row */
 .org-row {
     display: flex;
     align-items: center;
     gap: 8px;
-    min-height: 46px;
-    padding: 6px 12px;
-    border-radius: 10px;
+
+    min-height: 52px;
+    padding: 6px 16px;
+
     transition: background .12s ease;
 }
 
 .org-row:hover {
-    background: #f6f8fc;
+    background: #f9fafb;
 }
 
-/* ===== 드래그 핸들 ===== */
+/* drag */
 .org-row .drag-handle {
     flex-shrink: 0;
     margin-right: 2px;
 }
 
-/* ===== 토글 ===== */
+/* toggle */
 .org-toggle {
     width: 18px;
     height: 18px;
@@ -58,10 +65,9 @@
 .org-toggle-placeholder {
     width: 18px;
     height: 18px;
-    display: inline-block;
 }
 
-/* ===== 조직명 ===== */
+/* label */
 .org-label {
     flex: 1;
     font-size: 13.5px;
@@ -72,21 +78,16 @@
     text-overflow: ellipsis;
 }
 
-/* ===== 상태 배지 보정 ===== */
+/* status / action */
 .org-row .status-badge {
     margin-left: auto;
 }
 
-/* ===== 수정 버튼 위치 안정화 ===== */
 .org-row .table-btn {
     margin-left: 6px;
 }
 
-/* ===== 깊이 표현 ===== */
-.org-node {
-    position: relative;
-}
-
+/* depth line */
 .org-node::before {
     content: "";
     position: absolute;
@@ -97,63 +98,38 @@
     background: #e5e7eb;
 }
 
-/* 루트는 라인 제거 */
 .org-node[data-parent-id="root"]::before {
     display: none;
 }
 
-/* ===== 정렬 모드 ===== */
+/* drag state */
 .sortable-chosen .org-row {
     background: #f2f6ff;
 }
 
 .sortable-ghost {
-    opacity: 0.45;
+    opacity: .45;
 }
 
-.sortable-chosen .org-toggle {
-    pointer-events: none;
-    opacity: 0.4;
-}
-
-
-/* ===== 드래그 중 서브트리 ===== */
 .dragging-subtree .org-row {
     background: #f8fafc;
-    opacity: 0.9;
+    opacity: .9;
 }
 
-/* ===== 비활성 조직 ===== */
-.org-node:not([data-active="true"]) .org-label {
-    color: #98a2b3;
-}
-
-/* 비활성 조직 전체 */
+/* inactive */
 .org-node[data-active="false"] .org-row {
-    opacity: 0.55;
+    opacity: .55;
 }
 
-/* 비활성 조직은 hover도 약하게 */
 .org-node[data-active="false"] .org-row:hover {
     background: transparent;
 }
 
-/* 비활성 조직은 드래그 핸들 숨김 */
 .org-node[data-active="false"] .drag-handle {
     display: none;
 }
 
-/* ===== 반응형 보정 ===== */
-@media (max-width: 720px) {
-    .org-row {
-        padding: 8px 10px;
-    }
-
-    .org-label {
-        font-size: 13px;
-    }
-}
-
+/* focus / highlight */
 .org-focus .org-row {
     background: #fff7ed;
     outline: 2px solid #fdba74;
@@ -165,9 +141,7 @@
     padding: 0 2px;
 }
 
-/* ==================================================
-   조직 생성/수정 - 직책 정책 패널
-================================================== */
+/* ================= 모달 내부 레이아웃 ================= */
 
 .org-modal-grid {
     display: grid;
@@ -175,27 +149,45 @@
     gap: 24px;
 }
 
+/* 반응형 */
+@media (max-width: 720px) {
+    .org-row {
+        padding: 6px 12px;
+    }
+
+    .org-label {
+        font-size: 13px;
+    }
+
+    .org-modal-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ===============================
+   조직 모달 - 직책 사용 정책 UI
+=============================== */
+
 .org-policy-panel {
     padding: 16px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--line);
     border-radius: 12px;
     background: #fafbff;
-    display: flex;
-    flex-direction: column;
 }
 
 .org-policy-panel h3 {
-    font-size: 14px;
-    font-weight: 800;
+    font-size: 15px;
+    font-weight: 700;
     margin-bottom: 4px;
 }
 
 .org-policy-panel p {
-    font-size: 12px;
-    color: #667085;
+    font-size: 13px;
+    color: #6b7280;
     margin-bottom: 12px;
 }
 
+/* 검색 / 필터 */
 .policy-toolbar {
     display: flex;
     gap: 8px;
@@ -204,41 +196,122 @@
 
 .policy-toolbar input,
 .policy-toolbar select {
-    height: 34px;
-    font-size: 12.5px;
+    height: 36px;
+    padding: 0 10px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    font-size: 13px;
 }
 
+/* 테이블 */
 .policy-table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 12.5px;
+    font-size: 13px;
 }
 
-.policy-table th {
+.policy-table thead th {
     text-align: left;
-    color: #667085;
-    font-weight: 700;
-    padding-bottom: 6px;
+    padding: 10px 8px;
+    border-bottom: 1px solid var(--line);
+    color: #6b7280;
+    font-weight: 600;
 }
 
-.policy-table td {
-    padding: 8px 4px;
+.policy-table tbody td {
+    padding: 10px 8px;
+    border-bottom: 1px solid var(--line);
     vertical-align: middle;
 }
 
-.policy-empty {
-    text-align: center;
-    color: #98a2b3;
-    padding: 16px 0;
+.policy-table tbody tr:hover {
+    background: #f9fafb;
 }
 
-.badge-head {
+/* 비활성 직책 안내 */
+.policy-empty,
+.org-policy-panel .form-help {
+    font-size: 12px;
+    color: #9ca3af;
+    margin-top: 8px;
+}
+
+/* ===============================
+   조직 모달 전용 사이즈 확장
+=============================== */
+
+.modal-panel-wide {
+    width: 760px;
+    max-width: 92vw;
+}
+
+/* ===============================
+   정책 토글 (사용 / 미사용)
+=============================== */
+
+.policy-table .switch {
+    position: relative;
     display: inline-block;
-    margin-right: 4px;
-    padding: 2px 8px;
-    font-size: 11px;
-    font-weight: 800;
+    width: 42px;
+    height: 22px;
+}
+
+.policy-table .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.policy-table .slider {
+    position: absolute;
+    inset: 0;
+    background: #e5e7eb;
     border-radius: 999px;
-    background: #eef2ff;
-    color: #3730a3;
+    transition: .2s;
+}
+
+.policy-table .slider::before {
+    content: "";
+    position: absolute;
+    height: 18px;
+    width: 18px;
+    left: 2px;
+    top: 2px;
+    background: #fff;
+    border-radius: 50%;
+    transition: .2s;
+    box-shadow: 0 1px 2px rgba(0,0,0,.15);
+}
+
+.policy-table .switch input:checked + .slider {
+    background: var(--primary);
+}
+
+.policy-table .switch input:checked + .slider::before {
+    transform: translateX(20px);
+}
+
+/* disabled */
+.policy-table .switch input:disabled + .slider {
+    background: #f3f4f6;
+    cursor: not-allowed;
+}
+
+/* ===============================
+   조직 모달 - 입력 필드 너비 통일
+=============================== */
+
+.org-form-panel .form-input,
+.org-form-panel select,
+.org-form-panel input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/* 높이 / 패딩 통일 */
+.org-form-panel .form-input {
+    height: 40px;
+    padding: 0 12px;
+    font-size: 13.5px;
+    border-radius: 8px;
 }

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -61,7 +61,7 @@ async function loadOrganizations() {
     const includeInactive = els.includeInactive().checked;
 
     const res = await apiFetch(
-        `${API_BASE}?includeInactive=${includeInactive}`
+        `${API_BASE}/trees?includeInactive=${includeInactive}`
     );
 
     const json = await res.json();
@@ -130,10 +130,19 @@ function renderNode(org, depth, container) {
             ? `<span class="org-toggle">${isExpanded ? '▾' : '▸'}</span>`
             : `<span class="org-toggle-placeholder"></span>`
     }
-        <span class="org-label">${highlight(org.name, keyword)}</span>
+        <span class="org-label">
+            ${highlight(org.name, keyword)}
+            <span class="org-meta-item" title="하위 조직 수">${org.childOrgCount ?? 0}</span>
+        </span>
+            
+        <span class="org-meta">
+            <span class="org-meta-item" title="소속 사원 수">소속 사원 수: ${org.employeeCount ?? 0}</span>
+        </span>
+        
         <span class="status-badge ${normalizeActive(org) ? 'status-active' : 'status-inactive'}">
             ${normalizeActive(org) ? '활성' : '비활성'}
         </span>
+        
         <button class="table-btn">수정</button>
       </div>
     `;
@@ -306,7 +315,7 @@ async function openEdit(id) {
 
     // 활성 상태일 때만 "비활성화 가능 여부" 체크
     if (normalizeActive(org)) {
-        const res = await apiFetch(`/api/admin/organizations/${id}/deactivate-check`);
+        const res = await apiFetch(`${API_BASE}/${id}/deactivate-check`);
         const json = await res.json();
         const check = json.data;
 
@@ -590,7 +599,7 @@ async function loadOrganizationsWithSearch() {
         params.append('keyword', keyword);
     }
 
-    const res = await apiFetch(`${API_BASE}?${params.toString()}`);
+    const res = await apiFetch(`${API_BASE}/trees?${params.toString()}`);
     const json = await res.json();
 
     allOrgList = json.data || [];

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -42,7 +42,6 @@ const els = {
     orgName: () => document.getElementById('orgName'),
     parentSelect: () => document.getElementById('parentOrgSelect'),
     btnSave: () => document.getElementById('btnSaveOrg'),
-    btnCloseIcon: () => document.getElementById('btnModalCloseIcon'),
     btnCancel: () => document.getElementById('btnModalCancel'),
 };
 
@@ -244,7 +243,6 @@ function bindEvents() {
 
     els.btnCreate().addEventListener('click', openCreate);
     els.btnSaveOrder().addEventListener('click', saveOrder);
-    els.btnCloseIcon().addEventListener('click', closeModal);
     els.btnCancel().addEventListener('click', closeModal);
     els.btnSave().addEventListener('click', saveOrg);
 }

--- a/src/main/resources/templates/admin/hr/organization/list.html
+++ b/src/main/resources/templates/admin/hr/organization/list.html
@@ -16,36 +16,51 @@
 
 <th:block th:fragment="content">
 
-    <div class="orgcat-title-row">
-        <h1 class="orgcat-title">조직 관리</h1>
-    </div>
-
+    <!-- ================= 메인 카드 ================= -->
     <section class="orgcat-card">
 
+        <!-- 카드 헤더 -->
+        <div class="orgcat-card-head">
+            <h1 class="orgcat-title">조직 관리</h1>
+        </div>
+
+        <!-- ================= 툴바 ================= -->
         <div class="orgcat-toolbar">
             <div class="toolbar-left">
+
                 <div class="orgcat-search">
                     <i class="fa-solid fa-magnifying-glass"></i>
-                    <input id="searchKeyword" type="text" placeholder="조직명 검색 (예: 팀)">
+                    <input id="searchKeyword"
+                           type="text"
+                           placeholder="조직명 검색 (예: 팀)">
                 </div>
+
                 <button class="btn btn-outline" id="btnSearch">검색</button>
+
                 <label class="inactive-toggle">
                     <input type="checkbox" id="includeInactive">
-                    <span>비활성 포함</span>
+                    <span class="checkmark"></span>
+                    <span class="label-text">비활성 포함</span>
                 </label>
+
                 <label class="inactive-toggle">
                     <input type="checkbox" id="includeDescendants">
-                    <span>하위 조직 함께 보기</span>
+                    <span class="checkmark"></span>
+                    <span class="label-text">하위 조직 함께 보기</span>
                 </label>
             </div>
 
             <div class="toolbar-right">
-                <button class="btn btn-primary" id="btnOpenCreate">조직 추가</button>
+                <button class="btn btn-primary" id="btnOpenCreate">
+                    조직 추가
+                </button>
             </div>
         </div>
 
+        <!-- ================= 조직 트리 ================= -->
         <div class="org-tree" id="orgTree"></div>
 
+        <!-- ================= 하단 ================= -->
         <div class="orgcat-footer">
             <div class="orgcat-hint">
                 같은 상위 조직 내에서만 순서를 변경할 수 있습니다.
@@ -57,85 +72,94 @@
 
     </section>
 
-    <!-- 조직 생성 / 수정 모달 -->
+    <!-- ================= 조직 생성 / 수정 모달 ================= -->
     <div id="orgModal" class="modal hidden">
-        <div class="modal-panel">
+        <div class="modal-panel modal-panel-wide">
 
+            <!-- 모달 헤더 -->
             <div class="modal-head">
-                <h2 id="modalTitle">조직 생성 / 수정</h2>
-                <button class="icon-btn" id="btnModalCloseIcon">
-                    <i class="fa-solid fa-xmark"></i>
-                </button>
+                <div class="modal-head-text">
+                    <h2 id="modalTitle">조직 생성 / 수정</h2>
+                    <p class="modal-sub">조직 정보와 직책 사용 정책을 설정합니다.</p>
+                </div>
             </div>
 
-            <div class="modal-body org-modal-grid">
-                <!-- ================= 좌측: 조직 정보 (기존 코드 그대로) ================= -->
-                <div class="org-form-panel">
-                    <div class="form-group">
-                        <label class="form-label">조직 카테고리</label>
-                        <select id="categorySelect" class="form-input"></select>
+            <!-- modal-body는 grid 금지 -->
+            <div class="modal-body">
+                <div class="org-modal-grid">
+
+                    <!-- 좌측: 조직 정보 -->
+                    <div class="org-form-panel">
+
+                        <div class="form-group">
+                            <label class="form-label">조직 카테고리</label>
+                            <select id="categorySelect" class="form-input"></select>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="form-label">조직명</label>
+                            <input id="orgName"
+                                   class="form-input"
+                                   type="text"
+                                   placeholder="예: 인사팀">
+                        </div>
+
+                        <div class="form-group">
+                            <label class="form-label">상위 조직</label>
+                            <select id="parentOrgSelect" class="form-input"></select>
+                        </div>
+
+                        <div class="form-group toggle-row">
+                            <span class="toggle-text">사용 여부</span>
+                            <label class="switch">
+                                <input type="checkbox" id="activeToggle">
+                                <span class="slider"></span>
+                            </label>
+                            <span id="activeLabel">사용</span>
+                        </div>
+
+                        <p class="form-help" id="inactiveHelp" style="display:none;">
+                            비활성화하려면 해당 조직에 소속된 사원이 없어야 합니다.
+                        </p>
+
                     </div>
 
-                    <div class="form-group">
-                        <label class="form-label">조직명</label>
-                        <input id="orgName" class="form-input" type="text" placeholder="예: 인사팀">
-                    </div>
+                    <!-- 우측: 직책 정책 -->
+                    <section class="org-policy-panel">
 
-                    <div class="form-group">
-                        <label class="form-label">상위 조직</label>
-                        <select id="parentOrgSelect" class="form-input"></select>
-                    </div>
+                        <h3>직책 사용 정책</h3>
+                        <p>이 조직에서 사용할 직책을 선택하세요.</p>
 
-                    <div class="form-group toggle-row">
-                        <span class="toggle-text">사용 여부</span>
-                        <label class="switch">
-                            <input type="checkbox" id="activeToggle">
-                            <span class="slider"></span>
-                        </label>
-                        <span id="activeLabel">사용</span>
-                    </div>
+                        <div class="policy-toolbar">
+                            <input id="policyKeyword" placeholder="직책명 검색">
+                            <select id="policyHeadFilter">
+                                <option value="">전체</option>
+                                <option value="HEAD">HEAD</option>
+                                <option value="NORMAL">일반</option>
+                            </select>
+                        </div>
 
-                    <div class="form-help" id="inactiveHelp" style="display:none;">
-                        비활성화하려면 해당 조직에 소속된 사원이 없어야 합니다.
-                    </div>
+                        <table class="policy-table">
+                            <thead>
+                            <tr>
+                                <th>직책명</th>
+                                <th>부여 인원</th>
+                                <th>사용</th>
+                            </tr>
+                            </thead>
+                            <tbody id="policyTableBody"></tbody>
+                        </table>
+
+                        <p class="form-help">
+                            비활성 직책은 선택할 수 없습니다.
+                        </p>
+
+                    </section>
 
                 </div>
-
-                <!-- ================= 우측: 직책 정책 ================= -->
-                <section class="org-policy-panel">
-
-                    <h3>직책 사용 정책</h3>
-                    <p>이 조직에서 사용할 직책을 선택하세요.</p>
-
-                    <div class="policy-toolbar">
-                        <input id="policyKeyword" placeholder="직책명 검색">
-                        <select id="policyHeadFilter">
-                            <option value="">전체</option>
-                            <option value="HEAD">HEAD</option>
-                            <option value="NORMAL">일반</option>
-                        </select>
-                    </div>
-
-                    <table class="policy-table">
-                        <thead>
-                        <tr>
-                            <th>직책명</th>
-                            <th>부여 인원</th>
-                            <th>사용</th>
-                        </tr>
-                        </thead>
-                        <tbody id="policyTableBody">
-                        <!-- JS 렌더링 -->
-                        </tbody>
-                    </table>
-
-                    <div class="form-help">
-                        비활성 직책은 선택할 수 없습니다.
-                    </div>
-
-                </section>
             </div>
 
+            <!-- 모달 하단 -->
             <div class="modal-actions">
                 <button class="btn btn-ghost" id="btnModalCancel">취소</button>
                 <button class="btn btn-primary" id="btnSaveOrg">저장</button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #432

## 📝 작업 내용
- **조직 관리 관련 UI/디자인 전반 개선**
    - 조직/카테고리 관리 화면 레이아웃 정리
    - 타이틀, 카드 영역, 상태 배지 등 디자인 통일
    - 관리자 화면에서 활성/비활성 조직 구분 가시성 개선
- **조직 비활성화 기준 로직 정리**
    - 조직 비활성화 시 판단 기준을 **사원 상태 `ACTIVE` 기준으로 통일**
    - `TEMP`, `SUSPENDED` 등 비재직 상태 사원은 비활성화 차단 조건에서 제외
    - “조직을 막는 존재”의 정의를 **실제 재직 중(= ACTIVE) 사원 존재 여부**로 명확화
- **조직 목록/관리 화면 카운트 기준 정합성 정리**
    - 조직별 사원 수, 하위 조직 수 집계 시 `ACTIVE` 기준으로 계산
    - 비활성 조직 및 비재직 사원이 카운트에 영향을 주지 않도록 정리

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
