### PR TITLE
feat(org-tree): 조직도 페이지 - 결재 서명 등록 기능 추가

### DIFF
--- a/src/main/resources/static/css/organization/org-tree.css
+++ b/src/main/resources/static/css/organization/org-tree.css
@@ -52,7 +52,7 @@
 }
 
 .employee-panel.hidden {
-    display: none;
+    display: none !important;
 }
 
 /* Hero */
@@ -167,4 +167,215 @@
 
 .hero-work-dot.away {
     background: #f59e0b; /* 자리비움 */
+}
+
+.hidden {
+    display: none !important;
+}
+
+/* =========================
+   Modal Backdrop
+========================= */
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+
+/* =========================
+   Signature Modal Card
+========================= */
+.signature-modal {
+    width: 420px;
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 22px 24px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+    animation: modalFadeIn 0.2s ease-out;
+}
+
+@keyframes modalFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.modal-title {
+    font-size: 18px;
+    font-weight: 900;
+    margin-bottom: 10px;
+}
+
+.signature-guide {
+    font-size: 13px;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 14px;
+}
+
+.signature-upload-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.signature-preview-box {
+    width: 100%;
+    height: 160px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background: #f8f9fa;
+    border: 2px dashed #d1d5db;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.signature-preview-box:hover {
+    border-color: #2563eb;
+    background: #eef4ff;
+}
+
+.signature-preview-box img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.signature-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    color: #6b7280;
+}
+
+.signature-placeholder i {
+    font-size: 42px;
+    opacity: 0.4;
+}
+
+.signature-placeholder p {
+    font-size: 14px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.signature-hint {
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.signature-remove-btn {
+    align-self: flex-end;
+    padding: 6px 14px;
+    font-size: 13px;
+    font-weight: 700;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    background: #ef4444;
+    color: #ffffff;
+}
+
+.signature-remove-btn:hover {
+    background: #dc2626;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 18px;
+}
+
+.modal-actions button {
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 700;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+#signatureCancelBtn {
+    background: #f3f4f6;
+    border: none;
+    color: #374151;
+}
+
+#signatureCancelBtn:hover {
+    background: #e5e7eb;
+}
+
+#signatureSaveBtn {
+    background: #2563eb;
+    border: none;
+    color: #ffffff;
+}
+
+#signatureSaveBtn:hover {
+    background: #1d4ed8;
+}
+
+
+
+/* =========================
+   Primary Button
+========================= */
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+
+    padding: 8px 16px;
+    height: 36px;
+
+    font-size: 14px;
+    font-weight: 800;
+    border-radius: 999px;
+
+    background: #2563eb; /* primary */
+    color: #ffffff;
+    border: none;
+
+    cursor: pointer;
+    white-space: nowrap;
+
+    transition: background 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.05s ease;
+}
+
+.btn-primary:hover {
+    background: #1d4ed8;
+    box-shadow: 0 6px 14px rgba(37, 99, 235, 0.35);
+}
+
+.btn-primary:active {
+    transform: translateY(1px);
+}
+
+.btn-primary:disabled {
+    background: #93c5fd;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.emp-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
 }

--- a/src/main/resources/static/js/org-tree.js
+++ b/src/main/resources/static/js/org-tree.js
@@ -1,14 +1,13 @@
+let currentEmployeeId = null;
+let loginEmployeeId = null;
+
+/* =========================
+   상수
+========================= */
 const EMPLOYMENT_LABEL = {
     REGULAR: '정규직',
     NON_REGULAR: '비정규직',
     CONTRACT: '계약직'
-};
-
-const STATUS_LABEL = {
-    TEMP: '미활성',
-    ACTIVE: '재직중',
-    SUSPENDED: '정지',
-    RESIGNED: '퇴사'
 };
 
 const WORK_STATUS_LABEL = {
@@ -17,19 +16,33 @@ const WORK_STATUS_LABEL = {
     AWAY: '자리비움'
 };
 
+/* =========================
+   초기 로딩
+========================= */
+document.addEventListener('DOMContentLoaded', async () => {
 
-let currentEmployeeId = null;
+    // 로그인 사용자 정보
+    try {
+        const res = await apiFetch('/api/auth/me');
+        const result = await res.json();
+        loginEmployeeId = Number(result.data.employeeId);
+    } catch {
+        console.warn('로그인 사용자 정보 조회 실패');
+    }
 
-
-
-document.addEventListener('DOMContentLoaded', () => {
-
+    // 조직 트리 로드
     apiFetch('/api/user/organizations/tree')
         .then(res => res.json())
-        .then(res => renderOrgTree(res.data))
-        .catch(console.error);
+        .then(res => renderOrgTree(res.data));
 
-    if (targetEmployeeId) {
+    // 버튼 이벤트 (한 번만 바인딩)
+    const myBtn = document.getElementById('myActionBtn');
+    if (myBtn) {
+        myBtn.addEventListener('click', openSignatureModal);
+    }
+
+    // 초기 선택
+    if (typeof targetEmployeeId !== 'undefined' && targetEmployeeId) {
         loadEmployeeDetail(targetEmployeeId);
     }
 });
@@ -70,15 +83,19 @@ function renderNode(node, parent, depth) {
 /* =========================
    Employee Detail
 ========================= */
-window.loadEmployeeDetail = async function (id) {
-    currentEmployeeId = id;
+async function loadEmployeeDetail(id) {
+    currentEmployeeId = Number(id);
 
     const panel = document.getElementById('employee-panel');
     panel.classList.remove('hidden');
 
+    const myBtn = document.getElementById('myActionBtn');
+    if (myBtn) myBtn.classList.add('hidden');
+
     const res = await apiFetch(`/api/employees/${id}`);
     const { data: e } = await res.json();
 
+    // 기본 정보
     document.getElementById('empAvatar').src =
         e.gender === 'FEMALE' ? '/images/female.png' : '/images/male.png';
 
@@ -88,9 +105,9 @@ window.loadEmployeeDetail = async function (id) {
 
     document.getElementById('empEmail').textContent = e.email ?? '-';
     document.getElementById('empInternalPhone').textContent = e.internalPhone ?? '-';
-
     document.getElementById('empEmployeeNo').textContent = e.employeeNo ?? '-';
-    document.getElementById('empEmploymentType').textContent = EMPLOYMENT_LABEL[e.employmentType] ?? '-';
+    document.getElementById('empEmploymentType').textContent =
+        EMPLOYMENT_LABEL[e.employmentType] ?? '-';
     document.getElementById('empHireDate').textContent =
         e.hireDate ? e.hireDate.replaceAll('-', '.') : '-';
 
@@ -98,21 +115,27 @@ window.loadEmployeeDetail = async function (id) {
     document.getElementById('empRank').textContent = e.rankName ?? '-';
     document.getElementById('empPosition').textContent = e.positionName ?? '-';
 
-    // const status = document.getElementById('empStatus');
-    // status.textContent = STATUS_LABEL[e.status] ?? e.status;
-    // status.className = `emp-status ${e.status.toLowerCase()}`;
+    // ⭐ 본인 여부 판단
+    if (myBtn && loginEmployeeId === currentEmployeeId) {
+        myBtn.classList.remove('hidden');
 
-    // 근무 상태 조회 (Attendance 도메인)
+        const hasSignature = await checkMySignature();
+        myBtn.textContent = hasSignature
+            ? '결재 서명 변경'
+            : '결재 서명 등록';
+    }
+
     await loadEmployeeWorkStatus(id);
+}
 
-};
-
+/* =========================
+   근무 상태
+========================= */
 async function loadEmployeeWorkStatus(employeeId) {
     const res = await apiFetch(`/api/attendance/work-status/${employeeId}`);
     const { data } = await res.json();
 
-    // 다른 사원으로 바뀌었으면 무시 --> race condition 방지
-    if (employeeId !== currentEmployeeId) return;
+    if (Number(employeeId) !== currentEmployeeId) return;
 
     document.getElementById('empWorkStatus').textContent =
         WORK_STATUS_LABEL[data.workStatus] ?? '-';
@@ -123,5 +146,156 @@ async function loadEmployeeWorkStatus(employeeId) {
     if (data.workStatus === 'WORKING') dot.classList.add('working');
     else if (data.workStatus === 'OFF_WORK') dot.classList.add('off');
     else if (data.workStatus === 'AWAY') dot.classList.add('away');
-
 }
+
+/* =========================
+   Signature Modal
+========================= */
+async function checkMySignature() {
+    try {
+        const res = await apiFetch('/api/approval/signature/me');
+        if (!res.ok) return false;
+
+        const result = await res.json();
+        return result.data.exists === true;
+    } catch {
+        return false;
+    }
+}
+
+async function openSignatureModal() {
+
+    const modal = document.getElementById('signatureModal');
+    if (!modal) return;
+
+    modal.classList.remove('hidden');
+
+
+    // 항상 초기화
+    signatureInput.value = '';
+    previewImg.src = '';
+    previewImg.style.display = 'none';
+    placeholder.style.display = 'flex';
+    removeBtn.style.display = 'none';
+
+
+    try {
+        const res = await apiFetch('/api/approval/signature/me');
+        if (!res.ok) return;
+
+        const { data } = await res.json();
+        if (!data.exists) return;
+
+        document.getElementById('signaturePreviewImage').src = data.imageUrl;
+        document.getElementById('signaturePreviewImage').style.display = 'block';
+        document.getElementById('signaturePlaceholder').style.display = 'none';
+        document.getElementById('signatureRemoveBtn').style.display = 'inline-block';
+    } catch {}
+}
+
+function closeSignatureModal() {
+    document.getElementById('signatureModal')?.classList.add('hidden');
+}
+
+document.getElementById('signatureCancelBtn')
+    ?.addEventListener('click', closeSignatureModal);
+
+
+/* =========================
+   Signature Upload Logic
+========================= */
+
+const signatureInput = document.getElementById('signatureInput');
+const previewBox = document.getElementById('signaturePreviewBox');
+const previewImg = document.getElementById('signaturePreviewImage');
+const placeholder = document.getElementById('signaturePlaceholder');
+const removeBtn = document.getElementById('signatureRemoveBtn');
+const saveBtn = document.getElementById('signatureSaveBtn');
+
+/* 클릭 → 파일 선택 */
+previewBox?.addEventListener('click', () => {
+    signatureInput.click();
+});
+
+/* 파일 선택 시 */
+signatureInput?.addEventListener('change', () => {
+    const file = signatureInput.files[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+        alert('이미지 파일만 업로드 가능합니다.');
+        signatureInput.value = '';
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = e => {
+        previewImg.src = e.target.result;
+        previewImg.style.display = 'block';
+        placeholder.style.display = 'none';
+        removeBtn.style.display = 'inline-block';
+    };
+    reader.readAsDataURL(file);
+});
+
+
+removeBtn?.addEventListener('click', () => {
+    signatureInput.value = '';
+    previewImg.src = '';
+    previewImg.style.display = 'none';
+    placeholder.style.display = 'flex';
+    removeBtn.style.display = 'none';
+});
+
+
+saveBtn?.addEventListener('click', async () => {
+    const file = signatureInput.files[0];
+
+    if (!file) {
+        alert('서명 이미지를 선택해주세요.');
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+        saveBtn.disabled = true;
+        saveBtn.textContent = '저장 중...';
+
+        const res = await apiFetch('/api/approval/signature', {
+            method: 'POST',
+            body: formData
+        });
+
+        if (!res.ok) {
+            alert('서명 저장에 실패했습니다.');
+            return;
+        }
+
+        alert('서명이 저장되었습니다.');
+
+        // 모달 닫기
+        closeSignatureModal();
+
+        // 버튼 텍스트 갱신
+        const myBtn = document.getElementById('myActionBtn');
+        if (myBtn) {
+            myBtn.textContent = '결재 서명 변경';
+        }
+
+        // 입력 초기화
+        signatureInput.value = '';
+        previewImg.src = '';
+        previewImg.style.display = 'none';
+        placeholder.style.display = 'flex';
+        removeBtn.style.display = 'none';
+
+    } catch (e) {
+        console.error(e);
+        alert('서명 저장 중 오류가 발생했습니다.');
+    } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = '서명 등록';
+    }
+});

--- a/src/main/resources/templates/organization/tree.html
+++ b/src/main/resources/templates/organization/tree.html
@@ -49,6 +49,13 @@
                         <span>내선 <b id="empInternalPhone">-</b></span>
                     </div>
                 </div>
+
+                <div class="emp-actions">
+                    <button id="myActionBtn" class="btn-primary hidden">
+                        결재 서명 등록
+                    </button>
+                </div>
+
             </div>
 
             <!-- Info -->
@@ -80,6 +87,51 @@
 
         </section>
     </div>
+
+
+    <!-- ===============================
+     결재 서명 등록 / 갱신 팝업
+=============================== -->
+    <div id="signatureModal" class="modal-backdrop hidden">
+        <div class="approval-modal signature-modal">
+
+            <div class="modal-title">결재 서명 등록</div>
+
+            <div class="modal-form-group">
+                <div class="signature-guide">
+                    결재 승인 시 사용될 서명 이미지를 등록해주세요.
+                </div>
+
+                <div class="signature-upload-container">
+                    <div class="signature-preview-box" id="signaturePreviewBox">
+                        <img id="signaturePreviewImage" style="display:none;" />
+                        <div class="signature-placeholder" id="signaturePlaceholder">
+                            <i class="fa-solid fa-signature"></i>
+                            <p>서명 이미지 업로드</p>
+                            <span class="signature-hint">클릭하여 이미지 선택</span>
+                        </div>
+                    </div>
+
+                    <button
+                            type="button"
+                            class="signature-remove-btn"
+                            id="signatureRemoveBtn"
+                            style="display:none;"
+                    >
+                        제거
+                    </button>
+                </div>
+
+                <input type="file" id="signatureInput" hidden />
+            </div>
+
+            <div class="modal-actions">
+                <button id="signatureCancelBtn">취소</button>
+                <button id="signatureSaveBtn">서명 등록</button>
+            </div>
+        </div>
+    </div>
+
 </th:block>
 
 <!-- =========================


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- 조직도 페이지 내 **본인 사원 상세 조회 시 ‘결재 서명 등록/변경’ 버튼 노출 로직 구현**
- 로그인 사용자와 조회 중인 사원이 동일한 경우에만 버튼 노출 처리
- 결재 서명 **등록/변경 모달 UI 구현**
    - 기존 서명 존재 시 미리보기 표시
    - 서명 미존재 시 업로드 안내 UI 노출
- 서명 이미지 업로드 및 저장 API 연동
- 서명 등록 여부에 따라 버튼 텍스트 동적 변경
    (`결재 서명 등록` ↔ `결재 서명 변경`)
- 모달 UI 및 버튼 스타일을 기존 사용자 화면 톤에 맞게 커스터마이징

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
