### PR TITLE
feat(employee, leave): 사원 생성 후 연차 부여 이벤트 기반 처리로 분리

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/OrbitflowApplication.java
+++ b/src/main/java/com/finalproj/orbitflow/OrbitflowApplication.java
@@ -5,8 +5,10 @@ import com.finalproj.orbitflow.global.security.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties({JwtProperties.class, HolidayApiProperties.class})

--- a/src/main/java/com/finalproj/orbitflow/attendance/leave/listener/LeaveEventListener.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/leave/listener/LeaveEventListener.java
@@ -1,0 +1,50 @@
+package com.finalproj.orbitflow.attendance.leave.listener;
+
+import com.finalproj.orbitflow.attendance.leave.service.LeaveService;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.event.EmployeeCreatedEvent;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : LeaveEventListener
+ * @since : 2026-01-10 토요일
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LeaveEventListener {
+
+    private final EmployeeRepository employeeRepository;
+    private final LeaveService leaveService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEmployeeCreated(EmployeeCreatedEvent event) {
+
+        Employee emp = employeeRepository.findById(event.getEmployeeId())
+                .orElse(null);
+
+        if (emp == null) {
+            log.warn("[LeaveEvent] 사원 없음 - id={}", event.getEmployeeId());
+            return;
+        }
+
+        try {
+            leaveService.grantInitialLeave(emp);
+        } catch (Exception e) {
+            log.error("[LeaveEvent] 초기 연차 부여 실패 - employeeId={}", emp.getId(), e);
+        }
+    }
+}

--- a/src/main/java/com/finalproj/orbitflow/attendance/leave/service/LeaveService.java
+++ b/src/main/java/com/finalproj/orbitflow/attendance/leave/service/LeaveService.java
@@ -6,9 +6,6 @@ import com.finalproj.orbitflow.approval.document.entity.Document;
 import com.finalproj.orbitflow.approval.document.enums.DocumentStatus;
 import com.finalproj.orbitflow.approval.formTemplateGroup.enums.BaseRole;
 import com.finalproj.orbitflow.attendance.leave.dto.*;
-import com.finalproj.orbitflow.attendance.leave.dto.LeaveBalanceResDto;
-import com.finalproj.orbitflow.attendance.leave.dto.LeaveHistoryResDto;
-import com.finalproj.orbitflow.attendance.leave.dto.LeaveRemainingResDto;
 import com.finalproj.orbitflow.attendance.leave.entity.LeaveBalance;
 import com.finalproj.orbitflow.attendance.leave.entity.LeaveGrant;
 import com.finalproj.orbitflow.attendance.leave.entity.LeaveType;
@@ -25,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -474,7 +472,7 @@ public class LeaveService {
      * 신규 사원 가입(입사) 직후 비례 연차 즉시 부여
      * EmployeeService 또는 AdminController에서 사원 객체를 전달받아 호출합니다.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void grantInitialLeave(Employee emp) {
         // 1. 입사일 존재 여부 확인
         if (emp == null || emp.getHireDate() == null) {

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/event/EmployeeCreatedEvent.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/event/EmployeeCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.finalproj.orbitflow.hr.employee.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : EmployeeCreatedEvent
+ * @since : 2026-01-10 토요일
+ */
+@Getter
+@AllArgsConstructor
+public class EmployeeCreatedEvent {
+    private final Long employeeId;
+}

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -8,6 +8,7 @@ import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeRole;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.enums.WorkStatus;
+import com.finalproj.orbitflow.hr.employee.event.EmployeeCreatedEvent;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
 import com.finalproj.orbitflow.hr.logAudit.dto.AuditLogResDto;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
@@ -20,6 +21,8 @@ import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRe
 import com.finalproj.orbitflow.hr.rank.entity.HrRank;
 import com.finalproj.orbitflow.hr.rank.repository.RankRepository;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -36,6 +39,7 @@ import java.util.*;
  * @since : 2025-12-23 화요일
  */
 
+@Slf4j
 @Service
 @Transactional
 @AllArgsConstructor
@@ -48,6 +52,8 @@ public class EmployeeService {
     private final PositionCategoryRepository positionCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuditLogService auditLogService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
 
     /* =============================
        조회
@@ -184,6 +190,10 @@ public class EmployeeService {
         );
 
         Employee saved = employeeRepository.save(employee);
+
+        applicationEventPublisher.publishEvent(
+                new EmployeeCreatedEvent(saved.getId())
+        );
 
         Map<String, Object> after = new LinkedHashMap<>();
         after.put("name", saved.getName());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #460

## 📝 작업 내용
- 사원 생성 시 연차 부여 로직을 이벤트 기반으로 분리
- Employee 트랜잭션 커밋 이후 연차 부여가 실행되도록 처리
- 연차 부여 실패가 사원 생성에 영향을 주지 않도록 안정성 강화
- 사원 생성 API 응답 지연 문제(모달 미닫힘) 해결

### 주요 변경 사항
- EmployeeService에서 연차 부여 직접 호출 제거
- EmployeeCreatedEvent 발행 추가
- LeaveEventListener에서 초기 연차 부여 처리
- `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 적용

## 체크리스트
- [x] 사원 생성 정상 동작
- [x] 연차 부여 AFTER_COMMIT 이후 정상 실행
- [x] 연차 부여 실패 시 사원 생성 영향 없음
- [x] 기존 연차 정책 로직 변경 없음

## 스크린샷 (선택)
<img width="1843" height="261" alt="image" src="https://github.com/user-attachments/assets/c98196d9-147f-47ab-84d6-601849880bc0" />

## 💬 리뷰 요구사항(선택)
