### PR TITLE
Feat/#524

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/AccountActivateController.java
@@ -6,10 +6,15 @@ import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 import static com.finalproj.orbitflow.email.enums.EmailTokenType.ACTIVATE_ACCOUNT;
 
@@ -27,6 +32,7 @@ public class AccountActivateController {
 
     private final EmailVerificationService emailService;
     private final EmployeeService employeeService;
+    private final AuditLogService auditLogService;
 
     @PostMapping("/activate")
     public ResponseEntity<?> activate(
@@ -47,6 +53,16 @@ public class AccountActivateController {
 
         // 계정 활성화
         employeeService.activate(employee);
+
+        auditLogService.log(
+                employee.getCompany(),
+                employee,
+                AuditEntityType.EMPLOYEE,
+                employee.getId(),
+                AuditEventType.ACTIVATE,
+                Map.of("status", "TEMP"),
+                Map.of("status", "ACTIVE")
+        );
 
         // 토큰 사용 처리
         emailService.markTokenUsed(vt);

--- a/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
+++ b/src/main/java/com/finalproj/orbitflow/email/controller/PasswordResetController.java
@@ -8,15 +8,11 @@ import com.finalproj.orbitflow.email.service.EmailVerificationService;
 import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.enums.EmployeeStatus;
 import com.finalproj.orbitflow.hr.employee.service.EmployeeService;
-import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
-import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
 import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 /**
  * Please explain the class!!!
@@ -68,16 +64,6 @@ public class PasswordResetController {
 
         // 여기서 토큰 사용 처리
         emailService.markTokenUsed(verificationToken);
-
-        auditLogService.log(
-                employee.getCompany(),
-                employee,
-                AuditEntityType.EMPLOYEE,
-                employee.getId(),
-                AuditEventType.UPDATE,
-                Map.of("password", "***"),
-                Map.of("password", "***")
-        );
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/company/service/CompanyService.java
@@ -1,5 +1,6 @@
 package com.finalproj.orbitflow.hr.company.service;
 
+import com.finalproj.orbitflow.board.boardCategory.service.OrganizationBoardCategorySyncService;
 import com.finalproj.orbitflow.global.exception.BusinessException;
 import com.finalproj.orbitflow.hr.company.dto.CompanySignupReqDto;
 import com.finalproj.orbitflow.hr.company.entity.Company;
@@ -49,6 +50,8 @@ public class CompanyService {
     private final ApplicationEventPublisher eventPublisher;
     private final OrgPositionUsageRepository orgPositionUsageRepository;
     private final RankRepository rankRepository;
+    private final OrganizationBoardCategorySyncService organizationBoardCategorySyncService;
+
 
     @Value("${business.validation.strict}")
     private boolean strictValidation;
@@ -121,6 +124,23 @@ public class CompanyService {
                         "기본생성팀",
                         1
                 )
+        );
+
+        // ================= 조직 게시판 자동 생성 =================
+        organizationBoardCategorySyncService.createIfAbsent(
+                company.getId(), rootOrg.getId(), rootOrg.getName()
+        );
+
+        organizationBoardCategorySyncService.createIfAbsent(
+                company.getId(), hqOrg.getId(), hqOrg.getName()
+        );
+
+        organizationBoardCategorySyncService.createIfAbsent(
+                company.getId(), deptOrg.getId(), deptOrg.getName()
+        );
+
+        organizationBoardCategorySyncService.createIfAbsent(
+                company.getId(), teamOrg.getId(), teamOrg.getName()
         );
 
 

--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -218,7 +218,7 @@ public class EmployeeService {
 
         auditLogService.log(
                 company,
-                getActorEmployee(),
+                actor,
                 AuditEntityType.EMPLOYEE,
                 saved.getId(),
                 AuditEventType.CREATE,
@@ -235,6 +235,8 @@ public class EmployeeService {
        ============================= */
 
     public void update(Long companyId, Long employeeId, EmployeeUpdateReqDto dto) {
+
+        Employee actor = getActorEmployee();
 
         Employee employee = employeeRepository.findById(employeeId)
                 .orElseThrow(() -> new IllegalArgumentException("사원을 찾을 수 없습니다."));
@@ -338,7 +340,7 @@ public class EmployeeService {
         // 권한 (대표 관리자만)
         if (dto.getRole() != null && dto.getRole() != employee.getRole()) {
 
-            if (getActorEmployee().getRole() != EmployeeRole.COMPANY_ADMIN) {
+            if (actor.getRole() != EmployeeRole.COMPANY_ADMIN) {
                 throw new IllegalStateException(
                         "대표 관리자만 사원 권한을 변경할 수 있습니다."
                 );
@@ -360,7 +362,7 @@ public class EmployeeService {
         if (!after.isEmpty()) {
             auditLogService.log(
                     employee.getCompany(),
-                    getActorEmployee(),
+                    actor,
                     AuditEntityType.EMPLOYEE,
                     employee.getId(),
                     AuditEventType.UPDATE,
@@ -431,6 +433,7 @@ public class EmployeeService {
     private void handleStatusChange(Employee employee, EmployeeStatus newStatus) {
 
         EmployeeStatus current = employee.getStatus();
+        Employee actor = getActorEmployee();
 
         // RESIGNED는 어떤 경우에도 변경 불가
         if (current == EmployeeStatus.RESIGNED) {
@@ -455,7 +458,7 @@ public class EmployeeService {
 
         auditLogService.log(
                 employee.getCompany(),
-                getActorEmployee(),
+                actor,
                 AuditEntityType.EMPLOYEE,
                 employee.getId(),
                 AuditEventType.STATUS_CHANGE,

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/controller/AuditLogController.java
@@ -3,7 +3,6 @@ package com.finalproj.orbitflow.hr.logAudit.controller;
 import com.finalproj.orbitflow.global.common.ResponseDto;
 import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.logAudit.dto.AuditLogResDto;
-import com.finalproj.orbitflow.hr.logAudit.entity.AuditLog;
 import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -55,14 +54,11 @@ public class AuditLogController {
     public ResponseEntity<ResponseDto<AuditLogResDto>> detail(
             @PathVariable Long id
     ) {
-
-        AuditLog log = auditLogService.findById(id);
-
-        if (!log.getCompany().getId().equals(SecurityUtils.getCompanyId())) {
-            throw new IllegalStateException("다른 회사의 감사 로그입니다.");
-        }
-
-        AuditLogResDto result = AuditLogResDto.from(log);
+        AuditLogResDto result =
+                auditLogService.findAdminAuditLog(
+                        id,
+                        SecurityUtils.getCompanyId()
+                );
 
         return ResponseEntity.ok(
                 new ResponseDto<>(
@@ -72,4 +68,5 @@ public class AuditLogController {
                 )
         );
     }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/dto/AuditLogResDto.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/dto/AuditLogResDto.java
@@ -40,7 +40,7 @@ public class AuditLogResDto {
                 log.getEntityType().name(),
                 log.getEntityId(),
                 log.getEntityType().getDisplayName(),
-                log.getEventType().name(),
+                log.getEventType().getDisplayName(),
                 log.getActor().getName(),
                 log.getActor().getEmail(),
                 log.getBeforeData(),

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEntityType.java
@@ -10,6 +10,7 @@ package com.finalproj.orbitflow.hr.logAudit.enums;
 public enum AuditEntityType {
 
     COMPANY("회사"),
+    ORG_CATEGORY("조직 카테고리"),
     ORGANIZATION("조직"),
     EMPLOYEE("사원"),
     HR_RANK("직급"),

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEventType.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/enums/AuditEventType.java
@@ -8,15 +8,26 @@ package com.finalproj.orbitflow.hr.logAudit.enums;
  * @since : 2025-12-16 화요일
  */
 public enum AuditEventType {
-    CREATE,             // 신규 생성
-    UPDATE,             // 일반 정보 수정
 
-    STATUS_CHANGE,      // 사용자 상태 변경 (임시/재직/휴직/퇴사)
+    CREATE("생성"),
+    UPDATE("정보 수정"),
 
-    ACTIVATE,           // 엔티티 활성화
-    DEACTIVATE,         // 엔티티 비활성화
+    STATUS_CHANGE("상태 변경"),
 
-    MOVE,               // 조직 이동
-    ASSIGN,             // 직급/직책 부여
-    UNASSIGN            // 직급/직책 해제
+    ACTIVATE("활성화"),
+    DEACTIVATE("비활성화"),
+
+    MOVE("조직 이동"),
+    ASSIGN("직급/직책 부여"),
+    UNASSIGN("직급/직책 해제");
+
+    private final String displayName;
+
+    AuditEventType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditEntityNameResolver.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditEntityNameResolver.java
@@ -3,6 +3,7 @@ package com.finalproj.orbitflow.hr.logAudit.service;
 import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
 import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.organization.repository.OrgRepository;
 import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRepository;
 import com.finalproj.orbitflow.hr.rank.repository.RankRepository;
@@ -25,30 +26,99 @@ public class AuditEntityNameResolver {
     private final RankRepository rankRepository;
     private final PositionCategoryRepository positionRepository;
     private final CompanyRepository companyRepository;
+    private final OrgCategoryRepository orgCategoryRepository;
 
+    /* 엔티티 이름 (헤더용) */
     public String resolve(AuditEntityType type, Long entityId) {
         return switch (type) {
-            case EMPLOYEE ->
-                    employeeRepository.findById(entityId)
-                            .map(e -> e.getName())
-                            .orElse("알 수 없음");
-            case ORGANIZATION ->
-                    organizationRepository.findById(entityId)
-                            .map(o -> o.getName())
-                            .orElse("알 수 없음");
-            case HR_RANK ->
-                    rankRepository.findById(entityId)
-                            .map(r -> r.getName())
-                            .orElse("알 수 없음");
-            case POSITION ->
-                    positionRepository.findById(entityId)
-                            .map(p -> p.getName())
-                            .orElse("알 수 없음");
-            case COMPANY ->
-                    companyRepository.findById(entityId)
-                            .map(c -> c.getName())
-                            .orElse("알 수 없음");
+            case EMPLOYEE -> employeeRepository.findById(entityId)
+                    .map(e -> e.getName()).orElse("알 수 없음");
+            case ORGANIZATION -> organizationRepository.findById(entityId)
+                    .map(o -> o.getName()).orElse("알 수 없음");
+            case HR_RANK -> rankRepository.findById(entityId)
+                    .map(r -> r.getName()).orElse("알 수 없음");
+            case POSITION -> positionRepository.findById(entityId)
+                    .map(p -> p.getName()).orElse("알 수 없음");
+            case COMPANY -> companyRepository.findById(entityId)
+                    .map(c -> c.getName()).orElse("알 수 없음");
             default -> "알 수 없음";
         };
     }
+
+    /* 필드용 이름 변환 */
+    public String organizationName(Long id) {
+        return id == null ? "-" :
+                organizationRepository.findById(id)
+                        .map(o -> o.getName())
+                        .orElse("알 수 없음");
+    }
+
+    public String orgCategoryName(Long id) {
+        return id == null ? "-" :
+                orgCategoryRepository.findById(id)
+                        .map(c -> c.getName())
+                        .orElse("알 수 없음");
+    }
+
+    public String positionName(Long id) {
+        return id == null ? "-" :
+                positionRepository.findById(id)
+                        .map(p -> p.getName())
+                        .orElse("알 수 없음");
+    }
+
+    public String rankName(Long id) {
+        return id == null ? "-" :
+                rankRepository.findById(id)
+                        .map(r -> r.getName())
+                        .orElse("알 수 없음");
+    }
+
+    public String enumDisplay(String key, Object value) {
+        if (value == null) return "-";
+
+        return switch (key) {
+            case "status" -> switch (value.toString()) {
+                case "ACTIVE" -> "재직";
+                case "SUSPENDED" -> "휴직";
+                case "RESIGNED" -> "퇴사";
+                case "TEMP" -> "임시계정";
+                default -> value.toString();
+            };
+
+            case "employmentType" -> switch (value.toString()) {
+                case "REGULAR" -> "정규직";
+                case "NON_REGULAR" -> "비정규직";
+                default -> value.toString();
+            };
+
+            case "gender" -> switch (value.toString()) {
+                case "MALE" -> "남성";
+                case "FEMALE" -> "여성";
+                default -> value.toString();
+            };
+
+            case "role" -> switch (value.toString()) {
+                case "ADMIN" -> "관리자";
+                case "EMPLOYEE" -> "사원";
+                case "COMPANY_ADMIN" -> "대표 관리자";
+                default -> value.toString();
+            };
+
+            default -> value.toString();
+        };
+    }
+
+    public String booleanDisplay(String key, Object value) {
+        if (value == null) return "-";
+
+        if ("isHead".equals(key)) {
+            return Boolean.parseBoolean(value.toString())
+                    ? "가능"
+                    : "불가";
+        }
+
+        return value.toString();
+    }
+
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/logAudit/service/AuditLogService.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +62,19 @@ public class AuditLogService {
     }
 
     @Transactional(readOnly = true)
+    public AuditLogResDto findAdminAuditLog(Long id, Long companyId) {
+        AuditLog log = auditLogRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("AuditLog not found"));
+
+        if (!log.getCompany().getId().equals(companyId)) {
+            throw new IllegalStateException("다른 회사의 감사 로그입니다.");
+        }
+
+        return toAdminDto(log);
+    }
+
+
+    @Transactional(readOnly = true)
     public Page<AuditLogResDto> searchAdminAuditLogs(
             Long companyId,
             String actorName,
@@ -82,7 +96,8 @@ public class AuditLogService {
                 AuditEventType.STATUS_CHANGE,
                 AuditEventType.ACTIVATE,
                 AuditEventType.DEACTIVATE,
-                AuditEventType.CREATE
+                AuditEventType.CREATE,
+                AuditEventType.UPDATE
         );
 
         return auditLogRepository
@@ -111,18 +126,75 @@ public class AuditLogService {
         String entityDisplay =
                 log.getEntityType().getDisplayName() + " · " + entityName;
 
+        Map<String, Object> before = convertReadable(log.getBeforeData());
+        Map<String, Object> after  = convertReadable(log.getAfterData());
+
         return new AuditLogResDto(
                 log.getId(),
                 log.getEntityType().name(),
                 log.getEntityId(),
                 entityDisplay,
-                log.getEventType().name(),
+                log.getEventType().getDisplayName(),
                 log.getActor().getName(),
                 log.getActor().getEmail(),
-                log.getBeforeData(),
-                log.getAfterData(),
+                before,
+                after,
                 log.getCreatedAt()
         );
     }
 
+    private Map<String, Object> convertReadable(Map<String, Object> data) {
+        if (data == null) return null;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+
+        for (var entry : data.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            Object readableValue = switch (key) {
+
+                case "isHead" ->
+                        entityNameResolver.booleanDisplay(key, value);
+
+                case "orgId" ->
+                        entityNameResolver.organizationName(toLong(value));
+
+                case "orgCategoryId" ->
+                        entityNameResolver.orgCategoryName(toLong(value));
+
+                case "parentPositionId", "positionCategoryId" ->
+                        entityNameResolver.positionName(toLong(value));
+
+                case "parentRankId","rankId" ->
+                        entityNameResolver.rankName(toLong(value));
+
+                // enum 한글화
+                case "status", "employmentType", "gender", "role" ->
+                        entityNameResolver.enumDisplay(key, value);
+
+                // 일반 필드
+                default -> value;
+            };
+
+            result.put(key, readableValue);
+        }
+
+        return result;
+    }
+
+
+    private Long toLong(Object value) {
+        if (value == null) return null;
+
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/orgCategory/service/OrgCategoryService.java
@@ -5,6 +5,14 @@ import com.finalproj.orbitflow.global.exception.BusinessException;
 import com.finalproj.orbitflow.global.exception.InvalidRequestException;
 import com.finalproj.orbitflow.global.exception.InvalidStateException;
 import com.finalproj.orbitflow.global.exception.NotFoundException;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryOrderUpdateReqDto;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryResDto;
 import com.finalproj.orbitflow.hr.orgCategory.dto.OrgCategoryUpdateReqDto;
@@ -16,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Please explain the class!!!
@@ -31,6 +40,9 @@ public class OrgCategoryService {
 
     private final OrgCategoryRepository repository;
     private final OrgRepository orgRepository;
+    private final AuditLogService auditLogService;
+    private final CompanyRepository companyRepository;
+    private final EmployeeRepository employeeRepository;
 
     /* ================= 목록 (검색 포함) ================= */
     @Transactional(readOnly = true)
@@ -71,9 +83,32 @@ public class OrgCategoryService {
         Integer max = repository.findMaxActiveOrderIndexByCompanyId(companyId);
         int nextOrder = (max == null) ? 1 : max + 1;
 
-        return repository.save(
+        OrgCategory saved = repository.save(
                 OrgCategory.create(companyId, name, nextOrder, false)
-        ).getId();
+        );
+
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        auditLogService.log(
+                company,
+                actor,
+                AuditEntityType.ORG_CATEGORY,
+                saved.getId(),
+                AuditEventType.CREATE,
+                null,
+                Map.of(
+                        "name", saved.getName(),
+                        "orderIndex", saved.getOrderIndex()
+                )
+        );
+
+        return saved.getId();
+
     }
 
     /* ================= 수정 (이름 + 활성/비활성/재활성화) ================= */
@@ -84,8 +119,17 @@ public class OrgCategoryService {
             throw new InvalidStateException("회사 카테고리는 수정할 수 없습니다.");
         }
 
-        String name = request.getName().trim();
-        if (repository.existsByCompanyIdAndNameAndIdNot(companyId, name, id)) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        String newName = request.getName().trim();
+        String oldName = category.getName();
+
+        if (repository.existsByCompanyIdAndNameAndIdNot(companyId, newName, id)) {
             throw new BusinessException("이미 존재하는 조직 카테고리입니다.");
         }
 
@@ -93,29 +137,60 @@ public class OrgCategoryService {
         boolean willActivate = Boolean.TRUE.equals(request.getIsActive());
         boolean willDeactivate = Boolean.FALSE.equals(request.getIsActive());
 
-        // 재활성화
+        /* ===== 재활성화 ===== */
         if (wasInactive && willActivate) {
             Integer max = repository.findMaxActiveOrderIndexByCompanyId(companyId);
             category.activate(max == null ? 1 : max + 1);
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.ORG_CATEGORY,
+                    category.getId(),
+                    AuditEventType.ACTIVATE,
+                    Map.of("isActive", false),
+                    Map.of("isActive", true)
+            );
         }
 
-        // 비활성화
+        /* ===== 비활성화 ===== */
         if (willDeactivate) {
-
-            if (category.getIsRoot()) {
-                throw new InvalidStateException("회사 카테고리는 비활성화할 수 없습니다.");
-            }
 
             if (orgRepository.existsByCompanyIdAndCategoryIdAndIsActiveTrue(companyId, id)) {
                 throw new InvalidStateException(
                         "해당 카테고리를 사용하는 조직이 존재하여 비활성화할 수 없습니다."
                 );
             }
-            category.deactivate(); // 내부에서 orderIndex = null 처리
+
+            category.deactivate();
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.ORG_CATEGORY,
+                    category.getId(),
+                    AuditEventType.DEACTIVATE,
+                    Map.of("isActive", true),
+                    Map.of("isActive", false)
+            );
         }
 
-        category.updateName(name);
+        /* ===== 이름 변경 ===== */
+        if (!oldName.equals(newName)) {
+            category.updateName(newName);
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.ORG_CATEGORY,
+                    category.getId(),
+                    AuditEventType.UPDATE,
+                    Map.of("name", oldName),
+                    Map.of("name", newName)
+            );
+        }
     }
+
 
     /* ================= 순서 변경 ================= */
     public void updateOrder(Long companyId, List<OrgCategoryOrderUpdateReqDto.OrderItem> orders) {

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -342,6 +342,12 @@ public class OrgService {
 
         Long newParentId = request.getParentOrgId();
         String newName = normalizeNameOrThrow(request.getName());
+
+        // 수정 시 parentOrgId가 안 오면 기존 값 유지
+        if (newParentId == null) {
+            newParentId = org.getParentOrgId();
+        }
+
         Boolean reqActive = request.getIsActive();
 
         // 비활성화 요청 처리

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -92,18 +92,19 @@ public class OrgService {
                 SecurityUtils.getEmployeeId()
         ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
 
+        Map<String, Object> after = new java.util.HashMap<>();
+        after.put("name", saved.getName());
+        after.put("parentOrgId", saved.getParentOrgId());
+        after.put("categoryId", saved.getCategoryId());
+
         auditLogService.log(
-                company,    // company
-                actor,      // actor
+                company,
+                actor,
                 AuditEntityType.ORGANIZATION,
                 saved.getId(),
                 AuditEventType.CREATE,
                 null,
-                Map.of(
-                        "name", saved.getName(),
-                        "parentOrgId", saved.getParentOrgId(),
-                        "categoryId", saved.getCategoryId()
-                )
+                after
         );
 
 
@@ -278,111 +279,73 @@ public class OrgService {
 
     /* ================= 수정 ================= */
     public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
+
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
 
-
         Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
-        String oldName = org.getName();
-        Long oldParentId = org.getParentOrgId();
 
-        // ===== 회사 루트 조직 처리 =====
+        String oldName = org.getName();
+        String newName = normalizeNameOrThrow(request.getName());
+        Boolean reqActive = request.getIsActive();
+
+        // ===== 회사 루트 조직 =====
         if (org.getParentOrgId() == null) {
 
-            String newName = normalizeNameOrThrow(request.getName());
-
-            // 비활성화 금지
-            if (Boolean.FALSE.equals(request.getIsActive())) {
+            if (Boolean.FALSE.equals(reqActive)) {
                 throw new InvalidStateException("회사 루트 조직은 비활성화할 수 없습니다.");
             }
 
             // 회사 루트 조직은 parentOrgId를 절대 변경하지 않는다
-            org.update(null, newName);
+            org.update(org.getParentOrgId(), newName);
 
-            boolean moved = !Objects.equals(oldParentId, org.getParentOrgId());
+            if (!Objects.equals(oldName, newName)) {
+                Employee actor = employeeRepository.findById(
+                        SecurityUtils.getEmployeeId()
+                ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
 
-            Employee actor = employeeRepository.findById(
-                    SecurityUtils.getEmployeeId()
-            ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+                Map<String, Object> before = new java.util.HashMap<>();
+                before.put("name", oldName);
 
-            if (moved) {
-                auditLogService.log(
-                        company,
-                        actor,
-                        AuditEntityType.ORGANIZATION,
-                        org.getId(),
-                        AuditEventType.MOVE,
-                        Map.of("parentOrgId", oldParentId),
-                        Map.of("parentOrgId", org.getParentOrgId())
-                );
-            }
+                Map<String, Object> after = new java.util.HashMap<>();
+                after.put("name", newName);
 
-            if (!Objects.equals(oldName, org.getName())) {
                 auditLogService.log(
                         company,
                         actor,
                         AuditEntityType.ORGANIZATION,
                         org.getId(),
                         AuditEventType.UPDATE,
-                        Map.of("name", oldName),
-                        Map.of("name", org.getName())
+                        before,
+                        after
                 );
-            }
 
 
-            // 게시판 이름 동기화
-            if (!oldName.equals(newName)) {
                 organizationBoardCategorySyncService
                         .syncBoardName(companyId, organizationId, newName);
             }
-
-            return; // 여기서 종료
+            return;
         }
 
+        // ===== 일반 조직 =====
 
-        Long newParentId = request.getParentOrgId();
-        String newName = normalizeNameOrThrow(request.getName());
-
-        // 수정 시 parentOrgId가 안 오면 기존 값 유지
-        if (newParentId == null) {
-            newParentId = org.getParentOrgId();
-        }
-
-        Boolean reqActive = request.getIsActive();
-
-        // 비활성화 요청 처리
-        if (Boolean.FALSE.equals(request.getIsActive())) {
+        // 비활성화
+        if (Boolean.FALSE.equals(reqActive)) {
             deactivateInternal(companyId, org);
             return;
         }
 
-        // 자기 자신을 상위로 금지
-        if (newParentId != null && Objects.equals(newParentId, organizationId)) {
-            throw new InvalidRequestException("자기 자신을 상위 조직으로 지정할 수 없습니다.");
-        }
-
-        // 순환 참조 방지: newParent의 조상 중에 organizationId가 있으면 금지
-        if (newParentId != null && isCycle(companyId, organizationId, newParentId)) {
-            throw new InvalidStateException("조직 트리에 순환 구조가 발생할 수 있습니다.");
-        }
-
-        // 형제 단위 이름 중복 (수정: 자기 자신 제외)
+        // 형제 단위 이름 중복
         if (orgRepository.existsByCompanyIdAndParentOrgIdAndNameAndIsActiveTrueAndIdNot(
-                companyId, newParentId, newName, organizationId)) {
+                companyId, org.getParentOrgId(), newName, organizationId)) {
             throw new InvalidStateException("이미 존재하는 조직명입니다.");
         }
 
-        // ===== 재활성 여부 판단 =====
-        boolean reactivated =
-                Boolean.TRUE.equals(reqActive)
-                        && Boolean.FALSE.equals(org.getIsActive());
-
-        if (reactivated) {
-
-            Long parentId = org.getParentOrgId();
+        // 재활성
+        if (Boolean.TRUE.equals(reqActive) && Boolean.FALSE.equals(org.getIsActive())) {
 
             int nextOrderIndex =
-                    orgRepository.findMaxOrderIndex(companyId, parentId) + 1;
+                    orgRepository.findMaxOrderIndex(companyId, org.getParentOrgId()) + 1;
 
             org.activate(nextOrderIndex);
 
@@ -399,14 +362,13 @@ public class OrgService {
                     Map.of("isActive", false),
                     Map.of("isActive", true)
             );
-
         }
 
         // 실제 값 반영
         org.update(org.getParentOrgId(), newName);
+        orgRepository.flush();
 
-        // 이름이 바뀐 경우에만 게시판 카테고리명 동기화 (정책 선택)
-        if (!oldName.equals(newName)) {
+        if (!Objects.equals(oldName, newName)) {
             organizationBoardCategorySyncService
                     .syncBoardName(companyId, organizationId, newName);
         }

--- a/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/organization/service/OrgService.java
@@ -5,7 +5,14 @@ import com.finalproj.orbitflow.global.exception.ForbiddenException;
 import com.finalproj.orbitflow.global.exception.InvalidRequestException;
 import com.finalproj.orbitflow.global.exception.InvalidStateException;
 import com.finalproj.orbitflow.global.exception.NotFoundException;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
+import com.finalproj.orbitflow.hr.company.entity.Company;
+import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
 import com.finalproj.orbitflow.hr.organization.dto.*;
@@ -19,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -39,11 +47,15 @@ public class OrgService {
     private final OrgCategoryRepository orgCategoryRepository;
     private final OrgPositionUsageRepository orgPositionUsageRepository;
     private final OrganizationBoardCategorySyncService organizationBoardCategorySyncService;
+    private final AuditLogService auditLogService;
+    private final CompanyRepository companyRepository;
 
     /* ================= 생성 ================= */
     public Long create(Long companyId, OrgCreateReqDto request) {
 
         Long parentOrgId = request.getParentOrgId();
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
 
         // 최상위 조직 생성 차단
         if (parentOrgId == null) {
@@ -75,6 +87,25 @@ public class OrgService {
                 Organization.create(companyId, categoryId, parentOrgId, name, nextOrderIndex);
 
         Organization saved = orgRepository.save(org);
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        auditLogService.log(
+                company,    // company
+                actor,      // actor
+                AuditEntityType.ORGANIZATION,
+                saved.getId(),
+                AuditEventType.CREATE,
+                null,
+                Map.of(
+                        "name", saved.getName(),
+                        "parentOrgId", saved.getParentOrgId(),
+                        "categoryId", saved.getCategoryId()
+                )
+        );
+
 
         // 조직 게시판 카테고리 자동 생성
         organizationBoardCategorySyncService.createIfAbsent(
@@ -247,18 +278,13 @@ public class OrgService {
 
     /* ================= 수정 ================= */
     public void update(Long companyId, Long organizationId, OrgUpdateReqDto request) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
 
-        log.info(
-                "[ORG UPDATE] orgId={}, req.isActive={}, req.parentOrgId={}, req.name={}",
-                organizationId,
-                request.getIsActive(),
-                request.getParentOrgId(),
-                request.getName()
-        );
 
         Organization org = getOrgInCompanyOrThrow(companyId, organizationId);
         String oldName = org.getName();
-
+        Long oldParentId = org.getParentOrgId();
 
         // ===== 회사 루트 조직 처리 =====
         if (org.getParentOrgId() == null) {
@@ -272,6 +298,37 @@ public class OrgService {
 
             // 회사 루트 조직은 parentOrgId를 절대 변경하지 않는다
             org.update(null, newName);
+
+            boolean moved = !Objects.equals(oldParentId, org.getParentOrgId());
+
+            Employee actor = employeeRepository.findById(
+                    SecurityUtils.getEmployeeId()
+            ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+            if (moved) {
+                auditLogService.log(
+                        company,
+                        actor,
+                        AuditEntityType.ORGANIZATION,
+                        org.getId(),
+                        AuditEventType.MOVE,
+                        Map.of("parentOrgId", oldParentId),
+                        Map.of("parentOrgId", org.getParentOrgId())
+                );
+            }
+
+            if (!Objects.equals(oldName, org.getName())) {
+                auditLogService.log(
+                        company,
+                        actor,
+                        AuditEntityType.ORGANIZATION,
+                        org.getId(),
+                        AuditEventType.UPDATE,
+                        Map.of("name", oldName),
+                        Map.of("name", org.getName())
+                );
+            }
+
 
             // 게시판 이름 동기화
             if (!oldName.equals(newName)) {
@@ -322,6 +379,21 @@ public class OrgService {
                     orgRepository.findMaxOrderIndex(companyId, parentId) + 1;
 
             org.activate(nextOrderIndex);
+
+            Employee actor = employeeRepository.findById(
+                    SecurityUtils.getEmployeeId()
+            ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.ORGANIZATION,
+                    org.getId(),
+                    AuditEventType.ACTIVATE,
+                    Map.of("isActive", false),
+                    Map.of("isActive", true)
+            );
+
         }
 
         // 실제 값 반영
@@ -477,6 +549,10 @@ public class OrgService {
 
     private void deactivateInternal(Long companyId, Organization org) {
 
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new IllegalStateException("회사 정보 없음"));
+
+
         // 루트 조직 비활성화 금지
         if (org.getParentOrgId() == null) {
             throw new InvalidStateException("회사 루트 조직은 비활성화할 수 없습니다.");
@@ -495,6 +571,21 @@ public class OrgService {
         log.info("[ORG DEACTIVATE] before org.deactivate() id={}", organizationId);
         org.deactivate();
         log.info("[ORG DEACTIVATE] after org.deactivate() id={}", organizationId);
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        auditLogService.log(
+                company,
+                actor,
+                AuditEntityType.ORGANIZATION,
+                org.getId(),
+                AuditEventType.DEACTIVATE,
+                Map.of("isActive", true),
+                Map.of("isActive", false)
+        );
+
 
         orgRepository.save(org);
         orgRepository.flush();

--- a/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/positionCategory/service/PositionCategoryService.java
@@ -4,8 +4,14 @@ import com.finalproj.orbitflow.global.exception.ForbiddenException;
 import com.finalproj.orbitflow.global.exception.InvalidRequestException;
 import com.finalproj.orbitflow.global.exception.InvalidStateException;
 import com.finalproj.orbitflow.global.exception.NotFoundException;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
+import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import com.finalproj.orbitflow.hr.orgCategory.entity.OrgCategory;
 import com.finalproj.orbitflow.hr.orgCategory.repository.OrgCategoryRepository;
 import com.finalproj.orbitflow.hr.orgPositionUsage.repository.OrgPositionUsageRepository;
@@ -17,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Please explain the class!!!
@@ -35,9 +42,15 @@ public class PositionCategoryService {
     private final CompanyRepository companyRepository;
     private final OrgCategoryRepository orgCategoryRepository;
     private final OrgPositionUsageRepository orgPositionUsageRepository;
+    private final AuditLogService auditLogService;
+    private final EmployeeRepository employeeRepository;
 
     /* ================= 생성 ================= */
     public Long create(Long companyId, PositionCategoryCreateReqDto request) {
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
 
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new NotFoundException("회사를 찾을 수 없습니다."));
@@ -114,7 +127,24 @@ public class PositionCategoryService {
                 request.getIsHead()
         );
 
-        return positionCategoryRepository.save(category).getId();
+        PositionCategory saved = positionCategoryRepository.save(category);
+
+        auditLogService.log(
+                company,
+                actor,
+                AuditEntityType.POSITION,
+                saved.getId(),
+                AuditEventType.CREATE,
+                null,
+                Map.of(
+                        "name", saved.getName(),
+                        "orgCategoryId", saved.getOrgCategory().getId(),
+                        "parentPositionId", saved.getParent() != null ? saved.getParent().getId() : null,
+                        "isHead", saved.getIsHead()
+                )
+        );
+
+        return saved.getId();
     }
 
     /* ================= 조회 ================= */
@@ -148,6 +178,13 @@ public class PositionCategoryService {
     /* ================= 수정 ================= */
     public void update(Long companyId, Long id, PositionCategoryUpdateReqDto request) {
 
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new NotFoundException("회사를 찾을 수 없습니다."));
+
         PositionCategory category = get(companyId, id);
 
         String name = normalizeName(request.getName());
@@ -164,6 +201,17 @@ public class PositionCategoryService {
         if (!wasActive && willActivate) {
             Integer max = positionCategoryRepository.findMaxActiveOrderIndexByCompanyId(companyId);
             category.activate(max == null ? 1 : max + 1);
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.POSITION,
+                    category.getId(),
+                    AuditEventType.ACTIVATE,
+                    Map.of("isActive", false),
+                    Map.of("isActive", true)
+            );
+
         }
 
         if (wasActive && willDeactivate) {
@@ -174,9 +222,36 @@ public class PositionCategoryService {
                 );
             }
             category.deactivate();
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.POSITION,
+                    category.getId(),
+                    AuditEventType.DEACTIVATE,
+                    Map.of("isActive", true),
+                    Map.of("isActive", false)
+            );
+
         }
 
-        category.updateName(name);
+        String oldName = category.getName();
+        String newName = name;
+
+        if (!oldName.equals(newName)) {
+            category.updateName(newName);
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.POSITION,
+                    category.getId(),
+                    AuditEventType.UPDATE,
+                    Map.of("name", oldName),
+                    Map.of("name", newName)
+            );
+        }
+
     }
 
     /* ================= 정렬 ================= */

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
@@ -1,9 +1,14 @@
 package com.finalproj.orbitflow.hr.rank.service;
 
 import com.finalproj.orbitflow.global.exception.BusinessException;
+import com.finalproj.orbitflow.global.security.SecurityUtils;
 import com.finalproj.orbitflow.hr.company.entity.Company;
 import com.finalproj.orbitflow.hr.company.repository.CompanyRepository;
+import com.finalproj.orbitflow.hr.employee.entity.Employee;
 import com.finalproj.orbitflow.hr.employee.repository.EmployeeRepository;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEntityType;
+import com.finalproj.orbitflow.hr.logAudit.enums.AuditEventType;
+import com.finalproj.orbitflow.hr.logAudit.service.AuditLogService;
 import com.finalproj.orbitflow.hr.rank.dto.RankCreateReqDto;
 import com.finalproj.orbitflow.hr.rank.dto.RankOrderUpdateReqDto;
 import com.finalproj.orbitflow.hr.rank.dto.RankResDto;
@@ -15,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Please explain the class!!!
@@ -31,6 +37,7 @@ public class RankService {
     private final RankRepository rankRepository;
     private final CompanyRepository companyRepository;
     private final EmployeeRepository employeeRepository;
+    private final AuditLogService auditLogService;
 
     /* ================= 목록 ================= */
     @Transactional(readOnly = true)
@@ -86,13 +93,50 @@ public class RankService {
         int nextOrder = (max == null) ? 1 : max + 1;
 
         HrRank rank = HrRank.create(company, parent, name, nextOrder);
-        return rankRepository.save(rank).getId();
+        HrRank saved = rankRepository.save(rank);
+
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        auditLogService.log(
+                company,
+                actor,
+                AuditEntityType.HR_RANK,
+                saved.getId(),
+                AuditEventType.CREATE,
+                null,
+                Map.of(
+                        "name", saved.getName(),
+                        "parentRankId", saved.getParentHrRank() != null
+                                ? saved.getParentHrRank().getId()
+                                : null,
+                        "orderIndex", saved.getOrderIndex()
+                )
+        );
+
+        return saved.getId();
+
     }
 
     /* ================= 수정 ================= */
     public void updateRank(Long companyId, Long rankId, RankUpdateReqDto req) {
 
+        Employee actor = employeeRepository.findById(
+                SecurityUtils.getEmployeeId()
+        ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
+
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new BusinessException("회사를 찾을 수 없습니다."));
+
         HrRank rank = getRank(companyId, rankId);
+
+
+        String oldName = rank.getName();
+        Long oldParentId = rank.getParentHrRank() != null
+                ? rank.getParentHrRank().getId()
+                : null;
+
 
         String name = req.getName().trim();
         if (rankRepository.existsByCompanyIdAndNameAndIdNot(companyId, name, rankId)) {
@@ -117,17 +161,65 @@ public class RankService {
                     throw new BusinessException("부여 인원이 있는 직급은 비활성화할 수 없습니다.");
                 }
                 rank.deactivate();
+
+                auditLogService.log(
+                        company,
+                        actor,
+                        AuditEntityType.HR_RANK,
+                        rank.getId(),
+                        AuditEventType.DEACTIVATE,
+                        Map.of("isActive", true),
+                        Map.of("isActive", false)
+                );
+
             }
 
             // 재활성화
             if (req.getIsActive() && !rank.getIsActive()) {
                 Integer max = rankRepository.findMaxActiveOrderIndex(companyId);
                 rank.activate(max == null ? 1 : max + 1);
+
+                auditLogService.log(
+                        company,
+                        actor,
+                        AuditEntityType.HR_RANK,
+                        rank.getId(),
+                        AuditEventType.ACTIVATE,
+                        Map.of("isActive", false),
+                        Map.of("isActive", true)
+                );
+
             }
         }
 
-        // 이름/상위 직급만 변경
-        rank.update(name, parent);
+
+        Long newParentId = parent != null ? parent.getId() : null;
+
+        boolean nameChanged = !oldName.equals(name);
+        boolean parentChanged = !java.util.Objects.equals(oldParentId, newParentId);
+
+        if (nameChanged || parentChanged) {
+            // 이름/상위 직급만 변경
+            rank.update(name, parent);
+
+            auditLogService.log(
+                    company,
+                    actor,
+                    AuditEntityType.HR_RANK,
+                    rank.getId(),
+                    AuditEventType.UPDATE,
+                    Map.of(
+                            "name", oldName,
+                            "parentRankId", oldParentId
+                    ),
+                    Map.of(
+                            "name", name,
+                            "parentRankId", newParentId
+                    )
+            );
+        }
+
+
     }
 
 

--- a/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/rank/service/RankService.java
@@ -99,6 +99,15 @@ public class RankService {
                 SecurityUtils.getEmployeeId()
         ).orElseThrow(() -> new IllegalStateException("행위자 사원 정보 없음"));
 
+        Map<String, Object> after = new java.util.HashMap<>();
+        after.put("name", saved.getName());
+        after.put("parentRankId",
+                saved.getParentHrRank() != null
+                        ? saved.getParentHrRank().getId()
+                        : null
+        );
+        after.put("orderIndex", saved.getOrderIndex());
+
         auditLogService.log(
                 company,
                 actor,
@@ -106,13 +115,7 @@ public class RankService {
                 saved.getId(),
                 AuditEventType.CREATE,
                 null,
-                Map.of(
-                        "name", saved.getName(),
-                        "parentRankId", saved.getParentHrRank() != null
-                                ? saved.getParentHrRank().getId()
-                                : null,
-                        "orderIndex", saved.getOrderIndex()
-                )
+                after
         );
 
         return saved.getId();
@@ -202,20 +205,22 @@ public class RankService {
             // 이름/상위 직급만 변경
             rank.update(name, parent);
 
+            Map<String, Object> before = new java.util.HashMap<>();
+            before.put("name", oldName);
+            before.put("parentRankId", oldParentId);
+
+            Map<String, Object> after = new java.util.HashMap<>();
+            after.put("name", name);
+            after.put("parentRankId", newParentId);
+
             auditLogService.log(
                     company,
                     actor,
                     AuditEntityType.HR_RANK,
                     rank.getId(),
                     AuditEventType.UPDATE,
-                    Map.of(
-                            "name", oldName,
-                            "parentRankId", oldParentId
-                    ),
-                    Map.of(
-                            "name", name,
-                            "parentRankId", newParentId
-                    )
+                    before,
+                    after
             );
         }
 

--- a/src/main/resources/static/js/admin-audit/admin-audit-logs.js
+++ b/src/main/resources/static/js/admin-audit/admin-audit-logs.js
@@ -150,10 +150,7 @@ async function openAuditLogModal(id) {
         setText('modal-created-at', formatDateTime(log.createdAt));
         setText('modal-actor', `${log.actorName} (${log.actorEmail})`);
         setText('modal-entity', log.entityDisplay);
-        setText(
-            'modal-event',
-            humanizeEvent(log.eventType)
-        );
+        setText('modal-event', humanizeEvent(log.eventType));
 
 
         // BEFORE / AFTER
@@ -200,7 +197,7 @@ function formatDiff(before, after) {
         const a = after?.[key];
 
         if (b !== a) {
-            lines.push(`${humanizeKey(key)}: ${b ?? '-'} → ${a ?? '-'}`);
+            lines.push(`${humanizeKey(key)}: ${humanizeData(b) ?? '-'} → ${humanizeData(a) ?? '-'}`);
         }
     });
 
@@ -209,10 +206,22 @@ function formatDiff(before, after) {
 
 function humanizeKey(key) {
     const map = {
-        status: '상태',
+        name: '이름',
+        isHead: '결재처리여부',
+        employeeNo: '사번',
+        email: '이메일',
+        role: '권한',
         orgId: '조직',
+        orgCategoryId: '조직카테고리',
+        parentPositionId: '상위직책',
         rankId: '직급',
-        positionCategoryId: '직책'
+        positionCategoryId: '직책',
+        parentRankId: '상위직급',
+        orderIndex: '정렬순서',
+        status: '상태',
+        gender: '성별',
+        hireDate: '입사일',
+        employmentType: '고용형태'
     };
     return map[key] ?? key;
 }
@@ -231,7 +240,29 @@ function humanizeEvent(event) {
         ASSIGN: '직급/직책 부여',
         UNASSIGN: '직급/직책 해제',
         STATUS_CHANGE: '상태 변경',
-        CREATE: '생성'
+        CREATE: '생성',
+        UPDATE: '정보 수정'
     };
     return map[event] ?? event;
+}
+
+function humanizeData(data) {
+    const map = {
+        ACTIVE: '재직',
+        SUSPENDED: '휴직',
+        RESIGNED: '퇴사',
+        TEMP: '임시계정',
+
+        REGULAR: '정규직',
+        NON_REGULAR: '비정규직',
+
+        MALE: '남성',
+        FEMALE: '여성',
+
+
+        ADMIN: '관리자',
+        EMPLOYEE: '사원',
+        COMPANY_ADMIN: '대표 관리자'
+    };
+    return map[data] ?? data;
 }

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -339,6 +339,7 @@ async function openEdit(id) {
 
     buildCategorySelect(org.categoryId);
     buildParentSelect(org.parentOrgId ?? null);
+    document.getElementById('parentOrgSelectValue').value = org.parentOrgId;
 
     // 회사 루트 조직 전용 제어
     if (isRootOrg) {

--- a/src/main/resources/static/js/admin-organization.js
+++ b/src/main/resources/static/js/admin-organization.js
@@ -425,11 +425,19 @@ async function saveOrg() {
         return;
     }
 
-    const payload = {
-        name,
-        categoryId: Number(categoryValue),
-        parentOrgId: parentOrgValue ? Number(parentOrgValue) : null
-    };
+    const payload = {name};
+
+    // 생성일 때만 category / parent 전달
+    if (!isEditMode) {
+        payload.categoryId = Number(categoryValue);
+        payload.parentOrgId = Number(parentOrgValue);
+    }
+
+    // 수정일 때는 활성 여부만 (가능한 경우에만)
+    if (isEditMode && !activeToggle.disabled) {
+        payload.isActive = activeToggle.checked;
+    }
+
 
     // 활성 토글이 사용 가능한 경우만 전달
     if (isEditMode && !activeToggle.disabled) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #524

## 📝 작업 내용
### 1. 감사 로그(Audit Log) 전반 구조 개선
- `AuditLogService`에 관리자용 조회 DTO 변환 로직 통합
    - ID 기반 데이터를 사용자 친화적인 이름/한글 값으로 변환
    - 조직, 조직 카테고리, 직책, 직급, enum 값 공통 처리
- `AuditEntityNameResolver` 역할 명확화
    - 엔티티 헤더용 이름 조회
    - 필드 단위 변환용 메서드 분리
    - enum / boolean / 참조 ID 변환 책임 일원화
- `isHead`(결재처리자 여부) 로그를 boolean → 한글 표현으로 변환


### 2. 감사 이벤트 타입 개선

- `AuditEventType`에 `displayName` 도입
- 로그 목록/상세에서 enum raw 값 대신 의미 있는 한글 이벤트명 노출
    - 생성 / 정보 수정 / 활성화 / 비활성화 / 조직 이동 등


### 3. 관리자 감사 로그 화면 UX 개선

- 변경 diff 표시 로직 개선
    - before / after 값 모두 한글화된 값 기준으로 비교
    - `true / false`, enum, ID 값이 그대로 노출되던 문제 해결
- `humanizeKey`, `humanizeData`, `humanizeEvent` 맵 정비
    - 조직/직책/직급/상태/권한 등 일관된 용어 사용
- 감사 로그 상세 모달 가독성 개선

### 4. 조직 / 직책 / 직급 도메인 로그 보강

- 생성 / 수정 / 활성화 / 비활성화 시점에 감사 로그 추가
    - Organization
    - OrgCategory
    - PositionCategory
    - HR Rank
- 각 이벤트마다
    - actor(행위자)
    - before / after 데이터 명확히 기록
    - 활성/비활성 전환 시 상태 변화 명시


### 5. 조직 관리 로직 안정화

- 조직 생성 시 회사 정보 명시적 조회
- 조직 수정 로직 정리
    - 활성/비활성 분기 명확화
    - 재활성화 시 orderIndex 재계산
    - 이름 변경 시 게시판 카테고리 동기화
- 프론트(admin-organization.js)
    - 생성/수정 payload 분리
    - 수정 시 불필요한 category/parent 전달 제거
    - 활성 토글 제어 로직 명확화

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
