### PR TITLE
feat(employee): 사원의 소속조직/직책 변경시 알림

### DIFF
--- a/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
+++ b/src/main/java/com/finalproj/orbitflow/hr/employee/service/EmployeeService.java
@@ -20,6 +20,8 @@ import com.finalproj.orbitflow.hr.positionCategory.entity.PositionCategory;
 import com.finalproj.orbitflow.hr.positionCategory.repository.PositionCategoryRepository;
 import com.finalproj.orbitflow.hr.rank.entity.HrRank;
 import com.finalproj.orbitflow.hr.rank.repository.RankRepository;
+import com.finalproj.orbitflow.notification.enums.NotificationType;
+import com.finalproj.orbitflow.notification.service.NotificationCommandService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -53,6 +55,7 @@ public class EmployeeService {
     private final PasswordEncoder passwordEncoder;
     private final AuditLogService auditLogService;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final NotificationCommandService notificationCommandService;
 
 
     /* =============================
@@ -300,11 +303,34 @@ public class EmployeeService {
 
 
         // ===== 조직/직급/직책 =====
+// ===== 조직 =====
         if (dto.getOrgId() != null && !dto.getOrgId().equals(employee.getOrganization().getId())) {
-            putDiff(before, after, "orgId", employee.getOrganization().getId(), dto.getOrgId());
-            Organization org = orgRepository.findById(dto.getOrgId())
+
+            Organization beforeOrg = employee.getOrganization();
+
+            putDiff(before, after, "orgId",
+                    beforeOrg.getId(),
+                    dto.getOrgId());
+
+            Organization afterOrg = orgRepository.findById(dto.getOrgId())
                     .orElseThrow(() -> new IllegalArgumentException("조직 정보가 없습니다."));
-            employee.changeOrganization(org);
+
+            employee.changeOrganization(afterOrg);
+
+            // 조직 변경 알림
+            String message = String.format(
+                    "소속 조직이 변경되었습니다.\n%s → %s",
+                    beforeOrg.getName(),
+                    afterOrg.getName()
+            );
+
+            notificationCommandService.createNotification(
+                    employee.getCompany().getId(),
+                    employee.getId(),
+                    NotificationType.EMPLOYEE_ORG_CHANGED,
+                    message,
+                    "/view/organizations?employeeId=" + employee.getId()
+            );
         }
 
         if (dto.getRankId() != null) {
@@ -315,11 +341,41 @@ public class EmployeeService {
             }
         }
 
+// ===== 직책 =====
         if (dto.getPositionCategoryId() != null) {
-            Long currentPosId = employee.getPositionCategory() != null ? employee.getPositionCategory().getId() : null;
+
+            Long currentPosId = employee.getPositionCategory() != null
+                    ? employee.getPositionCategory().getId()
+                    : null;
+
             if (!dto.getPositionCategoryId().equals(currentPosId)) {
-                putDiff(before, after, "positionCategoryId", currentPosId, dto.getPositionCategoryId());
-                employee.changePosition(positionCategoryRepository.findById(dto.getPositionCategoryId()).orElse(null));
+
+                PositionCategory beforePos = employee.getPositionCategory();
+
+                putDiff(before, after, "positionCategoryId",
+                        currentPosId,
+                        dto.getPositionCategoryId());
+
+                PositionCategory afterPos =
+                        positionCategoryRepository.findById(dto.getPositionCategoryId())
+                                .orElse(null);
+
+                employee.changePosition(afterPos);
+
+                // 직책 변경 알림
+                String message = String.format(
+                        "직책이 변경되었습니다.\n%s → %s",
+                        beforePos != null ? beforePos.getName() : "미지정",
+                        afterPos != null ? afterPos.getName() : "미지정"
+                );
+
+                notificationCommandService.createNotification(
+                        employee.getCompany().getId(),
+                        employee.getId(),
+                        NotificationType.EMPLOYEE_POSITION_CHANGED,
+                        message,
+                        "/view/organizations?employeeId=" + employee.getId()
+                );
             }
         }
 

--- a/src/main/java/com/finalproj/orbitflow/notification/enums/NotificationType.java
+++ b/src/main/java/com/finalproj/orbitflow/notification/enums/NotificationType.java
@@ -21,7 +21,8 @@ public enum NotificationType {
     MESSAGE("메시지"),
     APPROVAL("결재"),
     ATTENDANCE("근태"),
-    ORGANIZATION("인사"),
+    EMPLOYEE_ORG_CHANGED("조직 변경"),
+    EMPLOYEE_POSITION_CHANGED("직책 변경"),
     BOARD("게시판");
 
     private final String description;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- 사원 정보 수정 시 조직 변경 알림 기능 추가
- 사원 정보 수정 시 직책 변경 알림 기능 추가
- NotificationType에 조직 변경 / 직책 변경 타입 추가
- 기존 감사 로그(Audit Log)와 알림 책임을 분리하여 구조 정리

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="501" height="364" alt="image" src="https://github.com/user-attachments/assets/8b65545d-4b40-4518-ad43-c7f2547880dd" />

## 💬 리뷰 요구사항(선택)
