### PR TITLE
Design/#452

### DIFF
--- a/sql/insert.sql
+++ b/sql/insert.sql
@@ -499,6 +499,32 @@ SET @c1_pos_tm := (SELECT id
                      AND name = '팀원'
                    LIMIT 1);
 
+-- 팀원의 상위 → 팀장
+UPDATE position_category
+SET parent_position_id = @c1_pos_tl
+WHERE id = @c1_pos_tm;
+
+-- 팀장의 상위 → 부장
+UPDATE position_category
+SET parent_position_id = @c1_pos_dept
+WHERE id = @c1_pos_tl;
+
+-- 부장의 상위 → 본부장
+UPDATE position_category
+SET parent_position_id = @c1_pos_hq
+WHERE id = @c1_pos_dept;
+
+-- 본부장의 상위 → 사장
+UPDATE position_category
+SET parent_position_id = @c1_pos_ceo
+WHERE id = @c1_pos_hq;
+
+-- 사장은 최상위
+UPDATE position_category
+SET parent_position_id = NULL
+WHERE id = @c1_pos_ceo;
+
+
 -- ORG_POSITION_USAGE (Ignore로 재실행 안전)
 INSERT IGNORE INTO org_position_usage (company_id, org_id, position_category_id, created_at, updated_at)
 SELECT @c1,
@@ -1116,6 +1142,33 @@ SET @c2_pos_tm := (SELECT id
                      AND name = '팀원'
                    LIMIT 1);
 
+
+-- 팀원의 상위 → 팀장
+UPDATE position_category
+SET parent_position_id = @c2_pos_tl
+WHERE id = @c2_pos_tm;
+
+-- 팀장의 상위 → 부장
+UPDATE position_category
+SET parent_position_id = @c2_pos_dept
+WHERE id = @c2_pos_tl;
+
+-- 부장의 상위 → 본부장
+UPDATE position_category
+SET parent_position_id = @c2_pos_hq
+WHERE id = @c2_pos_dept;
+
+-- 본부장의 상위 → 사장
+UPDATE position_category
+SET parent_position_id = @c2_pos_ceo
+WHERE id = @c2_pos_hq;
+
+-- 사장은 최상위
+UPDATE position_category
+SET parent_position_id = NULL
+WHERE id = @c2_pos_ceo;
+
+
 INSERT IGNORE INTO org_position_usage (company_id, org_id, position_category_id, created_at, updated_at)
 SELECT @c2,
        o.id,
@@ -1689,6 +1742,33 @@ SET @c3_pos_tm := (SELECT id
                      AND org_category_id = @c3_cat_team
                      AND name = '팀원'
                    LIMIT 1);
+
+
+-- 팀원의 상위 → 팀장
+UPDATE position_category
+SET parent_position_id = @c3_pos_tl
+WHERE id = @c3_pos_tm;
+
+-- 팀장의 상위 → 부장
+UPDATE position_category
+SET parent_position_id = @c3_pos_dept
+WHERE id = @c3_pos_tl;
+
+-- 부장의 상위 → 본부장
+UPDATE position_category
+SET parent_position_id = @c3_pos_hq
+WHERE id = @c3_pos_dept;
+
+-- 본부장의 상위 → 사장
+UPDATE position_category
+SET parent_position_id = @c3_pos_ceo
+WHERE id = @c3_pos_hq;
+
+-- 사장은 최상위
+UPDATE position_category
+SET parent_position_id = NULL
+WHERE id = @c3_pos_ceo;
+
 
 INSERT IGNORE INTO org_position_usage (company_id, org_id, position_category_id, created_at, updated_at)
 SELECT @c3,

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/controller/PositionCategoryController.java
@@ -2,8 +2,9 @@ package com.finalproj.orbitflow.hr.positionCategory.controller;
 
 import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryCreateReqDto;
 import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryReqDto;
+import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryUpdateReqDto;
 import com.finalproj.orbitflow.hr.positionCategory.service.PositionCategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class PositionCategoryController {
 
     @PostMapping
     public ResponseEntity<ResponseDto> create(
-            @RequestBody @Valid PositionCategoryReqDto request
+            @RequestBody @Valid PositionCategoryCreateReqDto request
     ) {
         return ResponseEntity.ok(
                 new ResponseDto(
@@ -59,7 +60,7 @@ public class PositionCategoryController {
     @PutMapping("/{id}")
     public ResponseEntity<ResponseDto> update(
             @PathVariable Long id,
-            @RequestBody @Valid PositionCategoryReqDto request
+            @RequestBody @Valid PositionCategoryUpdateReqDto request
     ) {
         positionCategoryService.update(SecurityUtils.getCompanyId(), id, request);
 

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryCreateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryCreateReqDto.java
@@ -1,0 +1,31 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryCreateReqDto
+ * @since : 2026-01-09 금요일
+ */
+@Getter
+@NoArgsConstructor
+public class PositionCategoryCreateReqDto {
+
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    @NotNull
+    private Long orgCategoryId;
+
+    private Long parentPositionId;
+
+    @NotNull
+    private Boolean isHead;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryUpdateReqDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/dto/PositionCategoryUpdateReqDto.java
@@ -1,0 +1,26 @@
+package com.finalproj.orbitflow.hr.positionCategory.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : PositionCategoryUpdateReqDto
+ * @since : 2026-01-09 금요일
+ */
+@Getter
+@NoArgsConstructor
+public class PositionCategoryUpdateReqDto {
+
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    @NotNull
+    private Boolean isActive;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/repository/PositionCategoryRepository.java
@@ -49,9 +49,6 @@ public interface PositionCategoryRepository extends JpaRepository<PositionCatego
     /* 목록 */
     List<PositionCategory> findByCompanyIdAndIsActiveTrueOrderByOrderIndexAsc(Long companyId);
 
-    /* 중복 */
-    boolean existsByCompanyIdAndName(Long companyId, String name);
-
     boolean existsByCompanyIdAndNameAndIdNot(
             Long companyId,
             String name,
@@ -88,4 +85,11 @@ public interface PositionCategoryRepository extends JpaRepository<PositionCatego
             @Param("companyId") Long companyId,
             @Param("includeInactive") boolean includeInactive
     );
+
+    boolean existsByCompanyIdAndOrgCategoryIdAndName(
+            Long companyId,
+            Long orgCategoryId,
+            String name
+    );
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
@@ -9,10 +9,7 @@ import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
-import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryListDto;
-import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryOrderUpdateReqDto;
-import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryReqDto;
-import com.finalproj.orbitflow.hr.positionCategory.dto.PositionCategoryResDto;
+import com.finalproj.orbitflow.hr.positionCategory.dto.*;
 import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
 import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,20 +37,20 @@ public class PositionCategoryService {
     private final OrgPositionUsageRepository orgPositionUsageRepository;
 
     /* ================= 생성 ================= */
-    public Long create(Long companyId, PositionCategoryReqDto request) {
+    public Long create(Long companyId, PositionCategoryCreateReqDto request) {
 
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new NotFoundException("회사를 찾을 수 없습니다."));
 
         String name = normalizeName(request.getName());
 
-        if (positionCategoryRepository
-                .existsByCompanyIdAndName(companyId, name)) {
-            throw new InvalidStateException("이미 존재하는 직책 카테고리입니다.");
-        }
-
         OrgCategory orgCategory = orgCategoryRepository.findById(request.getOrgCategoryId())
                 .orElseThrow(() -> new NotFoundException("조직 카테고리를 찾을 수 없습니다."));
+
+        if (positionCategoryRepository
+                .existsByCompanyIdAndOrgCategoryIdAndName(companyId, orgCategory.getId(), name)) {
+            throw new InvalidStateException("이미 존재하는 직책 카테고리입니다.");
+        }
 
         if (!orgCategory.getCompanyId().equals(companyId)) {
             throw new ForbiddenException("해당 회사의 조직 카테고리가 아닙니다.");
@@ -72,8 +69,35 @@ public class PositionCategoryService {
             parent = positionCategoryRepository.findById(request.getParentPositionId())
                     .orElseThrow(() -> new NotFoundException("상위 직책을 찾을 수 없습니다."));
 
+            // 회사 검증
             if (!parent.getCompany().getId().equals(companyId)) {
                 throw new ForbiddenException("해당 회사의 직책이 아닙니다.");
+            }
+
+            // 활성 상태 검증
+            if (!Boolean.TRUE.equals(parent.getIsActive())) {
+                throw new InvalidStateException("비활성 직책은 상위 직책으로 선택할 수 없습니다.");
+            }
+
+            OrgCategory parentOrg = parent.getOrgCategory();
+
+            // 회사(org root)는 항상 허용
+            // 회사 조직 유형(is_root = true)은 최상위 고정 개념이므로
+            // order_index 비교 대상에서 제외한다.
+            if (Boolean.FALSE.equals(parentOrg.getIsRoot())) {
+
+                Integer parentOrder = parentOrg.getOrderIndex();
+                Integer currentOrder = orgCategory.getOrderIndex();
+
+                if (parentOrder == null || currentOrder == null) {
+                    throw new InvalidStateException("조직 유형 순서 정보가 올바르지 않습니다.");
+                }
+
+                if (parentOrder > currentOrder) {
+                    throw new InvalidStateException(
+                            "상위 직책은 선택한 조직 유형 이상에 속한 직책만 지정할 수 있습니다."
+                    );
+                }
             }
         }
 
@@ -122,31 +146,29 @@ public class PositionCategoryService {
 
 
     /* ================= 수정 ================= */
-    public void update(Long companyId, Long id, PositionCategoryReqDto request) {
+    public void update(Long companyId, Long id, PositionCategoryUpdateReqDto request) {
 
         PositionCategory category = get(companyId, id);
 
         String name = normalizeName(request.getName());
 
         if (positionCategoryRepository.existsByCompanyIdAndNameAndIdNot(
-                companyId,
-                name,
-                id
-        )) {
+                companyId, name, id)) {
             throw new InvalidStateException("이미 존재하는 직책 카테고리입니다.");
         }
 
-        boolean wasInactive = !category.getIsActive();
+        boolean wasActive = category.getIsActive();
         boolean willActivate = Boolean.TRUE.equals(request.getIsActive());
         boolean willDeactivate = Boolean.FALSE.equals(request.getIsActive());
 
-        if (wasInactive && willActivate) {
+        if (!wasActive && willActivate) {
             Integer max = positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
             category.activate(max == null ? 1 : max + 1);
         }
 
-        if (willDeactivate) {
-            if (orgPositionUsageRepository.existsByCompany_IdAndPositionCategory_Id(companyId, id)) {
+        if (wasActive && willDeactivate) {
+            if (orgPositionUsageRepository
+                    .existsByCompany_IdAndPositionCategory_Id(companyId, id)) {
                 throw new InvalidStateException(
                         "해당 직책을 사용하는 조직이 존재하여 비활성화할 수 없습니다."
                 );
@@ -206,4 +228,16 @@ public class PositionCategoryService {
         }
         return name;
     }
+
+    private boolean isCycle(PositionCategory newParent, PositionCategory target) {
+        PositionCategory cursor = newParent;
+        while (cursor != null) {
+            if (cursor.getId().equals(target.getId())) {
+                return true;
+            }
+            cursor = cursor.getParent();
+        }
+        return false;
+    }
+
 }

--- a/src/main/resources/static/css/admin-position-category.css
+++ b/src/main/resources/static/css/admin-position-category.css
@@ -1,504 +1,69 @@
-/* ==================================================
-   admin-org-category.css
-   - 조직 카테고리 관리 (목록 + 모달)
-================================================== */
+/* =========================
+   직책 전용 스타일
+========================= */
 
-:root {
-    --bg: #f5f7fb;
-    --card: #ffffff;
-    --line: #eef1f6;
-    --text: #111827;
-    --muted: #6b7280;
-    --primary: #2f6af6;
-    --primary-weak: rgba(47, 106, 246, .12);
-
-    --success-bg: #dff7e7;
-    --success-text: #137a3a;
-
-    --danger-bg: #fde2e2;
-    --danger-text: #b42318;
-
-    --shadow: 0 12px 36px rgba(16, 24, 40, 0.08);
-}
-
-
-/* 타이틀 */
-.orgcat-title-row {
-    margin-bottom: 18px;
-}
-
-.orgcat-title {
-    font-size: 22px;
-    font-weight: 800;
-    letter-spacing: -0.2px;
-    color: var(--text);
-    margin: 0;
-}
-
-/* 카드 */
-.orgcat-card {
-    background: var(--card);
-    border: 1px solid var(--line);
-    border-radius: 18px;
-    box-shadow: var(--shadow);
-    padding: 18px 18px 14px;
-}
-
-/* 툴바 */
-.orgcat-toolbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px; /* 테이블이랑 거리 */
-}
-.toolbar-left {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-/* 검색 */
-.orgcat-search {
-    flex: 1;
-    max-width: 320px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    height: 44px;
-    border: 1px solid var(--line);
-    border-radius: 12px;
-    padding: 0 14px;
-    background: #fbfcff;
-}
-
-.orgcat-search i {
-    color: #9aa3b2;
+/* 상위 직책 컬럼 */
+.col-parent {
+    color: #6b7280;
     font-size: 14px;
 }
 
-.orgcat-search input {
-    width: 220px;
-    border: none;
-    outline: none;
-    background: transparent;
-    font-size: 13.5px;
-    color: var(--text);
-}
+/*!* HEAD 배지 컬럼 *!*/
+/*.col-head {*/
+/*    text-align: center;*/
+/*}*/
 
-.orgcat-search input::placeholder {
-    color: #9aa3b2;
-}
-
-/* 버튼 공통 */
-.btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    height: 42px;
-    padding: 0 16px;
-    border-radius: 12px;
-    border: 1px solid transparent;
-    font-size: 13.5px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: transform .06s ease, background .15s ease, border-color .15s ease;
-    user-select: none;
-}
-
-.btn:active {
-    transform: translateY(1px);
-}
-
-.btn-primary {
-    background: var(--primary);
-    color: #fff;
-    box-shadow: 0 10px 24px rgba(47, 106, 246, .22);
-}
-
-.btn-primary:hover {
-    filter: brightness(0.98);
-}
-
-.btn-outline {
-    background: #fff;
-    color: var(--primary);
-    border-color: rgba(47, 106, 246, .35);
-}
-
-.btn-outline:hover {
-    background: var(--primary-weak);
-}
-
-.btn-outline:disabled {
-    cursor: not-allowed;
-    opacity: .45;
-    background: #fff;
-}
-
-.btn-ghost {
-    background: #fff;
-    color: #374151;
-    border-color: #e5e7eb;
-}
-
-.btn-ghost:hover {
-    background: #f3f4f6;
-}
-
-/* 테이블 */
-.orgcat-table-wrap {
-    border: 1px solid var(--line);
-    border-radius: 16px;
-    overflow: hidden;
-    background: #fff;
-}
-
-.orgcat-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 13.5px;
-}
-
-.orgcat-table thead th {
-    background: #f6f7fb;
-    color: #667085;
-    text-align: left;
-    padding: 14px 16px;
-    font-weight: 800;
-    border-bottom: 1px solid var(--line);
-}
-
-.orgcat-table tbody td {
-    padding: 16px 16px;
-    border-bottom: 1px solid var(--line);
-    vertical-align: middle;
-    color: var(--text);
-}
-
-.orgcat-table tbody tr:last-child td {
-    border-bottom: none;
-}
-
-.col-order {
-    width: 90px;
-}
-
-.col-status {
-    width: 140px;
-}
-
-.col-action {
-    width: 140px;
-}
-
-/* 드래그 핸들(점 6개 느낌) */
-.drag-handle {
-    width: 34px;
-    height: 34px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 10px;
-    cursor: grab;
-    color: #98a2b3;
-}
-
-.drag-handle:active {
-    cursor: grabbing;
-}
-
-.drag-dots {
-    width: 14px;
-    height: 18px;
-    display: grid;
-    grid-template-columns: repeat(2, 4px);
-    grid-template-rows: repeat(3, 4px);
-    gap: 3px;
-}
-
-.drag-dots span {
-    width: 4px;
-    height: 4px;
-    background: #a9b1c3;
-    border-radius: 50%;
-}
-
-/* 상태 배지 */
-.status-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 56px;
-    height: 22px;
-    padding: 3px 14px;
-    border-radius: 20px;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1;
-}
-
-.status-active {
-    background: var(--success-bg);
-    color: var(--success-text);
-}
-
-.status-inactive {
-    background: var(--danger-bg);
-    color: var(--danger-text);
-}
-
-/* 수정 버튼(테이블 내) */
-.table-btn {
-    height: 36px;
-    padding: 0 14px;
-    border-radius: 12px;
-    border: 1px solid #d0d5dd;
-    background: #fff;
-    font-weight: 800;
-    font-size: 13px;
-    color: #344054;
-    cursor: pointer;
-}
-
-.table-btn:hover {
-    background: #f3f4f6;
-}
-
-/* 하단 */
-.orgcat-footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    padding: 12px 6px 0;
-}
-
-.orgcat-hint {
-    font-size: 12.5px;
-    color: #98a2b3;
-}
-
-/* =========================
-   모달
-========================= */
-.modal {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.45);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 2000;
-    padding: 18px;
-}
-
-.modal.hidden {
-    display: none;
-}
-
-.modal-panel {
-    width: 720px;
-    max-width: 92vw;
-    background: #fff;
-    border-radius: 18px;
-    box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
-    overflow: hidden;
-}
-
-.modal-head {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    padding: 22px 24px 10px;
-}
-
-.modal-head h2 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 900;
-    color: var(--text);
-}
-
-.modal-sub {
-    margin: 8px 0 0;
-    font-size: 12.5px;
-    color: #98a2b3;
-}
-
-.icon-btn {
-    width: 36px;
-    height: 36px;
-    border-radius: 10px;
-    border: 1px solid #eef2f7;
-    background: #fff;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #667085;
-}
-
-.icon-btn:hover {
-    background: #f3f4f6;
-}
-
-.modal-body {
-    padding: 8px 24px 18px;
-}
-
-.form-group {
-    margin-top: 14px;
-}
-
-.form-label {
-    display: block;
-    font-size: 12.5px;
-    font-weight: 900;
-    color: #667085;
-    margin-bottom: 8px;
-}
-
-.form-input {
-    width: 100%;
-    height: 46px;
-    padding: 0 14px;
-    border-radius: 12px;
-    border: 1px solid #e6eaf2;
-    background: #fbfcff;
-    outline: none;
-    font-size: 13.5px;
-    color: var(--text);
-}
-
-.form-input:focus {
-    border-color: rgba(47, 106, 246, .55);
-    box-shadow: 0 0 0 4px rgba(47, 106, 246, .12);
-}
-
-.form-help {
-    margin: 8px 2px 0;
-    font-size: 12.5px;
-    color: #ef4444;
-    min-height: 16px;
-}
-
-/* 토글 */
-.toggle-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding-top: 6px;
-}
-
-.toggle-text {
-    font-weight: 900;
-    font-size: 13.5px;
-    color: #344054;
-}
-
-/* switch */
-.switch {
-    position: relative;
-    display: inline-block;
-    width: 54px;
-    height: 30px;
-}
-
-.switch input {
-    display: none;
-}
-
-.slider {
-    position: absolute;
-    cursor: pointer;
-    inset: 0;
-    background: #d0d5dd;
-    border-radius: 999px;
-    transition: .2s;
-}
-
-.slider:before {
-    content: "";
-    position: absolute;
-    height: 24px;
-    width: 24px;
-    left: 3px;
-    top: 3px;
-    background: white;
-    border-radius: 50%;
-    transition: .2s;
-    box-shadow: 0 8px 18px rgba(0, 0, 0, .12);
-}
-
-.switch input:checked + .slider {
-    background: var(--primary);
-}
-
-.switch input:checked + .slider:before {
-    transform: translateX(24px);
-}
-
-/* 모달 하단 버튼 */
-.modal-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    padding: 16px 24px 22px;
-    border-top: 1px solid #eef2f7;
-}
-
-/* Sortable dragging */
-.sortable-chosen {
-    background: #f7f9ff;
-}
-
-.sortable-ghost {
-    opacity: .6;
-}
-
-.inactive-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    font-weight: 700;
-    color: #475467;
-}
-
-
-/* 반응형 */
-@media (max-width: 720px) {
-    .orgcat-toolbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .orgcat-search {
-        max-width: 100%;
-    }
-
-    .orgcat-footer {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .orgcat-footer .btn {
-        width: 100%;
-    }
-}
-
-.badge {
+/* 결재처리자 HEAD 배지 */
+.badge-head {
     display: inline-flex;
     align-items: center;
     padding: 4px 10px;
     font-size: 11.5px;
-    font-weight: 800;
+    font-weight: 700;
     border-radius: 999px;
-}
 
-.badge-head {
     background: #eef2ff;
     color: #3730a3;
     border: 1px solid #c7d2fe;
+}
+
+.orgcat-table th.col-status,
+.orgcat-table td.col-status,
+.orgcat-table th.col-action,
+.orgcat-table td.col-action {
+    text-align: center;
+    vertical-align: middle;
+}
+
+.td-center {
+    text-align: center;
+}
+
+.hidden {
+    display: none;
+}
+
+.form-input {
+    width: 100%;
+    height: 44px;
+    padding: 0 14px;
+    box-sizing: border-box;
+
+    font-size: 14px;
+    border-radius: 10px;
+    border: 1px solid var(--line);
+}
+
+select.form-input {
+    padding-right: 36px; /* 화살표 공간 */
+}
+
+.form-label {
+    margin-bottom: 8px;
+}
+
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }

--- a/src/main/resources/static/css/admin-rank.css
+++ b/src/main/resources/static/css/admin-rank.css
@@ -392,6 +392,10 @@
     vertical-align: middle;
 }
 
+.td-center {
+    text-align: center;
+}
+
 
 /* =========================
    Modal UI (ORG CATEGORY STYLE) - FINAL

--- a/src/main/resources/static/js/admin-position-category.js
+++ b/src/main/resources/static/js/admin-position-category.js
@@ -64,14 +64,35 @@ function render() {
 function row(v) {
     const tr = document.createElement('tr');
     tr.dataset.id = v.id;
+
     tr.innerHTML = `
-    <td>${v.isActive ? drag() : ''}</td>
-    <td>${v.name}</td>
-    <td>${v.parentPositionName ?? '-'}</td>
-    <td>${v.isHead ? `<span class="badge badge-head">HEAD</span>` : ''}</td>
-    <td>${v.isActive ? '활성' : '비활성'}</td>
-    <td><button data-edit>수정</button></td>
+    <td class="col-order">
+      ${v.isActive && !isSearch() ? drag() : ''}
+    </td>
+
+    <td class="col-name">
+      <strong>${v.name}</strong>
+    </td>
+
+    <td class="col-parent">
+      ${v.parentPositionName ?? '-'}
+    </td>
+
+    <td class="col-head">
+      ${v.isHead ? `<span class="badge badge-head">HEAD</span>` : ''}
+    </td>
+
+    <td class="col-status">
+      <span class="status-badge ${v.isActive ? 'status-active' : 'status-inactive'}">
+        ${v.isActive ? '활성' : '비활성'}
+      </span>
+    </td>
+
+    <td class="col-action">
+      <button class="table-btn" data-edit>수정</button>
+    </td>
   `;
+
     tr.querySelector('[data-edit]').onclick = () => openEdit(v.id);
     return tr;
 }
@@ -114,8 +135,12 @@ async function openCreate() {
     $('#isActive').checked = true;
     $('#isActive').disabled = true;
 
+    // 혹시 남아 있을 수 있는 help 숨김
+    $('#inactiveHelp')?.classList.add('hidden');
+
     buildParentPositionSelect(null, false);
     showModal();
+    updateHeadHelp();
 }
 
 
@@ -141,52 +166,77 @@ async function openEdit(id) {
     $('#isHead').checked = v.isHead;
     $('#isHead').disabled = true;
 
+    $('#headHelp').classList.add('hidden');
+
     // 사용 여부만 수정 가능
     $('#isActive').checked = v.isActive;
     $('#isActive').disabled = false;
 
-    // 상위 직책: 조회만
-    buildParentPositionSelect(parentPositionId, true);
+    // 1. 부모 후보 재구성 (자기 자신만 제외)
+    buildParentPositionSelect(selectedId, true);
+
+    // 2. 기존 parent를 명시적으로 선택
+    const parentSelect = $('#parentPositionSelect');
+    parentSelect.value = parentPositionId ?? '';
+
+
+    $('#inactiveHelp').classList.add('hidden');
 
     showModal();
+    updateHeadHelp();
+    bindActiveToggle();
 }
 
 
 
 /* ================= Save ================= */
 async function save() {
-    const parentValue = $('#parentPositionSelect').value;
 
+    const isCreate = !selectedId;
 
-    const payload = {
-        name: $('#positionName').value.trim(),
-        orgCategoryId: Number($('#orgCategorySelect').value),
-        parentPositionId: $('#parentPositionSelect').value
-            ? Number($('#parentPositionSelect').value)
-            : null,
-        isHead: $('#isHead').checked,
-        isActive: $('#isActive').checked
-    };
+    const name = $('#positionName').value.trim();
+    const orgCategoryId = Number($('#orgCategorySelect').value);
+    const parentPositionId = $('#parentPositionSelect').value
+        ? Number($('#parentPositionSelect').value)
+        : null;
+    const isHead = $('#isHead').checked;
+    const isActive = $('#isActive').checked;
 
+    const noParent = !parentPositionId;
 
-    const method = selectedId ? 'PUT' : 'POST';
-    const url = selectedId ? `${API}/${selectedId}` : API;
+    // 생성 + HEAD + parent 없음 경고
+    if (isCreate && noParent && isHead) {
+        const ok = confirm(
+            '상위 직책이 없는 최상위 결재처리자로 생성됩니다.\n계속 진행하시겠습니까?'
+        );
+        if (!ok) return;
+    }
 
-    await apiFetch(url, {
-        method,
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(payload)
-    });
+    const payload = isCreate
+        ? { name, orgCategoryId, parentPositionId, isHead }
+        : { name, isActive };
 
-    hideModal();
-    load();
+    const method = isCreate ? 'POST' : 'PUT';
+    const url = isCreate ? API : `${API}/${selectedId}`;
+
+    try {
+        await apiFetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        hideModal();
+        load();
+    } catch (e) {
+        alert(e.message || '요청 처리 중 오류가 발생했습니다.');
+    }
 }
 
 /* ================= Bind ================= */
 function bind() {
     $('#btnOpenCreate').onclick = openCreate;
     $('#btnCancel').onclick = hideModal;
-    $('#btnCloseModal').onclick = hideModal;
     $('#btnSave').onclick = save;
     $('#btnSearch').onclick = render;
     $('#includeInactive').onchange = load;
@@ -195,7 +245,15 @@ function bind() {
 
 /* ================= Utils ================= */
 const $ = s => document.querySelector(s);
-const drag = () => `<span class="drag-handle">⋮⋮</span>`;
+const drag = () => `
+  <span class="drag-handle">
+    <span class="drag-dots">
+      <span></span><span></span>
+      <span></span><span></span>
+      <span></span><span></span>
+    </span>
+  </span>
+`;
 const isSearch = () => $('#searchKeyword').value.trim().length > 0;
 
 function showModal() {
@@ -207,7 +265,7 @@ function hideModal() {
 }
 
 /* ================= 상위 직책 셀렉트 빌드 함수 ================= */
-function buildParentPositionSelect(selectedId, disabled = false) {
+function buildParentPositionSelect(excludeId, disabled = false) {
     const select = $('#parentPositionSelect');
 
     const currentOrgCategoryId =
@@ -218,18 +276,18 @@ function buildParentPositionSelect(selectedId, disabled = false) {
 
     const candidates = list.filter(v =>
         v.isActive &&
-        v.id !== selectedId &&
+        v.id !== excludeId &&
         allowedOrgCategoryIds.has(v.orgCategoryId)
     );
 
     select.innerHTML = `
-  ${candidates.map(v =>
-        `<option value="${v.id}" ${v.id === selectedId ? 'selected' : ''}>
-        ${v.name} (${v.orgCategoryName})${v.isHead ? ' · HEAD' : ''}
-    </option>`
-    ).join('')}
-`;
-// --> 부모 직책을 반드시 하나 선택해야 함 (“최상위 직책”이라는 개념이 사라짐, 모든 직책은 명시적 트리 안에 존재)
+      <option value="">(상위 직책 없음)</option>
+      ${candidates.map(v => `
+        <option value="${v.id}">
+          ${v.name} (${v.orgCategoryName})${v.isHead ? ' · HEAD' : ''}
+        </option>
+      `).join('')}
+    `;
 
     select.disabled = disabled;
 }
@@ -262,20 +320,6 @@ document
         buildParentPositionSelect(parentPositionId, false);
     });
 
-
-// function collectAllowedOrgCategoryIds(orgCategoryId) {
-//     const allowed = new Set();
-//     let currentId = orgCategoryId;
-//
-//     while (currentId) {
-//         allowed.add(currentId);
-//         const current = orgCategories.find(c => c.id === currentId);
-//         currentId = current?.parentId ?? null;
-//     }
-//
-//     return allowed;
-// }
-
 function collectAllowedOrgCategoryIds(orgCategoryId) {
     const current = orgCategories.find(c => c.id === orgCategoryId);
     if (!current) return new Set();
@@ -286,3 +330,33 @@ function collectAllowedOrgCategoryIds(orgCategoryId) {
             .map(c => c.id)
     );
 }
+
+function updateHeadHelp() {
+    const noParent = !$('#parentPositionSelect').value;
+    const isHead = $('#isHead').checked;
+
+    $('#headHelp').classList.toggle(
+        'hidden',
+        !(noParent && isHead)
+    );
+}
+
+$('#isHead')?.addEventListener('change', updateHeadHelp);
+$('#parentPositionSelect')?.addEventListener('change', updateHeadHelp);
+
+function bindActiveToggle() {
+    const toggle = $('#isActive');
+    const help = $('#inactiveHelp');
+
+    if (!toggle || !help) return;
+
+    toggle.onchange = () => {
+        if (selectedId && !toggle.checked) {
+            help.classList.remove('hidden');
+        } else {
+            help.classList.add('hidden');
+        }
+    };
+
+}
+

--- a/src/main/resources/static/js/admin-rank.js
+++ b/src/main/resources/static/js/admin-rank.js
@@ -113,12 +113,12 @@ function renderRow(r) {
       <td><strong>${r.name}</strong></td>
       <td>${r.parentRankName ?? '-'}</td>
       <td>${r.employeeCount}</td>
-      <td>
+      <td class="td-center">
         <span class="status-badge ${r.isActive ? 'status-active' : 'status-inactive'}">
           ${r.isActive ? '활성' : '비활성'}
         </span>
       </td>
-      <td>
+      <td class="td-center">
         <button class="table-btn">수정</button>
       </td>
     `;

--- a/src/main/resources/templates/admin/hr/position-category/list.html
+++ b/src/main/resources/templates/admin/hr/position-category/list.html
@@ -9,16 +9,17 @@
       )}">
 
 <th:block th:fragment="pageCss">
+  <link rel="stylesheet" th:href="@{/css/admin-org-category.css}">
   <link rel="stylesheet" th:href="@{/css/admin-position-category.css}">
 </th:block>
 
 <th:block th:fragment="content">
 
-  <div class="orgcat-title-row">
-    <h1 class="orgcat-title">직책 관리</h1>
-  </div>
-
   <section class="orgcat-card">
+
+    <div class="orgcat-card-head">
+      <h1 class="orgcat-title">직책 관리</h1>
+    </div>
 
     <!-- 툴바 -->
     <div class="orgcat-toolbar">
@@ -33,7 +34,9 @@
 
         <label class="inactive-toggle">
           <input type="checkbox" id="includeInactive">
-          <span>비활성 포함</span>
+          <span class="checkmark"></span>
+          <span class="label-text">비활성 포함</span>
+          <small>(정렬 제외)</small>
         </label>
 
       </div>
@@ -50,12 +53,12 @@
       <table class="orgcat-table">
         <thead>
         <tr>
-          <th style="width:80px">순서</th>
-          <th>직책명</th>
-          <th>상위 직책</th>
-          <th>결재처리자</th>
-          <th>상태</th>
-          <th>관리</th>
+          <th class="col-order">순서</th>
+          <th class="col-name">직책명</th>
+          <th class="col-parent">상위 직책</th>
+          <th class="col-head">결재처리자</th>
+          <th class="col-status">상태</th>
+          <th class="col-action">관리</th>
         </tr>
         </thead>
         <tbody id="tableBody"></tbody>
@@ -74,58 +77,78 @@
 
   </section>
 
-  <!-- 모달 -->
-  <div id="modal" class="modal hidden">
-    <div class="modal-panel">
+  <!-- ================= 모달 ================= -->
+  <div id="modal" class="modal hidden" aria-hidden="true">
+    <div class="modal-panel" role="dialog" aria-modal="true">
 
+      <!-- 헤더 -->
       <div class="modal-head">
-        <h2 id="modalTitle">직책 생성</h2>
-        <button class="icon-btn" id="btnCloseModal">
-          <i class="fa-solid fa-xmark"></i>
-        </button>
+        <div class="modal-head-text">
+          <h2 id="modalTitle">직책 생성</h2>
+          <p class="modal-sub">
+            조직 유형 기준으로 직책을 생성하고, 결재 처리 여부를 설정합니다.
+          </p>
+        </div>
       </div>
 
+      <!-- 바디 -->
       <div class="modal-body">
 
-        <input type="hidden" id="positionId">
-
+        <!-- 조직 유형 -->
         <div class="form-group">
           <label class="form-label">조직 유형 기준</label>
           <select id="orgCategorySelect" class="form-input"></select>
-          <p class="form-help">
-            결재선 및 직책 사용 정책의 기준이 되는 조직 유형입니다.
+        </div>
+
+        <!-- 상위 직책 -->
+        <div class="form-group">
+          <label class="form-label">상위 직책</label>
+          <select id="parentPositionSelect" class="form-input"></select>
+          <p class="form-help muted">
+            선택하지 않으면 최상위 직책으로 생성됩니다.
           </p>
         </div>
 
+        <!-- 직책명 -->
         <div class="form-group">
-          <label>상위 직책</label>
-          <select id="parentPositionSelect" class="form-input"></select>
-          <p class="form-help">최상위 직책은 선택하지 않아도 됩니다.</p>
-        </div>
-
-        <div class="form-group">
-          <label>직책명</label>
-          <input id="positionName" class="form-input">
+          <label class="form-label">직책명</label>
+          <input id="positionName" class="form-input" placeholder="예: 팀장">
           <p class="form-help" id="nameHelp"></p>
         </div>
 
+        <!-- 결재처리자 -->
         <div class="form-group">
-          <label>
-            <input type="checkbox" id="isHead">
-            결재처리자
-          </label>
+          <label class="form-label">결재 처리자</label>
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="isHead">
+              <span class="slider"></span>
+            </label>
+            <span class="toggle-text">결재처리자</span>
+          </div>
+          <p class="form-help hidden" id="headHelp">
+            상위 직책이 없는 결재처리자는 최상위 결재자로 동작합니다.
+          </p>
         </div>
 
+        <!-- 사용 여부 -->
         <div class="form-group">
-          <label>사용 여부</label>
-          <label class="switch">
-            <input type="checkbox" id="isActive" checked>
-            <span class="slider"></span>
-          </label>
+          <label class="form-label">사용 여부</label>
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="isActive" checked>
+              <span class="slider"></span>
+            </label>
+            <span class="toggle-text">사용</span>
+          </div>
+          <p class="form-help hidden" id="inactiveHelp">
+            이미 조직에 할당된 직책이 있으면 비활성화할 수 없습니다.
+          </p>
         </div>
 
       </div>
 
+      <!-- 하단 버튼 -->
       <div class="modal-actions">
         <button class="btn btn-ghost" id="btnCancel">취소</button>
         <button class="btn btn-primary" id="btnSave">저장</button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #452

## 📝 작업 내용
### 직책 / 조직 정책 명확화
- **회사 조직 카테고리(is_root = true)** 는 최상위 고정 개념으로 `order_index` 비교 대상에서 **항상 제외**하도록 정책 확정
- 직책 생성 시 **상위 직책 선택 규칙 명확화**
    - 상위 직책은 **동일 회사 + 활성 상태**만 허용
    - 조직 카테고리 순서는 `상위 직책의 조직 order_index ≤ 현재 직책의 조직 order_index` 조건으로 제한
    - 단, **회사(org root)** 소속 직책은 예외적으로 항상 허용
- HEAD 직책 정책 정리
    - HEAD 중복 제한 제거 (정책상 허용)
    - 상위 직책 없는 HEAD → **최상위 결재자**로 동작하도록 UX 안내 유지
- 직책 비활성화 정책 보강
    - 조직에 이미 사용 중인 직책은 비활성화 불가 처리
### 직책 관리 화면 UX / 로직 개선
- 수정 모달에서 **상위 직책이 정상적으로 표시되지 않던 문제 해결**
    - 상위 직책 select 빌드 시 현재 직책 ID 제외 + 실제 `parentPositionId`를 선택값으로 명확히 분리
- 조직 유형 변경 시 상위 직책 목록 동기화 로직 안정화
- Drag & Drop 정렬
    - 활성 직책만 정렬 대상
    - 검색/비활성 포함 상태에서는 정렬 비활성화
### 관리자 UI 디자인 통일
- **직책 관리 화면을 조직 카테고리 관리 디자인과 통일**
    - 카드 레이아웃 / 테이블 / 버튼 스타일 공통화
- 모달 UI 개선
    - input / select 높이, 폭, 좌우 여백 완전 통일
    - margin 보정 제거 → padding + box-sizing 기반 정렬로 수정
- select 전용 스타일 보강
    - 기본 브라우저 스타일 제거
    - 커스텀 화살표 적용으로 input과 시각적 일관성 확보
- 토글, help 텍스트, 상태 배지 디자인 정리

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
