### PR TITLE
fix(auditLog): 감사 로그 페이지 수정

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
@@ -32,23 +32,20 @@ public class AuditLogController {
     private final AuditLogService auditLogService;
 
     @GetMapping
-    public ResponseEntity<ResponseDto<Page<AuditLogResDto>>> search(
+    public ResponseEntity<ResponseDto<Page<AuditLogResDto>>> searchAdminAuditLogs(
             Pageable pageable
     ) {
         Page<AuditLogResDto> result =
-                auditLogService.search(
+                auditLogService.searchAdminAuditLogs(
                         SecurityUtils.getCompanyId(),
-                        null,
-                        null,
                         null,
                         pageable
                 );
 
-
         return ResponseEntity.ok(
                 new ResponseDto<>(
                         HttpStatus.OK,
-                        "감사 로그 목록 조회 성공",
+                        "관리자 감사 로그 조회 성공",
                         result
                 )
         );

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/repository/AuditLogRepository.java
@@ -29,14 +29,14 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
                 SELECT a FROM AuditLog a
                 JOIN a.actor act
                 WHERE a.company.id = :companyId
-                  AND (:entityType IS NULL OR a.entityType = :entityType)
-                  AND (:eventType IS NULL OR a.eventType = :eventType)
+                  AND a.entityType IN :entityTypes
+                  AND a.eventType IN :eventTypes
                   AND (:actorName IS NULL OR act.name LIKE %:actorName%)
             """)
-    Page<AuditLog> search(
+    Page<AuditLog> searchAdminAuditLogs(
             @Param("companyId") Long companyId,
-            @Param("entityType") AuditEntityType entityType,
-            @Param("eventType") AuditEventType eventType,
+            @Param("entityTypes") List<AuditEntityType> entityTypes,
+            @Param("eventTypes") List<AuditEventType> eventTypes,
             @Param("actorName") String actorName,
             Pageable pageable
     );

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
@@ -61,35 +61,39 @@ public class AuditLogService {
     }
 
     @Transactional(readOnly = true)
-    public Page<AuditLogResDto> search(
+    public Page<AuditLogResDto> searchAdminAuditLogs(
             Long companyId,
-            AuditEntityType entityType,
-            AuditEventType eventType,
             String actorName,
             Pageable pageable
     ) {
-        return auditLogRepository.search(companyId, entityType, eventType, actorName, pageable)
-                .map(log -> {
 
-                    String entityName =
-                            entityNameResolver.resolve(log.getEntityType(), log.getEntityId());
+        List<AuditEntityType> allowedEntities = List.of(
+                AuditEntityType.ORGANIZATION,
+                AuditEntityType.EMPLOYEE,
+                AuditEntityType.HR_RANK,
+                AuditEntityType.POSITION,
+                AuditEntityType.ORG_POSITION_USAGE
+        );
 
-                    String display =
-                            log.getEntityType().getDisplayName() + " · " + entityName;
+        List<AuditEventType> allowedEvents = List.of(
+                AuditEventType.MOVE,
+                AuditEventType.ASSIGN,
+                AuditEventType.UNASSIGN,
+                AuditEventType.STATUS_CHANGE,
+                AuditEventType.ACTIVATE,
+                AuditEventType.DEACTIVATE,
+                AuditEventType.CREATE
+        );
 
-                    return new AuditLogResDto(
-                            log.getId(),
-                            log.getEntityType().name(),
-                            log.getEntityId(),
-                            display,
-                            log.getEventType().name(),
-                            log.getActor().getName(),
-                            log.getActor().getEmail(),
-                            log.getBeforeData(),
-                            log.getAfterData(),
-                            log.getCreatedAt()
-                    );
-                });
+        return auditLogRepository
+                .searchAdminAuditLogs(
+                        companyId,
+                        allowedEntities,
+                        allowedEvents,
+                        actorName,
+                        pageable
+                )
+                .map(this::toAdminDto);
     }
 
 
@@ -97,6 +101,28 @@ public class AuditLogService {
     public AuditLog findById(Long id) {
         return auditLogRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("AuditLog not found"));
+    }
+
+    private AuditLogResDto toAdminDto(AuditLog log) {
+
+        String entityName =
+                entityNameResolver.resolve(log.getEntityType(), log.getEntityId());
+
+        String entityDisplay =
+                log.getEntityType().getDisplayName() + " · " + entityName;
+
+        return new AuditLogResDto(
+                log.getId(),
+                log.getEntityType().name(),
+                log.getEntityId(),
+                entityDisplay,
+                log.getEventType().name(),
+                log.getActor().getName(),
+                log.getActor().getEmail(),
+                log.getBeforeData(),
+                log.getAfterData(),
+                log.getCreatedAt()
+        );
     }
 
 }

--- a/src/main/resources/static/css/admin-audit/admin-audit-logs.css
+++ b/src/main/resources/static/css/admin-audit/admin-audit-logs.css
@@ -41,9 +41,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     border: 1px solid #e5e7eb;
 
-    min-height: 600px;
-    max-height: 600px;
-
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -338,17 +335,18 @@
     margin-bottom: 8px;
 }
 
-.diff-box.before {
-    border-left: 4px solid #adb5bd;
-}
-
-.diff-box.after {
-    border-left: 4px solid #4a69bd;
-}
-
 .diff-box pre {
     font-size: 13px;
     white-space: pre-wrap;
     line-height: 1.5;
     margin: 0;
+}
+
+
+.diff-box.after {
+    display: none;
+}
+
+.diff-box.before {
+    border-left: 4px solid #4a69bd;
 }

--- a/src/main/resources/static/js/admin-audit/admin-audit-logs.js
+++ b/src/main/resources/static/js/admin-audit/admin-audit-logs.js
@@ -150,13 +150,18 @@ async function openAuditLogModal(id) {
         setText('modal-created-at', formatDateTime(log.createdAt));
         setText('modal-actor', `${log.actorName} (${log.actorEmail})`);
         setText('modal-entity', log.entityDisplay);
-        setText('modal-event', log.eventType);
+        setText(
+            'modal-event',
+            humanizeEvent(log.eventType)
+        );
+
 
         // BEFORE / AFTER
         document.getElementById('modal-before').textContent =
-            formatJson(log.beforeData);
-        document.getElementById('modal-after').textContent =
-            formatJson(log.afterData);
+            formatDiff(log.beforeData, log.afterData);
+
+        document.getElementById('modal-after').style.display = 'none';
+
 
         document.getElementById('audit-log-modal').style.display = 'flex';
 
@@ -178,12 +183,55 @@ function setText(id, value) {
     if (el) el.textContent = value ?? '-';
 }
 
-function formatJson(obj) {
-    if (!obj || Object.keys(obj).length === 0) return '';
-    return JSON.stringify(obj, null, 2);
+function formatDiff(before, after) {
+    if (!before && !after) return '-';
+
+    const keys = new Set([
+        ...Object.keys(before || {}),
+        ...Object.keys(after || {})
+    ]);
+
+    if (keys.size === 0) return '-';
+
+    const lines = [];
+
+    keys.forEach(key => {
+        const b = before?.[key];
+        const a = after?.[key];
+
+        if (b !== a) {
+            lines.push(`${humanizeKey(key)}: ${b ?? '-'} → ${a ?? '-'}`);
+        }
+    });
+
+    return lines.join('\n');
 }
+
+function humanizeKey(key) {
+    const map = {
+        status: '상태',
+        orgId: '조직',
+        rankId: '직급',
+        positionCategoryId: '직책'
+    };
+    return map[key] ?? key;
+}
+
 
 function formatDateTime(isoString) {
     if (!isoString) return '-';
     return isoString.replace('T', ' ').substring(0, 19);
+}
+
+function humanizeEvent(event) {
+    const map = {
+        ACTIVATE: '계정 활성화',
+        DEACTIVATE: '비활성화',
+        MOVE: '조직 이동',
+        ASSIGN: '직급/직책 부여',
+        UNASSIGN: '직급/직책 해제',
+        STATUS_CHANGE: '상태 변경',
+        CREATE: '생성'
+    };
+    return map[event] ?? event;
 }

--- a/src/main/resources/templates/admin/audit-log/list.html
+++ b/src/main/resources/templates/admin/audit-log/list.html
@@ -102,7 +102,7 @@
 
         <div class="diff-container">
           <div class="diff-box before">
-            <h3>BEFORE</h3>
+            <h3>변경 요약</h3>
             <pre id="modal-before"></pre>
           </div>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #478

## 📝 작업 내용
- 관리자 감사 로그 조회 범위를 **회사 단위로 제한**
- 관리자 감사 로그에서 **개인정보/비밀번호 관련 변경 로그 제외**
- 감사 로그 상세 모달의 JSON 형태를 **사용자 친화적인 변경 요약 형식**으로 개선
    - 예: `상태: TEMP → ACTIVE`
- 감사 로그 목록 테이블에서 **마지막 행이 잘리던 레이아웃 문제 수정**
    - 고정 height 제거 및 레이아웃 개선

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
